### PR TITLE
fix: update default metrics port from 9090 to 9120

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=build-stage /doco-cd /doco-cd
 
 ENV TZ=UTC \
     HTTP_PORT=80 \
-    METRICS_PORT=9090 \
+    METRICS_PORT=9120 \
     LOG_LEVEL=info
 
 ENTRYPOINT ["/doco-cd"]

--- a/dev.compose.yaml
+++ b/dev.compose.yaml
@@ -17,7 +17,7 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
-      - "9090:9090"
+      - "9120:9120"
     env_file:
       - .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     restart: unless-stopped
     ports:
       - "80:80" # Webhook endpoint
-      - "9090:9090" # Prometheus metrics
+      - "9120:9120" # Prometheus metrics
     # For all available environment variables and explanations, see https://github.com/kimdre/doco-cd/wiki/App-Settings
     environment:
       TZ: Europe/Berlin

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -30,7 +30,7 @@ type AppConfig struct {
 	PollConfigFile      string                 `env:"POLL_CONFIG_FILE,file"`                                              // PollConfigFile is the file containing the PollConfig in YAML format
 	PollConfig          []PollConfig           `yaml:"-"`                                                                 // PollConfig is the YAML configuration for polling Git repositories for changes
 	MaxPayloadSize      int64                  `env:"MAX_PAYLOAD_SIZE,notEmpty" envDefault:"1048576"`                     // MaxPayloadSize is the maximum size of the payload in bytes that the HTTP server will accept (default 1MB = 1048576 bytes)
-	MetricsPort         uint16                 `env:"METRICS_PORT,notEmpty" envDefault:"9090" validate:"min=1,max=65535"` // MetricsPort is the port the prometheus metrics server will listen on
+	MetricsPort         uint16                 `env:"METRICS_PORT,notEmpty" envDefault:"9120" validate:"min=1,max=65535"` // MetricsPort is the port the prometheus metrics server will listen on
 }
 
 // GetAppConfig returns the configuration.


### PR DESCRIPTION
update default metrics port from 9090 to 9120 to avoid conflict with prometheus endpoint.