### PR TITLE
feat: add deployment meta as docker labels to container

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,21 @@ on:
       - 'docs/**'
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go mod download
+      - name: Run linters
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
+        with:
+          version: latest
+
   test:
     name: Run Acceptance Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
           version: latest
 
   test:
-    name: Run Acceptance Tests
+    name: Acceptance Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -205,7 +205,7 @@ func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 
 	jobLog.Info("deploying project")
 
-	err = docker.DeployCompose(ctx, dockerCli, project, deployConfig)
+	err = docker.DeployCompose(ctx, dockerCli, project, deployConfig, p)
 	if err != nil {
 		errMsg = "failed to deploy project"
 		jobLog.Error(errMsg,

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -2,9 +2,10 @@ package config
 
 import (
 	"errors"
+	"strings"
+
 	"github.com/caarlos0/env/v11"
 	"gopkg.in/validator.v2"
-	"strings"
 )
 
 // AppConfig is used to configure this application

--- a/internal/config/app_config_test.go
+++ b/internal/config/app_config_test.go
@@ -59,6 +59,7 @@ func TestGetAppConfig(t *testing.T) {
 			if !errors.Is(err, tt.expectedErr) {
 				t.Errorf("expected error to be '%v', got '%v'", tt.expectedErr, err)
 			}
+
 			if err == nil {
 				// Clean up the environment
 				for k := range tt.envVars {

--- a/internal/config/deploy_config.go
+++ b/internal/config/deploy_config.go
@@ -3,9 +3,10 @@ package config
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/validator.v2"
 	"os"
 	"path"
+
+	"gopkg.in/validator.v2"
 
 	"github.com/compose-spec/compose-go/v2/cli"
 )

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/kimdre/doco-cd/internal/webhook"
 	"io"
 	"net"
 	"net/http"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/kimdre/doco-cd/internal/webhook"
 
 	"github.com/kimdre/doco-cd/internal/config"
 

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"github.com/kimdre/doco-cd/internal/webhook"
 	"os"
 	"path/filepath"
 	"testing"
@@ -94,6 +95,14 @@ func TestLoadCompose(t *testing.T) {
 
 func TestDeployCompose(t *testing.T) {
 	c, err := config.GetAppConfig()
+	p := webhook.ParsedPayload{
+		Ref:       "/refs/heads/test",
+		CommitSHA: "26263c2b44133367927cd1423d8c8457b5befce5",
+		Name:      "doco-cd",
+		FullName:  "kimdre/doco-cd",
+		CloneURL:  "https://github.com/kimdre/doco-cd",
+		Private:   false,
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,7 +185,7 @@ compose_files:
 		}
 	}()
 
-	err = DeployCompose(ctx, dockerCli, project, deployConf)
+	err = DeployCompose(ctx, dockerCli, project, deployConf, p)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -3,10 +3,11 @@ package docker
 import (
 	"context"
 	"fmt"
-	"github.com/kimdre/doco-cd/internal/webhook"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/kimdre/doco-cd/internal/webhook"
 
 	"github.com/docker/compose/v2/pkg/api"
 	"github.com/docker/compose/v2/pkg/compose"
@@ -103,6 +104,7 @@ func TestDeployCompose(t *testing.T) {
 		CloneURL:  "https://github.com/kimdre/doco-cd",
 		Private:   false,
 	}
+
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2,10 +2,11 @@ package git
 
 import (
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/kimdre/doco-cd/internal/config"
 	"os"
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/kimdre/doco-cd/internal/config"
 )
 
 func TestGetAuthUrl(t *testing.T) {

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -51,6 +51,7 @@ func TestParseLevel(t *testing.T) {
 				t.Errorf("ParseLevel() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("ParseLevel() = %v, want %v", got, tt.want)
 			}
@@ -60,10 +61,12 @@ func TestParseLevel(t *testing.T) {
 
 func TestErrAttr(t *testing.T) {
 	err := errors.New("test message")
+
 	attr := ErrAttr(err)
 	if attr.Key != "error" {
 		t.Errorf("ErrAttr() key = %v, want %v", attr.Key, "error")
 	}
+
 	if !attr.Equal(slog.Any("error", err)) {
 		t.Errorf("ErrAttr() value = %v, want %v", attr.Value, err)
 	}
@@ -72,6 +75,7 @@ func TestErrAttr(t *testing.T) {
 func TestNew(t *testing.T) {
 	logLevel := LevelDebug
 	logger := New(logLevel)
+
 	if logger.Level != logLevel {
 		t.Errorf("New() level = %v, want %v", logger.Level, logLevel)
 	}
@@ -122,6 +126,7 @@ func TestLogger_ParseLevel(t *testing.T) {
 				t.Errorf("Logger.ParseLevel() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
+
 			if got != tt.want {
 				t.Errorf("Logger.ParseLevel() = %v, want %v", got, tt.want)
 			}

--- a/internal/webhook/payload.go
+++ b/internal/webhook/payload.go
@@ -7,6 +7,7 @@ import (
 // GithubPushPayload is a struct that represents the payload sent by GitHub or Gitea, as they have the same structure
 type GithubPushPayload struct {
 	Ref        string `json:"ref"`
+	CommitSHA  string `json:"after"`
 	Repository struct {
 		Name     string `json:"name"`
 		FullName string `json:"full_name"`
@@ -18,6 +19,7 @@ type GithubPushPayload struct {
 // GitlabPushPayload is a struct that represents the payload sent by GitLab
 type GitlabPushPayload struct {
 	Ref        string `json:"ref"`
+	CommitSHA  string `json:"after"`
 	Repository struct {
 		Name              string `json:"name"`
 		PathWithNamespace string `json:"path_with_namespace"`
@@ -28,11 +30,12 @@ type GitlabPushPayload struct {
 
 // ParsedPayload is a struct that contains the parsed payload data
 type ParsedPayload struct {
-	Ref      string
-	Name     string
-	FullName string
-	CloneURL string
-	Private  bool
+	Ref       string
+	CommitSHA string
+	Name      string
+	FullName  string
+	CloneURL  string
+	Private   bool
 }
 
 // ParsePayload parses the payload and returns a ParsedPayload struct
@@ -49,11 +52,12 @@ func parsePayload(payload []byte, provider string) (ParsedPayload, error) {
 		}
 
 		parsedPayload := ParsedPayload{
-			Ref:      githubPayload.Ref,
-			Name:     githubPayload.Repository.Name,
-			FullName: githubPayload.Repository.FullName,
-			CloneURL: githubPayload.Repository.CloneURL,
-			Private:  githubPayload.Repository.Private,
+			Ref:       githubPayload.Ref,
+			CommitSHA: githubPayload.CommitSHA,
+			Name:      githubPayload.Repository.Name,
+			FullName:  githubPayload.Repository.FullName,
+			CloneURL:  githubPayload.Repository.CloneURL,
+			Private:   githubPayload.Repository.Private,
 		}
 
 		return parsedPayload, nil
@@ -64,11 +68,12 @@ func parsePayload(payload []byte, provider string) (ParsedPayload, error) {
 		}
 
 		parsedPayload := ParsedPayload{
-			Ref:      gitlabPayload.Ref,
-			Name:     gitlabPayload.Repository.Name,
-			FullName: gitlabPayload.Repository.PathWithNamespace,
-			CloneURL: gitlabPayload.Repository.CloneURL,
-			Private:  gitlabPayload.Repository.VisibilityLevel == 0,
+			Ref:       gitlabPayload.Ref,
+			CommitSHA: gitlabPayload.CommitSHA,
+			Name:      gitlabPayload.Repository.Name,
+			FullName:  gitlabPayload.Repository.PathWithNamespace,
+			CloneURL:  gitlabPayload.Repository.CloneURL,
+			Private:   gitlabPayload.Repository.VisibilityLevel == 0,
 		}
 
 		return parsedPayload, nil


### PR DESCRIPTION
In preparation for future features this PR adds functionallity to add deployment meta information as labels to docker containers.