### PR TITLE
feat: log status during long deployments

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -432,6 +432,8 @@ func DeployStack(
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
+	time.Sleep(3 * time.Second)
+
 	return nil
 }
 

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -415,7 +415,7 @@ func DeployStack(
 		for {
 			select {
 			case <-ticker.C:
-				stackLog.Info("stack deployment in progress")
+				stackLog.Info("deployment in progress")
 			case <-done:
 				return
 			}

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -409,7 +409,7 @@ func DeployStack(
 	defer close(done)
 
 	go func() {
-		ticker := time.NewTicker(1 * time.Second)
+		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 
 		for {
@@ -432,7 +432,7 @@ func DeployStack(
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	return nil
 }

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -432,8 +432,6 @@ func DeployStack(
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
-	time.Sleep(10 * time.Second)
-
 	return nil
 }
 

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -405,6 +405,20 @@ func DeployStack(
 
 	stackLog.Info("deploying stack")
 
+	deploymentState := true
+	go func(deploying *bool) {
+		for *deploying {
+			time.Sleep(1 * time.Second)
+			stackLog.Info("still deploying stack", slog.String("stack", deployConfig.Name))
+		}
+
+		stackLog.Info("stack deployment completed", slog.String("stack", deployConfig.Name))
+	}(&deploymentState)
+
+	defer func(deploying *bool) {
+		*deploying = false
+	}(&deploymentState)
+
 	err = DeployCompose(*ctx, *dockerCli, project, deployConfig, *payload, externalWorkingDir, latestCommit, appVersion, forceDeploy)
 	if err != nil {
 		errMsg := "failed to deploy stack"


### PR DESCRIPTION
Log a status message every 5 seconds that a deployment is still in progress until it is finished.