### PR TITLE
fix(poll): run_once if interval is set to 0

### DIFF
--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -46,7 +46,7 @@ func getRepoLock(repoName string) *sync.Mutex {
 
 // StartPoll initializes PollJob with the provided configuration and starts the PollHandler goroutine.
 func StartPoll(h *handlerData, pollConfig config.PollConfig, wg *sync.WaitGroup) error {
-	if pollConfig.Interval == 0 {
+	if pollConfig.Interval == 0 && !pollConfig.RunOnce {
 		h.log.Info("polling job disabled by config", "config", pollConfig)
 
 		return nil


### PR DESCRIPTION
This pull request makes a minor adjustment to the polling logic in `handler_poll.go`. Now, the polling job will only be disabled if the interval is zero and the `RunOnce` flag is not set, allowing for initial polling jobs even when the interval is zero.

- Polling Logic Update:
  * Modified the condition in `StartPoll` to ensure that polling jobs with `RunOnce` enabled are not disabled when the interval is zero. (`cmd/doco-cd/handler_poll.go`)