### PR TITLE
fix(swarm): send registry auth

### DIFF
--- a/internal/docker/swarm.go
+++ b/internal/docker/swarm.go
@@ -38,7 +38,7 @@ func DeploySwarmStack(ctx context.Context, dockerCli command.Cli, project *types
 		Composefiles:     project.ComposeFiles,
 		Namespace:        deployConfig.Name,
 		ResolveImage:     swarm.ResolveImageAlways,
-		SendRegistryAuth: false,
+		SendRegistryAuth: true,
 		Prune:            deployConfig.RemoveOrphans,
 		Detach:           false,
 		Quiet:            true,


### PR DESCRIPTION
doco-cd did not enable SendRegistryAuth to tell the swarm manager node to send registry auth credentials to worker nodes on deployments.
This PR fixes that.