### PR TITLE
fix(deployment): implement detection and handling of infinite redeployment loops

### DIFF
--- a/cmd/doco-cd/deploy.go
+++ b/cmd/doco-cd/deploy.go
@@ -2,23 +2,25 @@ package main
 
 import "sync"
 
-const maxDeploymentLoopCount = 3 // Maximum allowed deployment loops before taking action.
-
 // deploymentLoopTracker keeps track of deployment loops for different stacks.
 var deploymentLoopTracker = struct {
 	sync.Mutex
 	loops map[string]struct {
 		lastCommit string
-		count      int
+		count      uint
 	}
 }{loops: make(map[string]struct {
 	lastCommit string
-	count      int
+	count      uint
 })}
 
 // shouldForceDeploy checks if a deployment loop is detected for the given stackName
 // based on the latestCommit. It returns true if the deployment should be forced.
-func shouldForceDeploy(stackName, latestCommit string) bool {
+func shouldForceDeploy(stackName, latestCommit string, maxDeploymentLoopCount uint) bool {
+	if maxDeploymentLoopCount == 0 {
+		return false
+	}
+
 	deploymentLoopTracker.Lock()
 	defer deploymentLoopTracker.Unlock()
 

--- a/cmd/doco-cd/deploy_test.go
+++ b/cmd/doco-cd/deploy_test.go
@@ -35,12 +35,12 @@ func TestShouldForceDeploy(t *testing.T) {
 			deploymentLoopTracker.Lock()
 			deploymentLoopTracker.loops = make(map[string]struct {
 				lastCommit string
-				count      int
+				count      uint
 			})
 			deploymentLoopTracker.Unlock()
 
 			for i, commit := range tt.commits {
-				result := shouldForceDeploy(tt.stackName, commit)
+				result := shouldForceDeploy(tt.stackName, commit, 3)
 				if result != tt.expected[i] {
 					t.Errorf("shouldForceDeploy(%s, %s) = %v; want %v", tt.stackName, commit, result, tt.expected[i])
 				}

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -564,7 +564,7 @@ func RunPoll(ctx context.Context, pollConfig config.PollConfig, appConfig *confi
 				WebURL:    string(pollConfig.CloneUrl),
 			}
 
-			forceDeploy := shouldForceDeploy(deployConfig.Name, latestCommit)
+			forceDeploy := shouldForceDeploy(deployConfig.Name, latestCommit, appConfig.MaxDeploymentLoopCount)
 			if forceDeploy {
 				subJobLog.Warn("deployment loop detected for stack, forcing deployment",
 					slog.String("stack", deployConfig.Name),

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -497,7 +497,7 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 					slog.String("deployed_commit", deployedCommit))
 			}
 
-			forceDeploy := shouldForceDeploy(deployConfig.Name, latestCommit)
+			forceDeploy := shouldForceDeploy(deployConfig.Name, latestCommit, appConfig.MaxDeploymentLoopCount)
 			if forceDeploy {
 				subJobLog.Warn("deployment loop detected for stack, forcing deployment",
 					slog.String("stack", deployConfig.Name),

--- a/internal/config/app_config.go
+++ b/internal/config/app_config.go
@@ -16,31 +16,32 @@ const AppName = "doco-cd" // Name of the application
 // AppConfig is used to configure this application
 // https://github.com/caarlos0/env?tab=readme-ov-file#env-tag-options
 type AppConfig struct {
-	LogLevel              string                 `env:"LOG_LEVEL,notEmpty" envDefault:"info"`                          // LogLevel is the log level for the application
-	HttpPort              uint16                 `env:"HTTP_PORT,notEmpty" envDefault:"80" validate:"min=1,max=65535"` // HttpPort is the port the HTTP server will listen on
-	HttpProxyString       string                 `env:"HTTP_PROXY"`                                                    // HttpProxyString is the HTTP proxy URL as a string
-	HttpProxy             transport.ProxyOptions // HttpProxy is the HTTP proxy configuration parsed from the HttpProxyString
-	ApiSecret             string                 `env:"API_SECRET"`                                                         // ApiSecret is the secret token used to authenticate with the API
-	ApiSecretFile         string                 `env:"API_SECRET_FILE,file"`                                               // ApiSecretFile is the file containing the ApiSecret
-	WebhookSecret         string                 `env:"WEBHOOK_SECRET"`                                                     // WebhookSecret is the secret token used to authenticate the webhook
-	WebhookSecretFile     string                 `env:"WEBHOOK_SECRET_FILE,file"`                                           // WebhookSecretFile is the file containing the WebhookSecret
-	GitAccessToken        string                 `env:"GIT_ACCESS_TOKEN"`                                                   // GitAccessToken is the access token used to authenticate with the Git server (e.g. GitHub) for private repositories
-	GitAccessTokenFile    string                 `env:"GIT_ACCESS_TOKEN_FILE,file"`                                         // GitAccessTokenFile is the file containing the GitAccessToken
-	AuthType              string                 `env:"AUTH_TYPE,notEmpty" envDefault:"oauth2"`                             // AuthType is the type of authentication to use when cloning repositories
-	SkipTLSVerification   bool                   `env:"SKIP_TLS_VERIFICATION,notEmpty" envDefault:"false"`                  // SkipTLSVerification skips the TLS verification when cloning repositories.
-	DockerQuietDeploy     bool                   `env:"DOCKER_QUIET_DEPLOY,notEmpty" envDefault:"true"`                     // DockerQuietDeploy suppresses the status output of dockerCli in deployments (e.g. pull, create, start)
-	DockerSwarmFeatures   bool                   `env:"DOCKER_SWARM_FEATURES,notEmpty" envDefault:"true"`                   // DockerSwarmFeatures enables the usage Docker Swarm features in the application if it has detected that it is running in a Docker Swarm environment
-	DeployConfigBaseDir   string                 `env:"DEPLOY_CONFIG_BASE_DIR" envDefault:"/"`                              // DeployConfigBaseDir is the base directory (relative to the repository root) where deployment configuration files will be searched for.
-	PollConfigYAML        string                 `env:"POLL_CONFIG"`                                                        // PollConfigYAML is the unparsed string containing the PollConfig in YAML format
-	PollConfigFile        string                 `env:"POLL_CONFIG_FILE,file"`                                              // PollConfigFile is the file containing the PollConfig in YAML format
-	PollConfig            []PollConfig           `yaml:"-"`                                                                 // PollConfig is the YAML configuration for polling Git repositories for changes
-	MaxPayloadSize        int64                  `env:"MAX_PAYLOAD_SIZE,notEmpty" envDefault:"1048576"`                     // MaxPayloadSize is the maximum size of the payload in bytes that the HTTP server will accept (default 1MB = 1048576 bytes)
-	MetricsPort           uint16                 `env:"METRICS_PORT,notEmpty" envDefault:"9120" validate:"min=1,max=65535"` // MetricsPort is the port the prometheus metrics server will listen on
-	AppriseApiURL         HttpUrl                `env:"APPRISE_API_URL" validate:"httpUrl"`                                 // AppriseApiURL is the URL of the Apprise notification service
-	AppriseNotifyUrls     string                 `env:"APPRISE_NOTIFY_URLS"`                                                // AppriseNotifyUrls is a comma-separated list of URLs to notify via the Apprise notification service
-	AppriseNotifyUrlsFile string                 `env:"APPRISE_NOTIFY_URLS_FILE,file"`                                      // AppriseNotifyUrlsFile is the file containing the AppriseNotifyUrls
-	AppriseNotifyLevel    string                 `env:"APPRISE_NOTIFY_LEVEL,notEmpty" envDefault:"success"`                 // AppriseNotifyLevel is the level of notifications to send via the Apprise notification service
-	SecretProvider        string                 `env:"SECRET_PROVIDER"`                                                    // SecretProvider is the secret provider/manager to use for retrieving secrets (e.g. bitwarden secrets manager)
+	LogLevel               string                 `env:"LOG_LEVEL,notEmpty" envDefault:"info"`                          // LogLevel is the log level for the application
+	HttpPort               uint16                 `env:"HTTP_PORT,notEmpty" envDefault:"80" validate:"min=1,max=65535"` // HttpPort is the port the HTTP server will listen on
+	HttpProxyString        string                 `env:"HTTP_PROXY"`                                                    // HttpProxyString is the HTTP proxy URL as a string
+	HttpProxy              transport.ProxyOptions // HttpProxy is the HTTP proxy configuration parsed from the HttpProxyString
+	ApiSecret              string                 `env:"API_SECRET"`                                                         // ApiSecret is the secret token used to authenticate with the API
+	ApiSecretFile          string                 `env:"API_SECRET_FILE,file"`                                               // ApiSecretFile is the file containing the ApiSecret
+	WebhookSecret          string                 `env:"WEBHOOK_SECRET"`                                                     // WebhookSecret is the secret token used to authenticate the webhook
+	WebhookSecretFile      string                 `env:"WEBHOOK_SECRET_FILE,file"`                                           // WebhookSecretFile is the file containing the WebhookSecret
+	GitAccessToken         string                 `env:"GIT_ACCESS_TOKEN"`                                                   // GitAccessToken is the access token used to authenticate with the Git server (e.g. GitHub) for private repositories
+	GitAccessTokenFile     string                 `env:"GIT_ACCESS_TOKEN_FILE,file"`                                         // GitAccessTokenFile is the file containing the GitAccessToken
+	AuthType               string                 `env:"AUTH_TYPE,notEmpty" envDefault:"oauth2"`                             // AuthType is the type of authentication to use when cloning repositories
+	SkipTLSVerification    bool                   `env:"SKIP_TLS_VERIFICATION,notEmpty" envDefault:"false"`                  // SkipTLSVerification skips the TLS verification when cloning repositories.
+	DockerQuietDeploy      bool                   `env:"DOCKER_QUIET_DEPLOY,notEmpty" envDefault:"true"`                     // DockerQuietDeploy suppresses the status output of dockerCli in deployments (e.g. pull, create, start)
+	DockerSwarmFeatures    bool                   `env:"DOCKER_SWARM_FEATURES,notEmpty" envDefault:"true"`                   // DockerSwarmFeatures enables the usage Docker Swarm features in the application if it has detected that it is running in a Docker Swarm environment
+	DeployConfigBaseDir    string                 `env:"DEPLOY_CONFIG_BASE_DIR" envDefault:"/"`                              // DeployConfigBaseDir is the base directory (relative to the repository root) where deployment configuration files will be searched for.
+	PollConfigYAML         string                 `env:"POLL_CONFIG"`                                                        // PollConfigYAML is the unparsed string containing the PollConfig in YAML format
+	PollConfigFile         string                 `env:"POLL_CONFIG_FILE,file"`                                              // PollConfigFile is the file containing the PollConfig in YAML format
+	PollConfig             []PollConfig           `yaml:"-"`                                                                 // PollConfig is the YAML configuration for polling Git repositories for changes
+	MaxPayloadSize         int64                  `env:"MAX_PAYLOAD_SIZE,notEmpty" envDefault:"1048576"`                     // MaxPayloadSize is the maximum size of the payload in bytes that the HTTP server will accept (default 1MB = 1048576 bytes)
+	MetricsPort            uint16                 `env:"METRICS_PORT,notEmpty" envDefault:"9120" validate:"min=1,max=65535"` // MetricsPort is the port the prometheus metrics server will listen on
+	AppriseApiURL          HttpUrl                `env:"APPRISE_API_URL" validate:"httpUrl"`                                 // AppriseApiURL is the URL of the Apprise notification service
+	AppriseNotifyUrls      string                 `env:"APPRISE_NOTIFY_URLS"`                                                // AppriseNotifyUrls is a comma-separated list of URLs to notify via the Apprise notification service
+	AppriseNotifyUrlsFile  string                 `env:"APPRISE_NOTIFY_URLS_FILE,file"`                                      // AppriseNotifyUrlsFile is the file containing the AppriseNotifyUrls
+	AppriseNotifyLevel     string                 `env:"APPRISE_NOTIFY_LEVEL,notEmpty" envDefault:"success"`                 // AppriseNotifyLevel is the level of notifications to send via the Apprise notification service
+	SecretProvider         string                 `env:"SECRET_PROVIDER"`                                                    // SecretProvider is the secret provider/manager to use for retrieving secrets (e.g. bitwarden secrets manager)
+	MaxDeploymentLoopCount uint                   `env:"MAX_DEPLOYMENT_LOOP_COUNT,notEmpty" envDefault:"3" validate:"min=0"` // Maximum allowed deployment loops before force deploy
 }
 
 // GetAppConfig returns the configuration.


### PR DESCRIPTION
When a deployConfig triggers consecutive deployments for a repository with the same commit sha, the `forceDeploy` flag will now be set to true to make Docker do a forced stack/project deployment.
Use the new appConfig setting `MAX_DEPLOYMENT_LOOP_COUNT` (default: `3`) to set, when the detection should set the `forceDeploy`. Set the option to `0`, to disable the detection logic and never set `forceDeploy`.