### PR TITLE
feat: respect .gitignore when decrypting files

### DIFF
--- a/internal/encryption/config.go
+++ b/internal/encryption/config.go
@@ -9,7 +9,12 @@ import (
 func SopsKeyIsSet() bool {
 	for _, env := range os.Environ() {
 		if strings.HasPrefix(env, "SOPS_") {
-			return true
+			// Check if the SOPS env var has a value
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 && strings.TrimSpace(parts[1]) != "" {
+				// SOPS env var is set and has a value
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
Cool project 🙏 

I think doco should respect .gitignore. I had a service container that created a symlink in a volume (which is .gitignored) which broke as it led outside the repository and doco tried to decrypt it.