### PR TITLE
feat(swarm): add resource readiness checks before deploying services

### DIFF
--- a/internal/docker/swarm/deploy_composefile.go
+++ b/internal/docker/swarm/deploy_composefile.go
@@ -71,6 +71,11 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, opts *options.Dep
 		return err
 	}
 
+	// Wait for all resources to be ready before deploying services
+	if err = waitForResources(ctx, dockerCli.Client(), networks, secrets, configs); err != nil {
+		return err
+	}
+
 	services, err := convert.Services(ctx, namespace, config, dockerCli.Client())
 	if err != nil {
 		return err


### PR DESCRIPTION
When deploying a swarm stack all resources get created async which can cause the services to be ready before the networks, configs and secrets they depend on.
A new function now makes sure that these are available before the services.