### PR TITLE
feat: enable docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 FROM busybox:1.37-uclibc@sha256:633928d4d846bc9877337776810c278189d7be3fdd734032e2c75893331d1d78 AS busybox-binaries
 
 FROM gcr.io/distroless/base-debian12@sha256:fa15492938650e1a5b87e34d47dc7d99a2b4e8aefd81b931b3f3eb6bb4c1d2f6 AS build-release-stage
-
+fix
 WORKDIR /
 
 # /data volume required to deploy from cloned Git repos
@@ -58,4 +58,4 @@ ENV TZ=UTC \
 ENTRYPOINT ["/doco-cd"]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD ["/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost/v1/health"]
+  CMD ["/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/v1/health"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=bind,target=. \
     go build -ldflags="-s -w -X main.Version=${APP_VERSION} ${BW_SDK_BUILD_FLAGS}" -o / ./...
 
-#FROM busybox AS busybox-binaries
-#
-#ARG BUSYBOX_VERSION=1.31.0-i686-uclibc
-#ADD https://busybox.net/downloads/binaries/$BUSYBOX_VERSION/busybox_WGET /wget
-#RUN chmod a+x /wget
+FROM busybox:1.37-uclibc@sha256:633928d4d846bc9877337776810c278189d7be3fdd734032e2c75893331d1d78 AS busybox-binaries
 
 FROM gcr.io/distroless/base-debian12@sha256:fa15492938650e1a5b87e34d47dc7d99a2b4e8aefd81b931b3f3eb6bb4c1d2f6 AS build-release-stage
 
@@ -52,7 +48,7 @@ WORKDIR /
 VOLUME /data
 
 COPY --from=build-stage /doco-cd /doco-cd
-# COPY --from=busybox-binaries /wget /usr/bin/wget
+COPY --from=busybox-binaries /bin/wget /usr/bin/wget
 
 ENV TZ=UTC \
     HTTP_PORT=80 \
@@ -61,5 +57,5 @@ ENV TZ=UTC \
 
 ENTRYPOINT ["/doco-cd"]
 
-#HEALTHCHECK --interval=30s --timeout=5s \
-#  CMD ["/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost/v1/health"]
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD ["/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://localhost/v1/health"]


### PR DESCRIPTION
We can also add in wiki if user change HTTP_PORT to add in docker-compose.yml

```yaml
---
services:

  doco-cd:
    image: ghcr.io/kimdre/doco-cd:0.39.0-rc.1
...
    environment:
      HTTP_PORT: 8080
...
    healthcheck:
      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/v1/health"]
      start_period: 15s
      interval: 30s
      timeout: 5s
      retries: 3
```