### PR TITLE
fix(decryption): prevent path traversal in bind mount directories

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1090,6 +1090,10 @@ func DecryptProjectFiles(repoPath string, p *types.Project) ([]string, error) {
 				if info.IsDir() {
 					decryptedFiles, err = encryption.DecryptFilesInDirectory(repoPath, v.Source)
 					if err != nil {
+						if errors.Is(err, encryption.ErrPathTraversal) {
+							continue
+						}
+
 						return decryptedFiles, fmt.Errorf("failed to decrypt files in bind mount directory '%s': %w", v.Source, err)
 					}
 

--- a/internal/encryption/decrypt.go
+++ b/internal/encryption/decrypt.go
@@ -27,7 +27,10 @@ var IgnoreDirs = []string{
 	"node_modules",
 }
 
-var ErrSopsKeyNotSet = errors.New("SOPS secret key is not set")
+var (
+	ErrSopsKeyNotSet = errors.New("SOPS secret key is not set")
+	ErrPathTraversal = errors.New("path traversal detected")
+)
 
 func GetFileFormat(path string) string {
 	var format string
@@ -63,8 +66,27 @@ func DecryptContent(content []byte, format string) ([]byte, error) {
 	return decrypt.Data(content, format)
 }
 
+// Add a check to ensure files/directories are within the repository root.
+func isWithinRepoRoot(repoPath, targetPath string) bool {
+	absRepoPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return false
+	}
+
+	absTargetPath, err := filepath.Abs(targetPath)
+	if err != nil {
+		return false
+	}
+
+	return strings.HasPrefix(absTargetPath, absRepoPath)
+}
+
 // DecryptFilesInDirectory walks through the specified directory and decrypts all SOPS-encrypted files.
 func DecryptFilesInDirectory(repoPath, dirPath string) ([]string, error) {
+	if !isWithinRepoRoot(repoPath, dirPath) {
+		return nil, fmt.Errorf("%w: %s is outside the repository root %s", ErrPathTraversal, dirPath, repoPath)
+	}
+
 	var decryptedFiles []string
 
 	var ignoreMatcher gitignore.Matcher
@@ -116,6 +138,9 @@ func DecryptFilesInDirectory(repoPath, dirPath string) ([]string, error) {
 
 			// Recursively walk the symlink target
 			_, err = DecryptFilesInDirectory(repoPath, absTarget)
+			if errors.Is(err, ErrPathTraversal) {
+				return nil
+			}
 
 			return err
 		}


### PR DESCRIPTION
`DecryptFilesInDirectory` will now skip any directories during decryption, that are outside of the repository root.
We expect encrypted files only in the cloned repository.