### PR TITLE
fix: use reference from trigger event as default for deployments

### DIFF
--- a/cmd/doco-cd/http_handler.go
+++ b/cmd/doco-cd/http_handler.go
@@ -131,7 +131,7 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	jobLog.Debug("retrieving deployment configuration")
 
 	// Get the deployment configs from the repository
-	deployConfigs, err := config.GetDeployConfigs(internalRepoPath, payload.Name, customTarget)
+	deployConfigs, err := config.GetDeployConfigs(internalRepoPath, payload.Name, customTarget, payload.Ref)
 	if err != nil {
 		if errors.Is(err, config.ErrDeprecatedConfig) {
 			jobLog.Warn(err.Error())

--- a/cmd/doco-cd/poll_handler.go
+++ b/cmd/doco-cd/poll_handler.go
@@ -84,8 +84,7 @@ func RunPoll(ctx context.Context, pollConfig config.PollConfig, appConfig *confi
 	repoName := getRepoName(cloneUrl)
 	jobLog := logger.With(
 		slog.String("repository", repoName),
-		slog.String("job_id", jobID),
-		slog.Any("poll_config", pollConfig))
+		slog.String("job_id", jobID))
 
 	if strings.Contains(repoName, "..") {
 		jobLog.Error("invalid repository name, contains '..'")

--- a/cmd/doco-cd/poll_handler.go
+++ b/cmd/doco-cd/poll_handler.go
@@ -84,7 +84,8 @@ func RunPoll(ctx context.Context, pollConfig config.PollConfig, appConfig *confi
 	repoName := getRepoName(cloneUrl)
 	jobLog := logger.With(
 		slog.String("repository", repoName),
-		slog.String("job_id", jobID))
+		slog.String("job_id", jobID),
+		slog.Any("poll_config", pollConfig))
 
 	if strings.Contains(repoName, "..") {
 		jobLog.Error("invalid repository name, contains '..'")

--- a/cmd/doco-cd/poll_handler.go
+++ b/cmd/doco-cd/poll_handler.go
@@ -95,7 +95,7 @@ func RunPoll(ctx context.Context, pollConfig config.PollConfig, appConfig *confi
 		jobLog = jobLog.With(slog.String("custom_target", pollConfig.CustomTarget))
 	}
 
-	jobLog.Info("polling repository", slog.Group("trigger", slog.String("event", "poll")))
+	jobLog.Info("polling repository", slog.Group("trigger", slog.String("event", "poll"), slog.Any("config", pollConfig)))
 
 	jobLog.Debug("get repository",
 		slog.String("url", cloneUrl))

--- a/cmd/doco-cd/poll_handler.go
+++ b/cmd/doco-cd/poll_handler.go
@@ -155,7 +155,7 @@ func RunPoll(ctx context.Context, pollConfig config.PollConfig, appConfig *confi
 	shortName := filepath.Base(repoName)
 
 	// Get the deployment configs from the repository
-	deployConfigs, err := config.GetDeployConfigs(internalRepoPath, shortName, pollConfig.CustomTarget)
+	deployConfigs, err := config.GetDeployConfigs(internalRepoPath, shortName, pollConfig.CustomTarget, pollConfig.Reference)
 	if err != nil {
 		if errors.Is(err, config.ErrDeprecatedConfig) {
 			jobLog.Warn(err.Error())

--- a/internal/config/deploy_config_test.go
+++ b/internal/config/deploy_config_test.go
@@ -62,7 +62,7 @@ compose_files:
 			t.Fatal(err)
 		}
 
-		configs, err := GetDeployConfigs(dirName, projectName, customTarget)
+		configs, err := GetDeployConfigs(dirName, projectName, customTarget, reference)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -119,7 +119,7 @@ compose_files:
 			t.Fatal(err)
 		}
 
-		configs, err := GetDeployConfigs(dirName, projectName, customTarget)
+		configs, err := GetDeployConfigs(dirName, projectName, customTarget, reference)
 		if err == nil || !errors.Is(err, ErrDeprecatedConfig) {
 			t.Fatalf("expected deprecated config error, got %v", err)
 		}
@@ -154,7 +154,7 @@ compose_files:
 }
 
 func TestGetDeployConfigs_DefaultValues(t *testing.T) {
-	defaultConfig := DefaultDeployConfig(projectName)
+	defaultConfig := DefaultDeployConfig(projectName, DefaultReference)
 
 	dirName := createTmpDir(t)
 	t.Cleanup(func() {
@@ -164,7 +164,7 @@ func TestGetDeployConfigs_DefaultValues(t *testing.T) {
 		}
 	})
 
-	configs, err := GetDeployConfigs(dirName, projectName, "")
+	configs, err := GetDeployConfigs(dirName, projectName, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/poll_config.go
+++ b/internal/config/poll_config.go
@@ -33,7 +33,7 @@ func (c *PollConfig) Validate() error {
 	}
 
 	if c.Reference == "" {
-		return fmt.Errorf("%w: branch", ErrKeyNotFound)
+		return fmt.Errorf("%w: reference", ErrKeyNotFound)
 	}
 
 	if c.Interval < 10 && c.Interval != 0 {

--- a/internal/config/poll_config.go
+++ b/internal/config/poll_config.go
@@ -13,11 +13,11 @@ var (
 )
 
 type PollConfig struct {
-	CloneUrl     HttpUrl `yaml:"url" validate:"httpUrl"`   // CloneUrl is the URL to clone the Git repository that is used to poll for changes
-	Reference    string  `yaml:"reference" default:"main"` // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
-	Interval     int     `yaml:"interval" default:"180"`   // Interval is the interval in seconds to poll for changes
-	CustomTarget string  `yaml:"target" default:""`        // CustomTarget is the name of an optional custom deployment config file, e.g. ".doco-cd.custom-name.yaml"
-	Private      bool    `yaml:"private" default:"false"`  // Private indicates if the repository is private, which requires authentication
+	CloneUrl     HttpUrl `yaml:"url" validate:"httpUrl"`              // CloneUrl is the URL to clone the Git repository that is used to poll for changes
+	Reference    string  `yaml:"reference" default:"refs/heads/main"` // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
+	Interval     int     `yaml:"interval" default:"180"`              // Interval is the interval in seconds to poll for changes
+	CustomTarget string  `yaml:"target" default:""`                   // CustomTarget is the name of an optional custom deployment config file, e.g. ".doco-cd.custom-name.yaml"
+	Private      bool    `yaml:"private" default:"false"`             // Private indicates if the repository is private, which requires authentication
 }
 
 type PollJob struct {

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -181,7 +181,7 @@ func TestDeployCompose(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deployConfigs, err := config.GetDeployConfigs(tmpDir, projectName, customTarget)
+	deployConfigs, err := config.GetDeployConfigs(tmpDir, projectName, customTarget, p.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR changes the default Git reference/branch for deployments when the `reference` field is not specified in the deployment configuration. Now the default reference is the same as the one that triggered the deployment:
- Polling: Reference of poll configuration
- Webhook: Reference of webhook trigger  