### PR TITLE
fix(compose): skip missing files in extends/include extraction

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -793,6 +793,12 @@ func getExtendsFilesFromYaml(composeFiles []string, workingDir string) ([]string
 
 		b, err := os.ReadFile(f)
 		if err != nil {
+			// The file list may contain candidate names that don't exist
+			// on disk (e.g., docker-compose.yml instead of compose.yml).
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+
 			return nil, err
 		}
 
@@ -919,6 +925,12 @@ func getIncludeFilesFromYaml(composeFiles []string, workingDir string) ([]string
 
 		b, err := os.ReadFile(f)
 		if err != nil {
+			// The file list may contain candidate names that don't exist
+			// on disk (e.g., docker-compose.yml instead of compose.yml).
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+
 			return nil, err
 		}
 

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -1146,6 +1146,20 @@ services:
 			composeFiles:  []string{"compose.yaml"},
 			expectedFiles: []string{},
 		},
+		{
+			name: "Non-existent compose file is skipped",
+			files: map[string]string{
+				"compose.yaml": `
+services:
+  app:
+    extends:
+      file: base.yml
+      service: base
+`,
+			},
+			composeFiles:  []string{"nonexistent.yaml", "compose.yaml"},
+			expectedFiles: []string{"base.yml"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The file list may contain candidate names that don't exist on disk (e.g., `docker-compose.yml` instead of `compose.yml`). Skip these instead of returning an error.

Fixes: #1079