### PR TITLE
refactor(docker): improve verification for Docker API access

### DIFF
--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -78,6 +78,11 @@ func registerHttpEndpoints(c *config.AppConfig, h *handlerData, log *logger.Logg
 
 // HealthCheckHandler handles health check requests.
 func (h *handlerData) HealthCheckHandler(w http.ResponseWriter, _ *http.Request) {
+	var (
+		err     error
+		errType error
+	)
+
 	jobID := uuid.Must(uuid.NewV7()).String()
 
 	metadata := notification.Metadata{
@@ -87,9 +92,9 @@ func (h *handlerData) HealthCheckHandler(w http.ResponseWriter, _ *http.Request)
 		Revision:   "",
 	}
 
-	err := docker.VerifySocketConnection()
+	err, errType = docker.VerifyDockerAPIAccess()
 	if err != nil {
-		onError(w, h.log.With(logger.ErrAttr(err)), docker.ErrDockerSocketConnectionFailed.Error(), err.Error(), http.StatusServiceUnavailable, metadata)
+		onError(w, h.log.With(logger.ErrAttr(err)), errType.Error(), err.Error(), http.StatusServiceUnavailable, metadata)
 
 		return
 	}

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -124,9 +124,9 @@ func main() {
 	}
 
 	// Test/verify the connection to the docker socket
-	err = docker.VerifySocketConnection()
+	err, errType := docker.VerifyDockerAPIAccess()
 	if err != nil {
-		log.Critical(docker.ErrDockerSocketConnectionFailed.Error(), logger.ErrAttr(err))
+		log.Critical(errType.Error(), logger.ErrAttr(err))
 	}
 
 	log.Debug("connection to docker socket was successful")

--- a/internal/docker/verify.go
+++ b/internal/docker/verify.go
@@ -1,0 +1,151 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+)
+
+var (
+	ErrDockerSocketConnectionFailed = errors.New("failed to connect to docker socket")
+	ErrDockerHostConnectionFailed   = errors.New("failed to connect to docker host")
+)
+
+// ConnectToSocket connects to the docker socket.
+func ConnectToSocket() (net.Conn, error) {
+	c, err := net.Dial("unix", SocketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func NewHttpClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", SocketPath)
+			},
+		},
+	}
+}
+
+// VerifySocketRead verifies whether the application can read from the docker socket.
+func VerifySocketRead(httpClient *http.Client) error {
+	reqBody, err := json.Marshal("")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("GET", "http://localhost/info", bytes.NewReader(reqBody))
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer resp.Body.Close() //nolint:errcheck
+
+	responseBody, _ := io.ReadAll(resp.Body)
+
+	// Check for a successful response
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to get containers: %s", responseBody)
+	}
+
+	return nil
+}
+
+// VerifySocketConnection verifies whether the application can connect to the docker socket.
+func VerifySocketConnection() error {
+	// Check if the docker socket file exists
+	if _, err := os.Stat(SocketPath); errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	c, err := ConnectToSocket()
+	if err != nil {
+		return err
+	}
+
+	httpClient := NewHttpClient()
+	defer httpClient.CloseIdleConnections()
+
+	err = VerifySocketRead(httpClient)
+	if err != nil {
+		return err
+	}
+
+	err = c.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// VerifyDockerHostConnection verifies the connection to the specified DOCKER_HOST.
+func VerifyDockerHostConnection(dockerHost string) error {
+	var (
+		httpClient *http.Client
+		url        string
+	)
+
+	switch {
+	case strings.HasPrefix(dockerHost, "unix://"):
+		socket := strings.TrimPrefix(dockerHost, "unix://")
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+					return net.Dial("unix", socket)
+				},
+			},
+		}
+		url = "http://localhost/info"
+	case strings.HasPrefix(dockerHost, "tcp://"):
+		addr := strings.TrimPrefix(dockerHost, "tcp://")
+		httpClient = &http.Client{}
+		url = fmt.Sprintf("http://%s/info", addr)
+	default:
+		return fmt.Errorf("unsupported DOCKER_HOST scheme: %s", dockerHost)
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to docker host: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("failed to get info: %s", body)
+	}
+
+	return nil
+}
+
+// VerifyDockerAPIAccess verifies access to the Docker API either via DOCKER_HOST or the default socket.
+func VerifyDockerAPIAccess() (error, error) {
+	dockerHost := os.Getenv("DOCKER_HOST")
+	if dockerHost != "" {
+		return VerifyDockerHostConnection(dockerHost), ErrDockerHostConnectionFailed
+	}
+
+	return VerifySocketConnection(), ErrDockerSocketConnectionFailed
+}


### PR DESCRIPTION
The verification now handles `DOCKER_HOST` correctly and does not require a docker socket bind mount anymore if this variable is set.