### PR TITLE
fix: unify container ID retrieval for Docker and Podman

### DIFF
--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -37,13 +37,11 @@ var (
 // getAppContainerID retrieves the application container ID from the cpuset file.
 func getAppContainerID() (string, error) {
 	const (
-		cgroupMounts = "/proc/self/mountinfo"
-		dockerPath   = "/docker/containers/"
-		podmanPath   = "/containers/storage/overlay-containers/"
+		cgroupMounts  = "/proc/self/mountinfo"
+		containerPath = "/containers/"
 	)
 
-	dockerPattern := regexp.MustCompile(dockerPath + `([a-z0-9]+)`)
-	podmanPattern := regexp.MustCompile(podmanPath + `([a-z0-9]+)`)
+	containerPattern := regexp.MustCompile(containerPath + `([a-z0-9]+)`)
 
 	data, err := os.ReadFile(cgroupMounts)
 	if err != nil {
@@ -60,14 +58,8 @@ func getAppContainerID() (string, error) {
 		path := fields[3]
 
 		if strings.Contains(line, "/etc/hostname") {
-			if strings.Contains(path, dockerPath) {
-				if matches := dockerPattern.FindStringSubmatch(path); len(matches) > 1 {
-					return matches[1], nil
-				}
-			}
-
-			if strings.Contains(path, podmanPath) {
-				if matches := podmanPattern.FindStringSubmatch(path); len(matches) > 1 {
+			if strings.Contains(path, containerPath) {
+				if matches := containerPattern.FindStringSubmatch(path); len(matches) > 1 {
 					return matches[1], nil
 				}
 			}


### PR DESCRIPTION
Fixes #579