### PR TITLE
fix(compose): empty dependency label

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -169,6 +169,15 @@ containers that are part of a service.
 */
 func addComposeServiceLabels(project *types.Project, deployConfig config.DeployConfig, payload webhook.ParsedPayload, repoDir, appVersion, timestamp, composeVersion, latestCommit string) {
 	for i, s := range project.Services {
+
+		// Extract service dependencies (depends_on)
+		dependencies := make([]string, 0, len(s.DependsOn))
+		for dep := range s.DependsOn {
+			// https://docs.docker.com/compose/how-tos/startup-order/#control-startup
+			// Example: <service>:<condition>:<restart>
+			dependencies = append(dependencies, dep)
+		}
+
 		s.CustomLabels = map[string]string{
 			DocoCDLabels.Metadata.Manager:      config.AppName,
 			DocoCDLabels.Metadata.Version:      appVersion,
@@ -186,6 +195,7 @@ func addComposeServiceLabels(project *types.Project, deployConfig config.DeployC
 			api.ConfigFilesLabel:               strings.Join(project.ComposeFiles, ","),
 			api.VersionLabel:                   composeVersion,
 			api.OneoffLabel:                    "False", // default, will be overridden by docker compose
+			api.DependenciesLabel:              strings.Join(dependencies, ","),
 		}
 		project.Services[i] = s
 	}

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -169,7 +169,6 @@ containers that are part of a service.
 */
 func addComposeServiceLabels(project *types.Project, deployConfig config.DeployConfig, payload webhook.ParsedPayload, repoDir, appVersion, timestamp, composeVersion, latestCommit string) {
 	for i, s := range project.Services {
-
 		// Extract service dependencies (depends_on)
 		dependencies := make([]string, 0, len(s.DependsOn))
 		for dep := range s.DependsOn {

--- a/test/test.compose.yaml
+++ b/test/test.compose.yaml
@@ -5,6 +5,8 @@ services:
     image: nginx:latest
     ports:
       - "80"  # use random published port
+    depends_on:
+      - dep
     volumes:
       - ./:/usr/share/nginx/html
     environment:
@@ -15,6 +17,9 @@ services:
       - test_secret
     configs:
       - test_config
+
+  dep:
+    image: nginx:latest
 
 secrets:
   test_secret:


### PR DESCRIPTION
This fixes the empty "depends_on" label for deployed compose services with dependencies.

For example a service `app`

```yaml
services:
  app:
    depends_on:
      - db
      - web
```

gets this label value now: 
`"com.docker.compose.depends_on": "db:service_started:false,web:service_started:false"`

instead of the previous:
`"com.docker.compose.depends_on": ""`