### PR TITLE
feat(api): add api endpoint to trigger repository polling on demand

### DIFF
--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -45,6 +47,7 @@ func registerApiEndpoints(c *config.AppConfig, h *handlerData, log *logger.Logge
 			{apiPath + "/stacks", h.GetStacksApiHandler},
 			{apiPath + "/stack/{stackName}", h.StackApiHandler},
 			{apiPath + "/stack/{stackName}/{action}", h.StackActionApiHandler},
+			{apiPath + "/poll/run", h.TriggerPollHandler},
 		}
 
 		for _, ep := range endpoints {
@@ -676,4 +679,97 @@ func (h *handlerData) GetStacksApiHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	JSONResponse(w, stacks, jobID, http.StatusOK)
+}
+
+// TriggerPollHandler handles API requests to trigger a poll of the configured repositories.
+// This can be used to manually trigger a poll outside the planned intervals,
+// for example after a failed deployment or to check for new commits after a network outage.
+func (h *handlerData) TriggerPollHandler(w http.ResponseWriter, r *http.Request) {
+	var err error
+
+	// Add a job id to the context to track deployments in the logs
+	jobID := uuid.Must(uuid.NewV7()).String()
+	jobLog := h.log.With(slog.String("job_id", jobID), slog.String("ip", r.RemoteAddr))
+
+	jobLog.Debug("received api request")
+
+	if !requireMethod(w, jobLog, r, http.MethodPost) {
+		return
+	}
+
+	if !restAPI.ValidateApiKey(r, h.appConfig.ApiSecret) {
+		jobLog.Error(restAPI.ErrInvalidApiKey.Error())
+		JSONError(w, restAPI.ErrInvalidApiKey.Error(), "", jobID, http.StatusUnauthorized)
+
+		return
+	}
+
+	wait := getQueryParam(r, w, jobLog, jobID, "wait", "bool", true).(bool)
+
+	decoder := json.NewDecoder(r.Body)
+
+	var pollConfigs []config.PollConfig
+	if err := decoder.Decode(&pollConfigs); err != nil {
+		h.log.Error(err.Error())
+		JSONError(w, err.Error(), "", "", http.StatusBadRequest)
+	}
+
+	if len(pollConfigs) > 0 {
+		h.log.Info(
+			"poll triggered via API, starting jobs",
+			slog.Any("poll_config", logger.BuildSliceLogValue(pollConfigs, "Deployments.Internal")),
+		)
+
+		var wg sync.WaitGroup
+
+		if wait {
+			for _, p := range pollConfigs {
+				p.RunOnce = true
+
+				pollJob := &config.PollJob{
+					Config:  p,
+					LastRun: 0,
+					NextRun: 0,
+				}
+
+				h.log.Debug("Starting poll handler", "config", p)
+				wg.Add(1)
+
+				go func() {
+					defer wg.Done()
+
+					h.PollHandler(pollJob)
+					h.log.Debug("PollJob handler stopped", "config", p)
+				}()
+			}
+
+			wg.Wait()
+		} else {
+			for _, p := range pollConfigs {
+				p.RunOnce = true
+
+				pollJob := &config.PollJob{
+					Config:  p,
+					LastRun: 0,
+					NextRun: 0,
+				}
+
+				h.log.Debug("Starting poll handler", "config", p)
+				wg.Add(1)
+
+				go func() {
+					defer wg.Done()
+
+					h.PollHandler(pollJob)
+					h.log.Debug("PollJob handler stopped", "config", p)
+				}()
+			}
+		}
+
+		JSONResponse(w, "poll jobs complete", jobID, http.StatusOK)
+	} else {
+		err = errors.New("no poll configuration provided in request body")
+		jobLog.Error(err.Error())
+		JSONError(w, err.Error(), "", jobID, http.StatusBadRequest)
+	}
 }

--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -708,6 +708,7 @@ func (h *handlerData) TriggerPollHandler(w http.ResponseWriter, r *http.Request)
 	wait := getQueryParam(r, w, jobLog, jobID, "wait", "bool", true).(bool)
 
 	decoder := json.NewDecoder(r.Body)
