### PR TITLE
fix(#355): add new environment variables to provide sensitive values from files

### DIFF
--- a/cmd/doco-cd/http_handler_test.go
+++ b/cmd/doco-cd/http_handler_test.go
@@ -32,9 +32,8 @@ const (
 func TestHandlerData_HealthCheckHandler(t *testing.T) {
 	expectedResponse := fmt.Sprintln(`{"details":"healthy"}`)
 	expectedStatusCode := http.StatusOK
-	secretsPath := path.Join(t.TempDir(), config.DockerSecretsPath)
 
-	appConfig, err := config.GetAppConfig(secretsPath)
+	appConfig, err := config.GetAppConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +79,6 @@ func TestHandlerData_HealthCheckHandler(t *testing.T) {
 func TestHandlerData_WebhookHandler(t *testing.T) {
 	expectedResponse := `{"details":"deployment successful","job_id":"[a-f0-9-]{36}"}`
 	expectedStatusCode := http.StatusCreated
-	secretsPath := path.Join(t.TempDir(), config.DockerSecretsPath)
 	tmpDir := t.TempDir()
 
 	repoDir := path.Join(tmpDir, "kimdre", "doco-cd")
@@ -97,7 +95,7 @@ func TestHandlerData_WebhookHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	appConfig, err := config.GetAppConfig(secretsPath)
+	appConfig, err := config.GetAppConfig()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -37,7 +37,7 @@ func main() {
 	log := logger.New(slog.LevelDebug)
 
 	// Get the application configuration
-	c, err := config.GetAppConfig(config.DockerSecretsPath)
+	c, err := config.GetAppConfig()
 	if err != nil {
 		log.Critical("failed to get application configuration", logger.ErrAttr(err))
 	}

--- a/cmd/doco-cd/main_test.go
+++ b/cmd/doco-cd/main_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -138,7 +137,6 @@ func TestHandleEvent(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			secretsPath := path.Join(t.TempDir(), config.DockerSecretsPath)
 
 			if tc.overrideEnv != nil {
 				for k, v := range tc.overrideEnv {
@@ -149,7 +147,7 @@ func TestHandleEvent(t *testing.T) {
 				}
 			}
 
-			appConfig, err := config.GetAppConfig(secretsPath)
+			appConfig, err := config.GetAppConfig()
 			if err != nil {
 				t.Fatalf("failed to get app config: %s", err.Error())
 			}

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/caarlos0/env/v11"
@@ -21,8 +20,6 @@ type AppConfig struct {
 	SkipTLSVerification bool   `env:"SKIP_TLS_VERIFICATION" envDefault:"false"`                      // SkipTLSVerification skips the TLS verification when cloning repositories.
 	DockerQuietDeploy   bool   `env:"DOCKER_QUIET_DEPLOY" envDefault:"true"`                         // DockerQuietDeploy suppresses the status output of dockerCli in deployments (e.g. pull, create, start)
 }
-
-var ErrInvalidLogLevel = validator.TextErr{Err: errors.New("invalid log level, must be one of debug, info, warn, error")}
 
 // GetAppConfig returns the configuration
 func GetAppConfig() (*AppConfig, error) {

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -13,28 +13,28 @@ import (
 type AppConfig struct {
 	LogLevel            string `env:"LOG_LEVEL,required" envDefault:"info"`                          // LogLevel is the log level for the application
 	HttpPort            uint16 `env:"HTTP_PORT,required" envDefault:"80" validate:"min=1,max=65535"` // HttpPort is the port the HTTP server will listen on
-	WebhookSecret       string `env:"WEBHOOK_SECRET,required,notEmpty"`                              // WebhookSecret is the secret used to authenticate the webhook
+	WebhookSecret       string `env:"WEBHOOK_SECRET"`                                                // WebhookSecret is the secret used to authenticate the webhook
+	WebhookSecretFile   string `env:"WEBHOOK_SECRET_FILE,file"`                                      // WebhookSecretFile is the file containing the WebhookSecret
 	GitAccessToken      string `env:"GIT_ACCESS_TOKEN"`                                              // GitAccessToken is the access token used to authenticate with the Git server (e.g. GitHub) for private repositories
+	GitAccessTokenFile  string `env:"GIT_ACCESS_TOKEN_FILE,file"`                                    // GitAccessTokenFile is the file containing the GitAccessToken
 	AuthType            string `env:"AUTH_TYPE" envDefault:"oauth2"`                                 // AuthType is the type of authentication to use when cloning repositories
 	SkipTLSVerification bool   `env:"SKIP_TLS_VERIFICATION" envDefault:"false"`                      // SkipTLSVerification skips the TLS verification when cloning repositories.
 	DockerQuietDeploy   bool   `env:"DOCKER_QUIET_DEPLOY" envDefault:"true"`                         // DockerQuietDeploy suppresses the status output of dockerCli in deployments (e.g. pull, create, start)
 }
 
-const DockerSecretsPath = "/run/secrets"
-
 var ErrInvalidLogLevel = validator.TextErr{Err: errors.New("invalid log level, must be one of debug, info, warn, error")}
 
 // GetAppConfig returns the configuration
-func GetAppConfig(secretsPath string) (*AppConfig, error) {
+func GetAppConfig() (*AppConfig, error) {
 	cfg := AppConfig{}
-
-	// Load env vars from Docker secrets if used
-	if err := loadEnvFromDockerSecrets(secretsPath); err != nil {
-		return nil, err
-	}
 
 	// Parse app config from environment variables
 	if err := env.Parse(&cfg); err != nil {
+		return nil, err
+	}
+
+	// Load file-based environment variables
+	if err := loadFileBasedEnvVars(&cfg); err != nil {
 		return nil, err
 	}
 

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -10,15 +10,15 @@ import (
 // AppConfig is used to configure this application
 // https://github.com/caarlos0/env?tab=readme-ov-file#env-tag-options
 type AppConfig struct {
-	LogLevel            string `env:"LOG_LEVEL,required" envDefault:"info"`                          // LogLevel is the log level for the application
-	HttpPort            uint16 `env:"HTTP_PORT,required" envDefault:"80" validate:"min=1,max=65535"` // HttpPort is the port the HTTP server will listen on
+	LogLevel            string `env:"LOG_LEVEL,notEmpty" envDefault:"info"`                          // LogLevel is the log level for the application
+	HttpPort            uint16 `env:"HTTP_PORT,notEmpty" envDefault:"80" validate:"min=1,max=65535"` // HttpPort is the port the HTTP server will listen on
 	WebhookSecret       string `env:"WEBHOOK_SECRET"`                                                // WebhookSecret is the secret used to authenticate the webhook
 	WebhookSecretFile   string `env:"WEBHOOK_SECRET_FILE,file"`                                      // WebhookSecretFile is the file containing the WebhookSecret
 	GitAccessToken      string `env:"GIT_ACCESS_TOKEN"`                                              // GitAccessToken is the access token used to authenticate with the Git server (e.g. GitHub) for private repositories
 	GitAccessTokenFile  string `env:"GIT_ACCESS_TOKEN_FILE,file"`                                    // GitAccessTokenFile is the file containing the GitAccessToken
-	AuthType            string `env:"AUTH_TYPE" envDefault:"oauth2"`                                 // AuthType is the type of authentication to use when cloning repositories
-	SkipTLSVerification bool   `env:"SKIP_TLS_VERIFICATION" envDefault:"false"`                      // SkipTLSVerification skips the TLS verification when cloning repositories.
-	DockerQuietDeploy   bool   `env:"DOCKER_QUIET_DEPLOY" envDefault:"true"`                         // DockerQuietDeploy suppresses the status output of dockerCli in deployments (e.g. pull, create, start)
+	AuthType            string `env:"AUTH_TYPE,notEmpty" envDefault:"oauth2"`                        // AuthType is the type of authentication to use when cloning repositories
+	SkipTLSVerification bool   `env:"SKIP_TLS_VERIFICATION,notEmpty" envDefault:"false"`             // SkipTLSVerification skips the TLS verification when cloning repositories.
+	DockerQuietDeploy   bool   `env:"DOCKER_QUIET_DEPLOY,notEmpty" envDefault:"true"`                // DockerQuietDeploy suppresses the status output of dockerCli in deployments (e.g. pull, create, start)
 }
 
 // GetAppConfig returns the configuration

--- a/internal/config/app_config_test.go
+++ b/internal/config/app_config_test.go
@@ -6,8 +6,6 @@ import (
 	"path"
 	"strconv"
 	"testing"
-
-	"github.com/caarlos0/env/v11"
 )
 
 func TestGetAppConfig(t *testing.T) {
@@ -67,8 +65,20 @@ func TestGetAppConfig(t *testing.T) {
 				// "WEBHOOK_SECRET": "", // Testing for missing secret
 				"GIT_ACCESS_TOKEN": "t0ken",
 			},
-			expectedErr: env.VarIsNotSetError{Key: "WEBHOOK_SECRET"},
+			expectedErr: ErrBothSecretsNotSet,
 		},
+	}
+
+	// Restore environment variables after the test
+	for _, k := range []string{"LOG_LEVEL", "HTTP_PORT", "WEBHOOK_SECRET", "GIT_ACCESS_TOKEN", "AUTH_TYPE", "SKIP_TLS_VERIFICATION"} {
+		if v, ok := os.LookupEnv(k); ok {
+			t.Cleanup(func() {
+				err := os.Setenv(k, v)
+				if err != nil {
+					t.Fatalf("failed to restore environment variable %s: %v", k, err)
+				}
+			})
+		}
 	}
 
 	for _, tt := range tests {

--- a/internal/config/app_config_test.go
+++ b/internal/config/app_config_test.go
@@ -54,6 +54,21 @@ func TestGetAppConfig(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name: "config with duplicate secrets",
+			envVars: map[string]string{
+				"LOG_LEVEL":             "info",
+				"HTTP_PORT":             "8080",
+				"AUTH_TYPE":             "oauth2",
+				"SKIP_TLS_VERIFICATION": "false",
+				"WEBHOOK_SECRET":        "webh00k_secret",
+			},
+			dockerSecrets: map[string]string{
+				"WEBHOOK_SECRET":   "webh00k_secret",
+				"GIT_ACCESS_TOKEN": "t0ken",
+			},
+			expectedErr: ErrBothSecretsSet,
+		},
+		{
 			name: "invalid config with docker secrets",
 			envVars: map[string]string{
 				"LOG_LEVEL":             "info",

--- a/internal/config/errors.go
+++ b/internal/config/errors.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"errors"
+
+	"gopkg.in/validator.v2"
+)
+
+var (
+	ErrInvalidLogLevel   = validator.TextErr{Err: errors.New("invalid log level, must be one of debug, info, warn, error")}
+	ErrBothSecretsSet    = errors.New("both secrets are set, please use one or the other")
+	ErrBothSecretsNotSet = errors.New("neither secrets are set, please use one or the other")
+)

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -4,12 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/creasty/defaults"
 	"io"
 	"os"
-	"regexp"
-	"strings"
-
-	"github.com/creasty/defaults"
 
 	"gopkg.in/yaml.v3"
 )
@@ -85,15 +82,4 @@ func loadFileBasedEnvVars(cfg *AppConfig) error {
 	}
 
 	return nil
-}
-
-// CamelCaseToSnakeCase converts a string from camelCase to snake_case.
-func CamelCaseToSnakeCase(str string) string {
-	matchFirstCap := regexp.MustCompile("(.)([A-Z][a-z]+)")
-	matchAllCap := regexp.MustCompile("([a-z0-9])([A-Z])")
-
-	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
-	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
-
-	return strings.ToLower(snake)
 }

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -87,8 +86,6 @@ func TestLoadCompose(t *testing.T) {
 }
 
 func TestDeployCompose(t *testing.T) {
-	secretsPath := path.Join(t.TempDir(), config.DockerSecretsPath)
-
 	value := os.Getenv("WEBHOOK_SECRET")
 	if value == "" {
 		err := os.Setenv("WEBHOOK_SECRET", "notempty")
@@ -105,7 +102,7 @@ func TestDeployCompose(t *testing.T) {
 		}
 	}
 
-	c, err := config.GetAppConfig(secretsPath)
+	c, err := config.GetAppConfig()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -86,22 +86,6 @@ func TestLoadCompose(t *testing.T) {
 }
 
 func TestDeployCompose(t *testing.T) {
-	value := os.Getenv("WEBHOOK_SECRET")
-	if value == "" {
-		err := os.Setenv("WEBHOOK_SECRET", "notempty")
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	value = os.Getenv("GIT_ACCESS_TOKEN")
-	if value == "" {
-		err := os.Setenv("GIT_ACCESS_TOKEN", "notempty")
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
 	c, err := config.GetAppConfig()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -20,9 +19,7 @@ const (
 )
 
 func TestGetAuthUrl(t *testing.T) {
-	secretsPath := path.Join(t.TempDir(), config.DockerSecretsPath)
-
-	c, err := config.GetAppConfig(secretsPath)
+	c, err := config.GetAppConfig()
 	if err != nil {
 		t.Fatalf("Failed to get app config: %v", err)
 	}


### PR DESCRIPTION
This PR changes the logic to load secret files and adds two new environment variables to provide sensitive values from files f e.g. with Docker secrets:
- `WEBHOOK_SECRET_FILE`: Path to the file containing the webhook secret (see `WEBHOOK_SECRET`)
- `GIT_ACCESS_TOKEN_FILE` Path to the file containing the Git access token (see `GIT_ACCESS_TOKEN`)

### Usage Example with Docker Secrets

1. Create Docker secrets (only with Docker Swarm)
    ```sh
    echo "token" | docker secret create git_access_token -
    echo "secret" | docker secret create webhook_secret -
    ```

2. Define secrets in `docker-compose.yml`
    ```yaml
    services:
      app:
        container_name: doco-cd
        image: ghcr.io/kimdre/doco-cd:latest
        restart: unless-stopped
        ports:
          - "80:80"
        environment:
          TZ: Europe/Berlin
          GIT_ACCESS_TOKEN_FILE: /run/secrets/git_access_token
          WEBHOOK_SECRET_FILE: /run/secrets/webhook_secret
        secrets:
          - git_access_token
          - webhook_secret
        volumes:
          - /var/run/docker.sock:/var/run/docker.sock
          - data:/data

    volumes:
      data:
    
    secrets:
      git_access_token:
        external: true
      webhook_secret:
        external: true
    ```