### PR TITLE
fix: always retrieve correct application container ID

### DIFF
--- a/cmd/doco-cd/http_handler.go
+++ b/cmd/doco-cd/http_handler.go
@@ -233,7 +233,7 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 			correctRepo := false
 
 			for _, cont := range containers {
-				if cont.Labels[docker.DocoCDLabels.Metadata.Manager] == "doco-cd" {
+				if cont.Labels[docker.DocoCDLabels.Metadata.Manager] == config.AppName {
 					managed = true
 
 					if cont.Labels[docker.DocoCDLabels.Repository.Name] == repoName {

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -41,7 +41,10 @@ func getAppContainerID() (string, error) {
 		return "", errors.New("failed to parse container ID from cpuset path")
 	}
 
-	return parts[len(parts)-1], nil
+	containerID := parts[len(parts)-1]
+	containerID = strings.TrimSpace(containerID)
+
+	return containerID, nil
 }
 
 func main() {

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
 	"sync"
 
 	"github.com/docker/docker/client"
@@ -25,11 +24,6 @@ var (
 	Version string
 	errMsg  string
 )
-
-// getAppContainerID retrieves the container ID of the application
-func getAppContainerID() string {
-	return os.Getenv("HOSTNAME")
-}
 
 func main() {
 	var wg sync.WaitGroup
@@ -89,7 +83,12 @@ func main() {
 		))
 
 	// Check if the application has a data mount point and get the host path
-	appContainerID := getAppContainerID()
+	appContainerID, err := docker.GetContainerID(dockerCli.Client(), "doco-cd")
+	if err != nil {
+		log.Critical("failed to retrieve application container id", logger.ErrAttr(err))
+		return
+	}
+
 	log.Debug("retrieved application container id", slog.String("container_id", appContainerID))
 
 	dataMountPoint, err := docker.GetMountPointByDestination(dockerClient, appContainerID, dataPath)

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -83,7 +83,7 @@ func main() {
 		))
 
 	// Check if the application has a data mount point and get the host path
-	appContainerID, err := docker.GetContainerID(dockerCli.Client(), "doco-cd")
+	appContainerID, err := docker.GetContainerID(dockerCli.Client(), config.AppName)
 	if err != nil {
 		log.Critical("failed to retrieve application container id", logger.ErrAttr(err))
 		return
@@ -133,7 +133,7 @@ func main() {
 
 	log.Debug("retrieving containers that are managed by doco-cd")
 
-	containers, err := docker.GetLabeledContainers(context.TODO(), dockerClient, docker.DocoCDLabels.Metadata.Manager, "doco-cd")
+	containers, err := docker.GetLabeledContainers(context.TODO(), dockerClient, docker.DocoCDLabels.Metadata.Manager, config.AppName)
 	if err != nil {
 		log.Error("failed to retrieve doco-cd containers", logger.ErrAttr(err))
 	}

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -7,6 +7,8 @@ import (
 	"gopkg.in/validator.v2"
 )
 
+const AppName = "doco-cd" // Name of the application
+
 // AppConfig is used to configure this application
 // https://github.com/caarlos0/env?tab=readme-ov-file#env-tag-options
 type AppConfig struct {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -162,7 +162,7 @@ containers that are part of a service.
 func addServiceLabels(project *types.Project, deployConfig config.DeployConfig, payload webhook.ParsedPayload, repoDir, appVersion, timestamp, composeVersion string) {
 	for i, s := range project.Services {
 		s.CustomLabels = map[string]string{
-			DocoCDLabels.Metadata.Manager:         "doco-cd",
+			DocoCDLabels.Metadata.Manager:         config.AppName,
 			DocoCDLabels.Metadata.Version:         appVersion,
 			DocoCDLabels.Deployment.Name:          deployConfig.Name,
 			DocoCDLabels.Deployment.Timestamp:     timestamp,
@@ -185,7 +185,7 @@ func addServiceLabels(project *types.Project, deployConfig config.DeployConfig, 
 func addVolumeLabels(project *types.Project, deployConfig config.DeployConfig, payload webhook.ParsedPayload, appVersion, timestamp, composeVersion string) {
 	for i, v := range project.Volumes {
 		v.CustomLabels = map[string]string{
-			DocoCDLabels.Metadata.Manager:         "doco-cd",
+			DocoCDLabels.Metadata.Manager:         config.AppName,
 			DocoCDLabels.Metadata.Version:         appVersion,
 			DocoCDLabels.Deployment.Name:          deployConfig.Name,
 			DocoCDLabels.Deployment.Timestamp:     timestamp,

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -211,7 +211,7 @@ func TestDeployCompose(t *testing.T) {
 
 		t.Log("Verifying deployment")
 
-		containers, err := GetLabeledContainers(ctx, dockerClient, DocoCDLabels.Metadata.Manager, "doco-cd")
+		containers, err := GetLabeledContainers(ctx, dockerClient, DocoCDLabels.Metadata.Manager, config.AppName)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -272,7 +272,7 @@ func TestDeployCompose(t *testing.T) {
 
 		t.Log("Verifying destruction")
 
-		containers, err = GetLabeledContainers(ctx, dockerClient, DocoCDLabels.Metadata.Manager, "doco-cd")
+		containers, err = GetLabeledContainers(ctx, dockerClient, DocoCDLabels.Metadata.Manager, config.AppName)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
When the container restarts without redeploying, the container ID changes but the hostname (and `$HOSTNAME` env var) is still the old container ID. This PR changes the way how the correct container id gets retrieved even after a container restart by fetching the current container id from the cpuset file of the application process (`/proc/1/cpuset`).
See also https://github.com/pre-commit/pre-commit/issues/1918