+	defer r.Body.Close()
 
 	var pollConfigs []config.PollConfig
 	if err := decoder.Decode(&pollConfigs); err != nil {
@@ -718,16 +719,31 @@ func (h *handlerData) TriggerPollHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Set default values for api-called poll jobs
+	for i, p := range pollConfigs {
+		p.RunOnce = true
+		p.Interval = 0
+
+		err = p.Validate()
+		if err != nil {
+			errMsg = fmt.Sprintf("invalid poll configuration at index %d", i)
+			h.log.Error(errMsg, logger.ErrAttr(err))
+			JSONError(w, errMsg, err.Error(), jobID, http.StatusBadRequest)
+
+			return
+		}
+
+		pollConfigs[i] = p
+	}
+
 	if len(pollConfigs) > 0 {
-		h.log.Info(
-			"poll triggered via API, starting jobs",
-			slog.Any("poll_config", logger.BuildSliceLogValue(pollConfigs, "Deployments.Internal")),
-		)
+		h.log.Info("poll triggered via API")
 
 		var wg sync.WaitGroup
 
 		for _, p := range pollConfigs {
 			p.RunOnce = true
+			p.Interval = 0
 
 			pollJob := &config.PollJob{
 				Config:  p,

--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -710,8 +711,11 @@ func (h *handlerData) TriggerPollHandler(w http.ResponseWriter, r *http.Request)
 
 	var pollConfigs []config.PollConfig
 	if err := decoder.Decode(&pollConfigs); err != nil {
-		h.log.Error(err.Error())
-		JSONError(w, err.Error(), "", "", http.StatusBadRequest)
+		errMsg = "failed to decode json in body"
+		h.log.Error(errMsg, logger.ErrAttr(err))
+		JSONError(w, errMsg, err.Error(), jobID, http.StatusBadRequest)
+
+		return
 	}
 
 	if len(pollConfigs) > 0 {
@@ -722,54 +726,39 @@ func (h *handlerData) TriggerPollHandler(w http.ResponseWriter, r *http.Request)
 
 		var wg sync.WaitGroup
 
-		if wait {
-			for _, p := range pollConfigs {
-				p.RunOnce = true
+		for _, p := range pollConfigs {
+			p.RunOnce = true
 
-				pollJob := &config.PollJob{
-					Config:  p,
-					LastRun: 0,
-					NextRun: 0,
-				}
-
-				h.log.Debug("Starting poll handler", "config", p)
-				wg.Add(1)
-
-				go func() {
-					defer wg.Done()
-
-					h.PollHandler(pollJob)
-					h.log.Debug("PollJob handler stopped", "config", p)
-				}()
+			pollJob := &config.PollJob{
+				Config:  p,
+				LastRun: 0,
+				NextRun: 0,
 			}
 
-			wg.Wait()
-		} else {
-			for _, p := range pollConfigs {
-				p.RunOnce = true
+			h.log.Debug("Starting poll handler", "config", p)
 
-				pollJob := &config.PollJob{
-					Config:  p,
-					LastRun: 0,
-					NextRun: 0,
-				}
+			wg.Add(1)
 
-				h.log.Debug("Starting poll handler", "config", p)
-				wg.Add(1)
+			go func(ctx context.Context) {
+				defer wg.Done()
 
-				go func() {
-					defer wg.Done()
-
-					h.PollHandler(pollJob)
-					h.log.Debug("PollJob handler stopped", "config", p)
-				}()
-			}
+				h.PollHandler(ctx, pollJob)
+			}(r.Context())
 		}
 
-		JSONResponse(w, "poll jobs complete", jobID, http.StatusOK)
-	} else {
-		err = errors.New("no poll configuration provided in request body")
-		jobLog.Error(err.Error())
-		JSONError(w, err.Error(), "", jobID, http.StatusBadRequest)
+		if wait {
+			wg.Wait()
+			JSONResponse(w, "poll jobs complete", jobID, http.StatusOK)
+
+			return
+		}
+
+		JSONResponse(w, "poll jobs started", jobID, http.StatusAccepted)
+
+		return
 	}
+
+	err = errors.New("no poll configuration provided in request body")
+	jobLog.Error(err.Error())
+	JSONError(w, err.Error(), "", jobID, http.StatusBadRequest)
 }

--- a/cmd/doco-cd/handler_api_test.go
+++ b/cmd/doco-cd/handler_api_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 
@@ -179,6 +181,137 @@ func TestHandlerData_ProjectApiHandler(t *testing.T) {
 
 			if status := rr.Code; status != tc.expectedStatus {
 				t.Errorf("handler returned wrong status code: got %v want %v", status, tc.expectedStatus)
+			}
+		})
+	}
+}
+
+func TestHandlerData_TriggerPollHandler(t *testing.T) {
+	// This is a placeholder test to ensure the TriggerPollHandler is registered and responds to requests.
+	// Implementing a full test would require setting up a mock PollManager and verifying it receives the trigger call.
+	testCases := []struct {
+		name             string
+		payload          *strings.Reader
+		wait             bool
+		expectedStatus   int
+		expectedResponse string
+	}{
+		{
+			name:             "With wait",
+			payload:          strings.NewReader(`[{"url": "https://github.com/kimdre/doco-cd_tests.git", "reference": "main"}]`),
+			wait:             true,
+			expectedStatus:   http.StatusOK,
+			expectedResponse: `{"content":"poll jobs complete","job_id":"[a-f0-9-]{36}"}`,
+		},
+		{
+			name:             "Without wait",
+			payload:          strings.NewReader(`[{"url": "https://github.com/kimdre/doco-cd_tests.git", "reference": "main"}]`),
+			wait:             false,
+			expectedStatus:   http.StatusOK,
+			expectedResponse: `{"content":"poll jobs complete","job_id":"[a-f0-9-]{36}"}`,
+		},
+		{
+			name:             "With deploy config",
+			payload:          strings.NewReader(`[{"url": "https://github.com/kimdre/doco-cd_tests.git", "reference": "main", "deployments": [{"name": "with-deploy-config"}]}]`),
+			wait:             true,
+			expectedStatus:   http.StatusOK,
+			expectedResponse: `{"content":"poll jobs complete","job_id":"[a-f0-9-]{36}"}`,
+		},
+		{
+			name:             "Empty body",
+			payload:          strings.NewReader(``),
+			wait:             false,
+			expectedStatus:   http.StatusBadRequest,
+			expectedResponse: `{"error":"failed to decode json in body","content":"EOF","job_id":"[a-f0-9-]{36}"}`,
+		},
+		{
+			name:             "Invalid JSON",
+			payload:          strings.NewReader(`[{"url": "https://github.com/kimdre/doco-cd_tests.git", "reference": "main"]`),
+			wait:             false,
+			expectedStatus:   http.StatusBadRequest,
+			expectedResponse: `{"error":"failed to decode json in body","content":"invalid character ']' after object key:value pair","job_id":"[a-f0-9-]{36}"}`,
+		},
+	}
+
+	appConfig, err := config.GetAppConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dockerCli, err := docker.CreateDockerCli(appConfig.DockerQuietDeploy, !appConfig.SkipTLSVerification)
+	if err != nil {
+		t.Fatalf("Failed to create docker client: %v", err)
+	}
+
+	backend, err := compose.NewComposeService(dockerCli)
+	if err != nil {
+		t.Fatalf("Failed to create compose service: %v", err)
+	}
+
+	t.Cleanup(func() {
+		err = dockerCli.Client().Close()
+		if err != nil {
+			return
+		}
+	})
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := handlerData{
+				dockerCli:  dockerCli,
+				appConfig:  appConfig,
+				appVersion: config.AppVersion,
+				log:        logger.New(logger.LevelCritical),
+				testName:   test.ConvertTestName(t.Name()),
+			}
+
+			endpoint := path.Join(apiPath, "/poll/run")
+
+			rr := httptest.NewRecorder()
+
+			mux := http.NewServeMux()
+			mux.HandleFunc(endpoint, h.TriggerPollHandler)
+
+			reqUrl := endpoint
+			if tc.wait {
+				reqUrl += "?wait=true"
+			}
+
+			req, err := http.NewRequest("POST", reqUrl, tc.payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Cleanup(func() {
+				downOpts := api.DownOptions{
+					RemoveOrphans: true,
+					Images:        "local",
+					Volumes:       true,
+				}
+
+				err = backend.Down(context.Background(), test.ConvertTestName(t.Name()), downOpts)
+				if err != nil {
+					t.Fatalf("Failed to remove test stack: %v", err)
+				}
+			})
+
+			// Set headers
+			req.Header.Set(restAPI.KeyHeader, appConfig.ApiSecret)
+			mux.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tc.expectedStatus {
+				t.Errorf("handler returned wrong status code: got %v want %v", status, tc.expectedStatus)
+			}
+
+			regex, err := regexp.Compile(tc.expectedResponse)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !regex.MatchString(rr.Body.String()) {
+				t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), tc.expectedResponse)
 			}
 		})
 	}

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -53,7 +53,7 @@ func StartPoll(h *handlerData, pollConfig config.PollConfig, wg *sync.WaitGroup)
 	go func() {
 		defer wg.Done()
 
-		h.PollHandler(pollJob)
+		h.PollHandler(context.Background(), pollJob)
 		h.log.Debug("PollJob handler stopped", "config", pollConfig)
 	}()
 
