### PR TITLE
fix: don't attempt to decrypt symlinks

### DIFF
--- a/internal/encryption/decrypt.go
+++ b/internal/encryption/decrypt.go
@@ -75,6 +75,11 @@ func DecryptFilesInDirectory(dirPath string) ([]string, error) {
 			return nil
 		}
 
+		fileInfo, err := os.Lstat(path)
+		if fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+				return nil
+		}
+
 		isEncrypted, err := IsEncryptedFile(path)
 		if err != nil {
 			return fmt.Errorf("failed to check if file is encrypted: %w", err)


### PR DESCRIPTION
Resolves https://github.com/kimdre/doco-cd/issues/799

When doco-cd is walking the working directory to look for secrets, it correctly [skips directories](https://github.com/kimdre/doco-cd/blob/db2f20ca38f194cf4580f5f6dcdf00e8a7a59427/internal/encryption/decrypt.go#L74-L76), as a directory cannot be encrypted/decrypted. However, it does not currently skip symlinks, which also cannot be encrypted/decrypted.

This PR adds logic to look for the ModeSymlink flag on files, so that we can properly skip them.

**Important note on behavior here:** `filepath.WalkDir` **does not follow symlinks.** This means that, while this PR allows the symlink to exist rather than erroring out as seen in the linked issue, it will not decrypt any secrets found on the other side of the symlink.

I believe this is still an improvement over the current behavior but we may want to add a note in the documents explaining this behavior.