### PR TITLE
fix: wrong assignment of project names in deployments

### DIFF
--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -176,7 +176,7 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 		deployConfig.ComposeFiles = tmpComposeFiles
 	}
 
-	project, err := docker.LoadCompose(ctx, workingDir, p.Name, deployConfig.ComposeFiles)
+	project, err := docker.LoadCompose(ctx, workingDir, deployConfig.Name, deployConfig.ComposeFiles)
 	if err != nil {
 		errMsg = "failed to load project"
 		jobLog.Error(errMsg,


### PR DESCRIPTION
The name assignment of docker compose projects was wrong and used the name of the repository instead of the one that is set in the deployment config file.
This PR fixes this issue.