@@ -61,7 +61,7 @@ func StartPoll(h *handlerData, pollConfig config.PollConfig, wg *sync.WaitGroup)
 }
 
 // PollHandler is a function that handles polling for changes in a repository.
-func (h *handlerData) PollHandler(pollJob *config.PollJob) {
+func (h *handlerData) PollHandler(ctx context.Context, pollJob *config.PollJob) {
 	repoName := git.GetRepoName(string(pollJob.Config.CloneUrl))
 
 	logger := h.log.With(slog.String("repository", repoName))
@@ -88,7 +88,7 @@ func (h *handlerData) PollHandler(pollJob *config.PollJob) {
 
 				logger.Debug("start poll job")
 
-				_ = RunPoll(context.Background(), pollJob.Config, h.appConfig, h.dataMountPoint, h.dockerCli, h.dockerClient, logger, metadata, h.secretProvider)
+				_ = RunPoll(ctx, pollJob.Config, h.appConfig, h.dataMountPoint, h.dockerCli, h.dockerClient, logger, metadata, h.secretProvider)
 
 				lock.Unlock()
 			}
@@ -100,7 +100,7 @@ func (h *handlerData) PollHandler(pollJob *config.PollJob) {
 
 		// If run_once is set, perform a single run and exit after the initial run.
 		if pollJob.Config.RunOnce {
-			logger.Info("RunOnce configured: single initial poll completed, stopped polling", slog.Any("config", pollJob.Config))
+			logger.Debug("run_once is set, exiting poll handler after run")
 			return
 		}
 

--- a/cmd/doco-cd/handler_poll_test.go
+++ b/cmd/doco-cd/handler_poll_test.go
@@ -83,7 +83,7 @@ func TestRunPoll(t *testing.T) {
 
 	downOpts := api.DownOptions{
 		RemoveOrphans: true,
-		Images:        "all",
+		Images:        "local",
 		Volumes:       true,
 	}
 

--- a/cmd/doco-cd/handler_webhook_test.go
+++ b/cmd/doco-cd/handler_webhook_test.go
@@ -164,7 +164,7 @@ func TestHandlerData_WebhookHandler(t *testing.T) {
 
 	downOpts := api.DownOptions{
 		RemoveOrphans: true,
-		Images:        "all",
+		Images:        "local",
 		Volumes:       true,
 	}
 

--- a/cmd/doco-cd/main_test.go
+++ b/cmd/doco-cd/main_test.go
@@ -292,7 +292,7 @@ func TestHandleEvent(t *testing.T) {
 
 				downOpts := api.DownOptions{
 					RemoveOrphans: true,
-					Images:        "all",
+					Images:        "local",
 					Volumes:       true,
 				}
 

--- a/cmd/doco-cd/testdata/bruno/Delete Stack by Name.bru
+++ b/cmd/doco-cd/testdata/bruno/Delete Stack by Name.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Delete Stack by Name
+  type: http
+  seq: 5
+}
+
+delete {
+  url: http://localhost/v1/api/stack/test-deploy
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/cmd/doco-cd/testdata/bruno/List Stack by Name.bru
+++ b/cmd/doco-cd/testdata/bruno/List Stack by Name.bru
@@ -1,0 +1,16 @@
+meta {
+  name: List Stack by Name
+  type: http
+  seq: 4
+}
+
+get {
+  url: http://localhost/v1/api/stack/test-deploy
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/cmd/doco-cd/testdata/bruno/List all Stacks.bru
+++ b/cmd/doco-cd/testdata/bruno/List all Stacks.bru
@@ -1,0 +1,16 @@
+meta {
+  name: List all Stacks
+  type: http
+  seq: 3
+}
+
+get {
+  url: http://localhost/v1/api/stacks
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/cmd/doco-cd/testdata/bruno/Manual Poll Trigger.bru
+++ b/cmd/doco-cd/testdata/bruno/Manual Poll Trigger.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Manual Poll Trigger
+  type: http
+  seq: 7
+}
+
+post {
+  url: http://localhost/v1/api/poll/run?wait=true
+  body: json
+  auth: inherit
+}
+
+params:query {
+  wait: true
+}
+
+body:json {
+  [
+    {
+      "url": "https://github.com/kimdre/doco-cd_tests.git",
+      "reference": "main",
+      "deployments": [
+        {
+          "name": "poll-test",
+          "env_files": [
+            ".env"
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/cmd/doco-cd/testdata/bruno/Projects.bru
+++ b/cmd/doco-cd/testdata/bruno/Projects.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Projects
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost/v1/api/projects
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/cmd/doco-cd/testdata/bruno/Restart Stack by Name.bru
+++ b/cmd/doco-cd/testdata/bruno/Restart Stack by Name.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Restart Stack by Name
+  type: http
+  seq: 7
+}
+
+post {
+  url: http://localhost/v1/api/stack/test-deploy/restart?service=test
+  body: none
+  auth: inherit
+}
+
+params:query {
+  service: test
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/cmd/doco-cd/testdata/bruno/Scale Stack by Name.bru
+++ b/cmd/doco-cd/testdata/bruno/Scale Stack by Name.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Scale Stack by Name
+  type: http
+  seq: 6
+}
+
+post {
+  url: http://localhost/v1/api/stack/test-deploy/scale?replicas=0
+  body: none
+  auth: inherit
+}
+
+params:query {
+  replicas: 0
+  ~service: test
+  ~wait: true
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/cmd/doco-cd/testdata/bruno/bruno.json
+++ b/cmd/doco-cd/testdata/bruno/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "doco-cd",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/cmd/doco-cd/testdata/bruno/collection.bru
+++ b/cmd/doco-cd/testdata/bruno/collection.bru
@@ -1,0 +1,9 @@
+auth {
+  mode: apikey
+}
+
+auth:apikey {
+  key: x-api-key
+  value: apiPW
+  placement: header
+}

--- a/internal/config/deploy_config.go
+++ b/internal/config/deploy_config.go
@@ -38,37 +38,37 @@ const DefaultReference = "refs/heads/main"
 
 // DeployConfig is the structure of the deployment configuration file.
 type DeployConfig struct {
-	Name               string   `yaml:"name"`                                                                                                         // Name of the docker-compose deployment / stack
-	RepositoryUrl      HttpUrl  `yaml:"repository_url" default:"" validate:"httpUrl"`                                                                 // RepositoryUrl is the http URL of the Git repository to deploy
-	WebhookEventFilter string   `yaml:"webhook_filter" default:""`                                                                                    // WebhookEventFilter is a regular expression to whitelist deployment triggers based on the webhook event payload (e.g., branch like "^refs/heads/main$" or "main", tag like "^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" or "v[0-9]+\.[0-9]+\.[0-9]+")
-	Reference          string   `yaml:"reference" default:""`                                                                                         // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
-	WorkingDirectory   string   `yaml:"working_dir" default:"."`                                                                                      // WorkingDirectory is the working directory for the deployment
-	ComposeFiles       []string `yaml:"compose_files" default:"[\"compose.yaml\", \"compose.yml\", \"docker-compose.yml\", \"docker-compose.yaml\"]"` // ComposeFiles is the list of docker-compose files to use
-	EnvFiles           []string `yaml:"env_files" default:"[\".env\"]"`                                                                               // EnvFiles is the list of dotenv files to use for variable interpolation
-	RemoveOrphans      bool     `yaml:"remove_orphans" default:"true"`                                                                                // RemoveOrphans removes containers for services not defined in the Compose file
-	PruneImages        bool     `yaml:"prune_images" default:"true"`                                                                                  // PruneImages removes images that are no longer used by any service in the deployment or any other running container
-	ForceRecreate      bool     `yaml:"force_recreate" default:"false"`                                                                               // ForceRecreate forces the recreation/redeployment of containers even if the configuration has not changed
-	ForceImagePull     bool     `yaml:"force_image_pull" default:"false"`                                                                             // ForceImagePull always pulls the latest version of the image tags you've specified if a newer version is available
-	Timeout            int      `yaml:"timeout" default:"180"`                                                                                        // Timeout is the time in seconds to wait for the deployment to finish in seconds before timing out
+	Name               string   `yaml:"name" json:"name"`                                                                                                                  // Name of the docker-compose deployment / stack
+	RepositoryUrl      HttpUrl  `yaml:"repository_url" json:"repository_url" default:"" validate:"httpUrl"`                                                                // RepositoryUrl is the http URL of the Git repository to deploy
+	WebhookEventFilter string   `yaml:"webhook_filter" json:"webhook_filter" default:""`                                                                                   // WebhookEventFilter is a regular expression to whitelist deployment triggers based on the webhook event payload (e.g., branch like "^refs/heads/main$" or "main", tag like "^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$" or "v[0-9]+\.[0-9]+\.[0-9]+")
+	Reference          string   `yaml:"reference" json:"reference" default:""`                                                                                             // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
+	WorkingDirectory   string   `yaml:"working_dir" json:"working_dir" default:"."`                                                                                        // WorkingDirectory is the working directory for the deployment
+	ComposeFiles       []string `yaml:"compose_files" json:"compose_files" default:"[\"compose.yaml\", \"compose.yml\", \"docker-compose.yml\", \"docker-compose.yaml\"]"` // ComposeFiles is the list of docker-compose files to use
+	EnvFiles           []string `yaml:"env_files" json:"env_files" default:"[\".env\"]"`                                                                                   // EnvFiles is the list of dotenv files to use for variable interpolation
+	RemoveOrphans      bool     `yaml:"remove_orphans" json:"remove_orphans" default:"true"`                                                                               // RemoveOrphans removes containers for services not defined in the Compose file
+	PruneImages        bool     `yaml:"prune_images" json:"prune_images" default:"true"`                                                                                   // PruneImages removes images that are no longer used by any service in the deployment or any other running container
+	ForceRecreate      bool     `yaml:"force_recreate" json:"force_recreate" default:"false"`                                                                              // ForceRecreate forces the recreation/redeployment of containers even if the configuration has not changed
+	ForceImagePull     bool     `yaml:"force_image_pull" json:"force_image_pull" default:"false"`                                                                          // ForceImagePull always pulls the latest version of the image tags you've specified if a newer version is available
+	Timeout            int      `yaml:"timeout" json:"timeout" default:"180"`                                                                                              // Timeout is the time in seconds to wait for the deployment to finish in seconds before timing out
 	BuildOpts          struct {
-		ForceImagePull bool              `yaml:"force_image_pull" default:"false"` // ForceImagePull always attempt to pull a newer version of the image
-		Quiet          bool              `yaml:"quiet" default:"false"`            // Quiet suppresses the build output
-		Args           map[string]string `yaml:"args"`                             // BuildArgs is a map of build-time arguments to pass to the build process
-		NoCache        bool              `yaml:"no_cache" default:"false"`         // NoCache disables the use of the cache when building images
+		ForceImagePull bool              `yaml:"force_image_pull" json:"force_image_pull" default:"false"` // ForceImagePull always attempt to pull a newer version of the image
+		Quiet          bool              `yaml:"quiet" json:"quiet" default:"false"`                       // Quiet suppresses the build output
+		Args           map[string]string `yaml:"args" json:"args"`                                         // BuildArgs is a map of build-time arguments to pass to the build process
+		NoCache        bool              `yaml:"no_cache" json:"no_cache" default:"false"`                 // NoCache disables the use of the cache when building images
 	} `yaml:"build_opts"` // BuildOpts is the build options for the deployment
-	Destroy     bool `yaml:"destroy" default:"false"` // Destroy removes the deployment and all its resources from the Docker host
+	Destroy     bool `yaml:"destroy" json:"destroy" default:"false"` // Destroy removes the deployment and all its resources from the Docker host
 	DestroyOpts struct {
-		RemoveVolumes bool `yaml:"remove_volumes" default:"true"` // RemoveVolumes removes the volumes used by the deployment (always enabled in docker swarm mode)
-		RemoveImages  bool `yaml:"remove_images" default:"true"`  // RemoveImages removes the images used by the deployment (currently not supported in docker swarm mode)
-		RemoveRepoDir bool `yaml:"remove_dir" default:"true"`     // RemoveRepoDir removes the repository directory after the deployment is destroyed
-	} `yaml:"destroy_opts"` // DestroyOpts is the destroy options for the deployment
-	Profiles         []string          `yaml:"profiles" default:"[]"`         // Profiles is a list of profiles to use for the deployment, e.g., ["dev", "prod"]. See https://docs.docker.com/compose/how-tos/profiles/
-	ExternalSecrets  map[string]string `yaml:"external_secrets"`              // ExternalSecrets maps env vars to secret IDs/keys for injecting secrets from external providers like Bitwarden SM at deployment, e.g. {"DB_PASSWORD": "138e3697-ed58-431c-b866-b3550066343a"}
-	AutoDiscover     bool              `yaml:"auto_discover" default:"false"` // AutoDiscover enables autodiscovery of services to deploy in the working directory by checking for subdirectories with docker-compose files
+		RemoveVolumes bool `yaml:"remove_volumes" json:"remove_volumes" default:"true"` // RemoveVolumes removes the volumes used by the deployment (always enabled in docker swarm mode)
+		RemoveImages  bool `yaml:"remove_images" json:"remove_images" default:"true"`   // RemoveImages removes the images used by the deployment (currently not supported in docker swarm mode)
+		RemoveRepoDir bool `yaml:"remove_dir" json:"remove_dir" default:"true"`         // RemoveRepoDir removes the repository directory after the deployment is destroyed
+	} `yaml:"destroy_opts" json:"destroy_opts"` // DestroyOpts is the destroy options for the deployment
+	Profiles         []string          `yaml:"profiles" json:"profiles" default:"[]"`              // Profiles is a list of profiles to use for the deployment, e.g., ["dev", "prod"]. See https://docs.docker.com/compose/how-tos/profiles/
+	ExternalSecrets  map[string]string `yaml:"external_secrets" json:"external_secrets"`           // ExternalSecrets maps env vars to secret IDs/keys for injecting secrets from external providers like Bitwarden SM at deployment, e.g. {"DB_PASSWORD": "138e3697-ed58-431c-b866-b3550066343a"}
+	AutoDiscover     bool              `yaml:"auto_discover" json:"auto_discover" default:"false"` // AutoDiscover enables autodiscovery of services to deploy in the working directory by checking for subdirectories with docker-compose files
 	AutoDiscoverOpts struct {
-		ScanDepth int  `yaml:"depth" default:"0"`     // ScanDepth is the maximum depth of subdirectories to scan for docker-compose files
-		Delete    bool `yaml:"delete" default:"true"` // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
-	} `yaml:"auto_discover_opts"` // AutoDiscoverOpts are options for the autodiscovery feature
+		ScanDepth int  `yaml:"depth" json:"depth" default:"0"`      // ScanDepth is the maximum depth of subdirectories to scan for docker-compose files
+		Delete    bool `yaml:"delete" json:"delete" default:"true"` // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
+	} `yaml:"auto_discover_opts" json:"auto_discover_opts"` // AutoDiscoverOpts are options for the autodiscovery feature
 	Internal struct {
 		File        string            `yaml:"-"` // File is the path to the deployment configuration file in the repository (if RepositoryUrl is not set) or in the cloned repository (if RepositoryUrl is set)
 		Environment map[string]string // Environment is stores environment variables for variable interpolation in the compose project

--- a/internal/config/poll_config.go
+++ b/internal/config/poll_config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -17,12 +18,12 @@ var (
 )
 
 type PollConfig struct {
-	CloneUrl     HttpUrl         `yaml:"url" validate:"httpUrl"`              // CloneUrl is the URL to clone the Git repository that is used to poll for changes
-	Reference    string          `yaml:"reference" default:"refs/heads/main"` // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
-	Interval     int             `yaml:"interval" default:"180"`              // Interval is the interval in seconds to poll for changes
-	CustomTarget string          `yaml:"target" default:""`                   // CustomTarget is the name of an optional custom deployment config file, e.g. ".doco-cd.custom-name.yaml"
-	RunOnce      bool            `yaml:"run_once" default:"false"`            // RunOnce when true, performs a single run and exits
-	Deployments  []*DeployConfig `yaml:"deployments" default:"[]"`            // Deployments allows defining deployment configs inline in the poll configuration
+	CloneUrl     HttpUrl         `yaml:"url" json:"url" validate:"httpUrl"`                    // CloneUrl is the URL to clone the Git repository that is used to poll for changes
+	Reference    string          `yaml:"reference" json:"reference" default:"refs/heads/main"` // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
+	Interval     int             `yaml:"interval" default:"180"`                               // Interval is the interval in seconds to poll for changes
+	CustomTarget string          `yaml:"target" json:"target" default:""`                      // CustomTarget is the name of an optional custom deployment config file, e.g. ".doco-cd.custom-name.yaml"
+	RunOnce      bool            `yaml:"run_once" default:"false"`                             // RunOnce when true, performs a single run and exits
+	Deployments  []*DeployConfig `yaml:"deployments" json:"deployments" default:"[]"`          // Deployments allows defining deployment configs inline in the poll configuration
 }
 
 type PollJob struct {
@@ -94,6 +95,21 @@ func (c *PollConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type Plain PollConfig
 
 	if err := unmarshal((*Plain)(c)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *PollConfig) UnmarshalJSON(data []byte) error {
+	err := defaults.Set(c)
+	if err != nil {
+		return err
+	}
+
+	type Plain PollConfig
+
+	if err := json.Unmarshal(data, (*Plain)(c)); err != nil {
 		return err
 	}
 

--- a/internal/config/poll_config.go
+++ b/internal/config/poll_config.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/creasty/defaults"
+	"gopkg.in/validator.v2"
 
 	"github.com/kimdre/doco-cd/internal/logger"
 )
@@ -76,6 +77,11 @@ func (c *PollConfig) Validate() error {
 		if err := validateUniqueProjectNames(c.Deployments); err != nil {
 			return err
 		}
+	}
+
+	err := validator.Validate(c)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidPollConfig, err)
 	}
 
 	return nil

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -265,7 +265,7 @@ compose_files:
 
 			downOpts := api.DownOptions{
 				RemoveOrphans: true,
-				Images:        "all",
+				Images:        "local",
 				Volumes:       true,
 			}
 


### PR DESCRIPTION
This PR adds a new API endpoint to manually trigger Poll jobs.

| Endpoint           | Method | Description                                                    | Query Parameters                                                                        |
|--------------------|--------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------|
| `/v1/api/poll/run` | POST   | Trigger a poll run for all polling targets in the body (JSON). | - `wait` (boolean, default: `true`): Wait for the poll run to finish before responding. |

The request body must be a JSON array of [poll configurations](https://github.com/kimdre/doco-cd/wiki/Poll-Settings), each containing at least a `url` field containing the Git clone URL to the repository.

The fields `run_once` and `interval` will be ignored for poll runs triggered via the API, as they are only relevant for the scheduled poll runs.

#### Example Request

Minimal example using the default settings:

```sh
curl --request POST \
  --url 'https://cd.example.com/v1/api/poll/run?wait=true' \
  --header 'content-type: application/json' \
  --header 'x-api-key: your-api-key' \
  --data '[
  {
    "url": "https://github.com/your/repo.git",
  }
]'
```

Example with custom reference and inline deployment configuration:

```sh
curl --request POST \
  --url 'https://cd.example.com/v1/api/poll/run?wait=true' \
  --header 'content-type: application/json' \
  --header 'x-api-key: your-api-key' \
  --data '[
  {
    "url": "https://github.com/your/repo.git",
    "reference": "dev",
    "deployments": [
      {
        "name": "my-app",
        "working_dir": "/app",
        "env_files": [
          ".env"
        ]
      }
    ]
  }
]'
```