### PR TITLE
feat(docker-swarm): add config and secret hash prefixing to overwrite deployed configs and secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test-coverage:
 # Run specified tests from arguments
 test-run:
 	@echo "Running tests: $(filter-out $@,$(MAKECMDGOALS))"
-	@WEBHOOK_SECRET="test_Secret1" go test -cover -p 1 ./... -timeout 5m -run $(filter-out $@,$(MAKECMDGOALS))
+	@WEBHOOK_SECRET="test_Secret1" go test -cover -v -p 1 ./... -timeout 5m -run $(filter-out $@,$(MAKECMDGOALS))
 
 build:
 	mkdir -p $(BINARY_DIR)

--- a/internal/config/deploy_config.go
+++ b/internal/config/deploy_config.go
@@ -31,16 +31,17 @@ const DefaultReference = "refs/heads/main"
 
 // DeployConfig is the structure of the deployment configuration file.
 type DeployConfig struct {
-	Name             string   `yaml:"name"`                                                                                                         // Name is the name of the docker-compose deployment / stack
-	RepositoryUrl    HttpUrl  `yaml:"repository_url" default:"" validate:"httpUrl"`                                                                 // RepositoryUrl is the http URL of the Git repository to deploy
-	Reference        string   `yaml:"reference" default:""`                                                                                         // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
-	WorkingDirectory string   `yaml:"working_dir" default:"."`                                                                                      // WorkingDirectory is the working directory for the deployment
-	ComposeFiles     []string `yaml:"compose_files" default:"[\"compose.yaml\", \"compose.yml\", \"docker-compose.yml\", \"docker-compose.yaml\"]"` // ComposeFiles is the list of docker-compose files to use
-	RemoveOrphans    bool     `yaml:"remove_orphans" default:"true"`                                                                                // RemoveOrphans removes containers for services not defined in the Compose file
-	ForceRecreate    bool     `yaml:"force_recreate" default:"false"`                                                                               // ForceRecreate forces the recreation/redeployment of containers even if the configuration has not changed
-	ForceImagePull   bool     `yaml:"force_image_pull" default:"false"`                                                                             // ForceImagePull always pulls the latest version of the image tags you've specified if a newer version is available
-	Timeout          int      `yaml:"timeout" default:"180"`                                                                                        // Timeout is the time in seconds to wait for the deployment to finish in seconds before timing out
-	BuildOpts        struct {
+	Name                  string   `yaml:"name"`                                                                                                         // Name is the name of the docker-compose deployment / stack
+	RepositoryUrl         HttpUrl  `yaml:"repository_url" default:"" validate:"httpUrl"`                                                                 // RepositoryUrl is the http URL of the Git repository to deploy
+	Reference             string   `yaml:"reference" default:""`                                                                                         // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
+	WorkingDirectory      string   `yaml:"working_dir" default:"."`                                                                                      // WorkingDirectory is the working directory for the deployment
+	ComposeFiles          []string `yaml:"compose_files" default:"[\"compose.yaml\", \"compose.yml\", \"docker-compose.yml\", \"docker-compose.yaml\"]"` // ComposeFiles is the list of docker-compose files to use
+	RemoveOrphans         bool     `yaml:"remove_orphans" default:"true"`                                                                                // RemoveOrphans removes containers for services not defined in the Compose file
+	ForceRecreate         bool     `yaml:"force_recreate" default:"false"`                                                                               // ForceRecreate forces the recreation/redeployment of containers even if the configuration has not changed
+	ForceImagePull        bool     `yaml:"force_image_pull" default:"false"`                                                                             // ForceImagePull always pulls the latest version of the image tags you've specified if a newer version is available
+	Timeout               int      `yaml:"timeout" default:"180"`                                                                                        // Timeout is the time in seconds to wait for the deployment to finish in seconds before timing out
+	DisableNameSuffixHash bool     `yaml:"disable_name_suffix_hash" default:"false"`                                                                     // DisableNameSiffixHash disable appending of a content hash suffix to the names of docker swarm configs and secrets to avoid name collisions on the Docker host after changing their contents.
+	BuildOpts             struct {
 		ForceImagePull bool              `yaml:"force_image_pull" default:"false"` // ForceImagePull always attempt to pull a newer version of the image
 		Quiet          bool              `yaml:"quiet" default:"false"`            // Quiet suppresses the build output
 		Args           map[string]string `yaml:"args"`                             // BuildArgs is a map of build-time arguments to pass to the build process

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -457,24 +457,26 @@ func DeployStack(
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
-	err = SetConfigHashPrefixes(project)
-	if err != nil {
-		errMsg := "failed to set config hash prefixes"
-		stackLog.Error(errMsg,
-			logger.ErrAttr(err),
-			slog.Group("compose_files", slog.Any("files", deployConfig.ComposeFiles)))
+	if !deployConfig.DisableNameSuffixHash {
+		err = SetConfigHashPrefixes(project)
+		if err != nil {
+			errMsg := "failed to set config hash prefixes"
+			stackLog.Error(errMsg,
+				logger.ErrAttr(err),
+				slog.Group("compose_files", slog.Any("files", deployConfig.ComposeFiles)))
 
-		return fmt.Errorf("%s: %w", errMsg, err)
-	}
+			return fmt.Errorf("%s: %w", errMsg, err)
+		}
 
-	err = SetSecretHashPrefixes(project)
-	if err != nil {
-		errMsg := "failed to set secret hash prefixes"
-		stackLog.Error(errMsg,
-			logger.ErrAttr(err),
-			slog.Group("compose_files", slog.Any("files", deployConfig.ComposeFiles)))
+		err = SetSecretHashPrefixes(project)
+		if err != nil {
+			errMsg := "failed to set secret hash prefixes"
+			stackLog.Error(errMsg,
+				logger.ErrAttr(err),
+				slog.Group("compose_files", slog.Any("files", deployConfig.ComposeFiles)))
 
-		return fmt.Errorf("%s: %w", errMsg, err)
+			return fmt.Errorf("%s: %w", errMsg, err)
+		}
 	}
 
 	stackLog.Info("deploying stack")

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -457,6 +457,26 @@ func DeployStack(
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
+	err = SetConfigHashPrefixes(project)
+	if err != nil {
+		errMsg := "failed to set config hash prefixes"
+		stackLog.Error(errMsg,
+			logger.ErrAttr(err),
+			slog.Group("compose_files", slog.Any("files", deployConfig.ComposeFiles)))
+
+		return fmt.Errorf("%s: %w", errMsg, err)
+	}
+
+	err = SetSecretHashPrefixes(project)
+	if err != nil {
+		errMsg := "failed to set secret hash prefixes"
+		stackLog.Error(errMsg,
+			logger.ErrAttr(err),
+			slog.Group("compose_files", slog.Any("files", deployConfig.ComposeFiles)))
+
+		return fmt.Errorf("%s: %w", errMsg, err)
+	}
+
 	stackLog.Info("deploying stack")
 
 	done := make(chan struct{})

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -50,12 +50,6 @@ services:
       TZ: Europe/Berlin
     volumes:
       - ./html:/usr/share/nginx/html
-    configs:
-      - source: nginx_config
-        target: /nginx.conf
-configs:
-  nginx_config:
-    content: Hello world!
 `
 )
 

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -47,8 +47,6 @@ services:
   test:
     image: nginx:latest
     environment:
-      GIT_ACCESS_TOKEN:
-      WEBHOOK_SECRET:
       TZ: Europe/Berlin
     volumes:
       - ./html:/usr/share/nginx/html

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -42,7 +42,8 @@ func createTestFile(fileName string, content string) error {
 
 const (
 	projectName     = "test"
-	composeContents = `services:
+	composeContents = `
+services:
   test:
     image: nginx:latest
     environment:
@@ -51,6 +52,12 @@ const (
       TZ: Europe/Berlin
     volumes:
       - ./html:/usr/share/nginx/html
+    configs:
+      - source: nginx_config
+        target: /nginx.conf
+configs:
+  nginx_config:
+    content: Hello world!
 `
 )
 

--- a/internal/docker/utils_test.go
+++ b/internal/docker/utils_test.go
@@ -1,0 +1,182 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kimdre/doco-cd/internal/utils"
+)
+
+func TestSetConfigHashPrefixes(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.compose.yaml")
+
+	createComposeFile(t, filePath, composeContents)
+
+	project, err := LoadCompose(ctx, tmpDir, projectName, []string{filePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		configName    string
+		configContent string
+		hash          string
+	)
+
+	for _, config := range project.Configs {
+		configName = config.Name
+		configContent = config.Content
+
+		hash, err = generateShortHash(strings.NewReader(configContent))
+		if err != nil {
+			t.Fatalf("failed to generate hash for config %s: %v", config.Name, err)
+		}
+
+		break
+	}
+
+	t.Logf("configName: %s", configName)
+	t.Logf("configContent: %s", configContent)
+	t.Logf("hash: %s", hash)
+
+	err = SetConfigHashPrefixes(project)
+	if err != nil {
+		t.Fatalf("failed to set config hash prefixes: %v", err)
+	}
+
+	serialized, err := json.MarshalIndent(project, "", " ")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	t.Log(string(serialized))
+
+	if len(project.Services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(project.Services))
+	}
+
+	if len(project.Configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(project.Configs))
+	}
+
+	for _, config := range project.Configs {
+		if config.Name != configName+"_"+hash {
+			t.Errorf("expected config name %s to be %s_%s", config.Name, configName, hash)
+		}
+
+		if config.Content != configContent {
+			t.Errorf("expected config content to be unchanged, got %s", config.Content)
+		}
+
+		for _, service := range project.Services {
+			for _, cfg := range service.Configs {
+				if cfg.Source == configName {
+					if cfg.Source != config.Name {
+						t.Errorf("expected service config source to be updated to %s, got %s", config.Name, cfg.Source)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSetSecretHashPrefixes(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.compose.yaml")
+
+	// secrets definition in compose file
+	composeContentsWithSecrets := fmt.Sprintf("%s\n%s",
+		composeContents, `
+secrets:
+  secret_example:
+    file: ./secret.txt
+`)
+
+	secretFilePath := filepath.Join(tmpDir, "secret.txt")
+
+	err := os.WriteFile(secretFilePath, []byte("This is a secret content."), utils.PermOwner)
+	if err != nil {
+		t.Fatalf("failed to create secret file %s: %v", secretFilePath, err)
+	}
+
+	createComposeFile(t, filePath, composeContentsWithSecrets)
+
+	project, err := LoadCompose(ctx, tmpDir, projectName, []string{filePath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		secretName    string
+		secretContent string
+		hash          string
+	)
+
+	for _, secret := range project.Secrets {
+		secretName = secret.Name
+
+		contentBytes, err := os.ReadFile(secret.File)
+		if err != nil {
+			t.Fatalf("failed to read secret file %s: %v", secret.File, err)
+		}
+
+		secretContent = string(contentBytes)
+
+		hash, err = generateShortHash(strings.NewReader(secretContent))
+		if err != nil {
+			t.Fatalf("failed to generate hash for secret %s: %v", secret.Name, err)
+		}
+
+		break
+	}
+
+	t.Logf("secretName: %s", secretName)
+	t.Logf("secretContent: %s", secretContent)
+	t.Logf("hash: %s", hash)
+
+	err = SetSecretHashPrefixes(project)
+	if err != nil {
+		t.Fatalf("failed to set secret hash prefixes: %v", err)
+	}
+
+	serialized, err := json.MarshalIndent(project, "", " ")
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	t.Log(string(serialized))
+
+	if len(project.Services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(project.Services))
+	}
+
+	if len(project.Secrets) != 1 {
+		t.Fatalf("expected 1 secret, got %d", len(project.Secrets))
+	}
+
+	for _, secret := range project.Secrets {
+		if secret.Name != secretName+"_"+hash {
+			t.Errorf("expected secret name %s to be %s_%s", secret.Name, secretName, hash)
+		}
+
+		for _, service := range project.Services {
+			for _, cfg := range service.Secrets {
+				if cfg.Source == secretName {
+					if cfg.Source != secret.Name {
+						t.Errorf("expected service secret source to be updated to %s, got %s", secret.Name, cfg.Source)
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/docker/utils_test.go
+++ b/internal/docker/utils_test.go
@@ -21,9 +21,11 @@ func TestSetConfigHashPrefixes(t *testing.T) {
 	createComposeFile(t, filePath, composeContents)
 
 	oldDir, _ := os.Getwd()
-	t.Logf("oldDir: %s", oldDir)
-	os.Chdir(tmpDir)
-	defer os.Chdir(oldDir)
+	_ = os.Chdir(tmpDir)
+
+	defer func(dir string) {
+		_ = os.Chdir(dir)
+	}(oldDir)
 
 	project, err := LoadCompose(ctx, tmpDir, projectName, []string{filePath})
 	if err != nil {
@@ -117,8 +119,11 @@ secrets:
 	createComposeFile(t, filePath, composeContentsWithSecrets)
 
 	oldDir, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	defer os.Chdir(oldDir)
+	_ = os.Chdir(tmpDir)
+
+	defer func(dir string) {
+		_ = os.Chdir(dir)
+	}(oldDir)
 
 	project, err := LoadCompose(ctx, tmpDir, projectName, []string{filePath})
 	if err != nil {

--- a/internal/docker/utils_test.go
+++ b/internal/docker/utils_test.go
@@ -20,6 +20,11 @@ func TestSetConfigHashPrefixes(t *testing.T) {
 
 	createComposeFile(t, filePath, composeContents)
 
+	oldDir, _ := os.Getwd()
+	t.Logf("oldDir: %s", oldDir)
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldDir)
+
 	project, err := LoadCompose(ctx, tmpDir, projectName, []string{filePath})
 	if err != nil {
 		t.Fatal(err)
@@ -110,6 +115,10 @@ secrets:
 	}
 
 	createComposeFile(t, filePath, composeContentsWithSecrets)
+
+	oldDir, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(oldDir)
 
 	project, err := LoadCompose(ctx, tmpDir, projectName, []string{filePath})
 	if err != nil {

--- a/internal/docker/utils_test.go
+++ b/internal/docker/utils_test.go
@@ -18,7 +18,17 @@ func TestSetConfigHashPrefixes(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "test.compose.yaml")
 
-	createComposeFile(t, filePath, composeContents)
+	composeContentsWithConfigs := fmt.Sprintf("%s\n%s",
+		composeContents, `
+    configs:
+      - source: nginx_config
+        target: /nginx.conf
+configs:
+  nginx_config:
+    content: Hello world!
+`)
+
+	createComposeFile(t, filePath, composeContentsWithConfigs)
 
 	oldDir, _ := os.Getwd()
 	_ = os.Chdir(tmpDir)
@@ -101,7 +111,6 @@ func TestSetSecretHashPrefixes(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "test.compose.yaml")
 
-	// secrets definition in compose file
 	composeContentsWithSecrets := fmt.Sprintf("%s\n%s",
 		composeContents, `
 secrets:


### PR DESCRIPTION
To Do:

- [x] Append a content hash of configs/secrets to their names as a suffix to avoid name collisions when deploying new version of them with changed content (docker swarm only) with new deploy var `disable_name_suffix_hash` (bool) to disable this behavior if needed. 
- [ ] Add `disable_name_suffix_hash` deploy setting to wiki
- [ ] Deploy with ForceRecreate enabled when the Git status contains a file that is referenced as the source of a config or secret.
- [ ] Deploy with ForceRecreate enabled when the inline content of a config changes.