### PR TITLE
fix: improve mount path check

### DIFF
--- a/cmd/doco-cd/http_handler.go
+++ b/cmd/doco-cd/http_handler.go
@@ -363,6 +363,10 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 				return
 			}
 
+			subJobLog.Debug("comparing commits",
+				slog.String("deployed_commit", deployedCommit),
+				slog.String("latest_commit", latestCommit))
+
 			var changedFiles []git.ChangedFile
 			if deployedCommit != "" {
 				changedFiles, err = git.GetChangedFilesBetweenCommits(repo, plumbing.NewHash(deployedCommit), plumbing.NewHash(latestCommit))

--- a/cmd/doco-cd/http_handler.go
+++ b/cmd/doco-cd/http_handler.go
@@ -400,7 +400,7 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 			}
 
 			err = docker.DeployStack(subJobLog, internalRepoPath, externalRepoPath, &ctx, &dockerCli, dockerClient,
-				&payload, deployConfig, changedFiles, latestCommit, Version, false)
+				&payload, deployConfig, changedFiles, latestCommit, Version, "webhook", false)
 			if err != nil {
 				onError(repoName, w, subJobLog.With(logger.ErrAttr(err)), "deployment failed", err.Error(), jobID, http.StatusInternalServerError)
 

--- a/cmd/doco-cd/poll_handler.go
+++ b/cmd/doco-cd/poll_handler.go
@@ -469,7 +469,7 @@ func RunPoll(ctx context.Context, pollConfig config.PollConfig, appConfig *confi
 			}
 
 			err = docker.DeployStack(subJobLog, internalRepoPath, externalRepoPath, &ctx, &dockerCli, dockerClient,
-				&payload, deployConfig, changedFiles, latestCommit, Version, false)
+				&payload, deployConfig, changedFiles, latestCommit, Version, "poll", false)
 			if err != nil {
 				subJobLog.Error("failed to deploy stack", log.ErrAttr(err))
 

--- a/cmd/doco-cd/poll_handler.go
+++ b/cmd/doco-cd/poll_handler.go
@@ -417,6 +417,10 @@ func RunPoll(ctx context.Context, pollConfig config.PollConfig, appConfig *confi
 				return fmt.Errorf("%w: %s: skipping deployment", ErrDeploymentConflict, deployConfig.Name)
 			}
 
+			subJobLog.Debug("comparing commits",
+				slog.String("deployed_commit", deployedCommit),
+				slog.String("latest_commit", latestCommit))
+
 			if latestCommit == deployedCommit {
 				subJobLog.Debug("no new commit found, skipping deployment", slog.String("last_commit", latestCommit))
 

--- a/dev.compose.yaml
+++ b/dev.compose.yaml
@@ -15,6 +15,8 @@ services:
       args:
         - APP_VERSION=dev
     restart: unless-stopped
+    depends_on:
+      - proxy
     ports:
       - "80:80"
       - "9120:9120"

--- a/dev.compose.yaml
+++ b/dev.compose.yaml
@@ -1,9 +1,9 @@
 x-poll-config: &poll-config
   POLL_CONFIG: |
     - url: https://github.com/kimdre/doco-cd_tests.git
-      reference: main
-      interval: 15
-      target: "" # "test"
+      reference: test
+      interval: 10
+      target: ""
       private: true
 
 services:

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -222,7 +222,7 @@ func TestDeployCompose(t *testing.T) {
 		jobLog := log.With(slog.String("job_id", jobID))
 
 		err = DeployStack(jobLog, repoPath, repoPath, &ctx, &dockerCli, dockerClient,
-			&p, deployConf, []git.ChangedFile{}, latestCommit, "test", false)
+			&p, deployConf, []git.ChangedFile{}, latestCommit, "test", "poll", false)
 		if err != nil {
 			if errors.Is(err, config.ErrDeprecatedConfig) {
 				t.Log(err.Error())

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -226,6 +226,8 @@ func TestDeployCompose(t *testing.T) {
 		if err != nil {
 			if errors.Is(err, config.ErrDeprecatedConfig) {
 				t.Log(err.Error())
+			} else {
+				t.Fatalf("failed to deploy stack: %v", err)
 			}
 		}
 


### PR DESCRIPTION
The absolute path was incorrectly merged if the files are located in a subdirectory.
The Suffix of the working directory path and Prefix of the diff path were both part of the absolute path:

E.g. with nginx subdirectory
`/var/lib/docker/volumes/doco-cd_data/_data/github.com/kimdre/doco-cd_tests/nginx/nginx/index.html` should be 
`/var/lib/docker/volumes/doco-cd_data/_data/github.com/kimdre/doco-cd_tests/nginx/index.html`