### PR TITLE
ci: build images for linux/arm/v7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,5 +57,6 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64
+            linux/arm/v7
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
closes #638 