### PR TITLE
fix(swarm): only redeploy services when changed

### DIFF
--- a/internal/docker/swarm.go
+++ b/internal/docker/swarm.go
@@ -80,18 +80,18 @@ func RemoveSwarmStack(ctx context.Context, dockerCli command.Cli, namespace stri
 	return swarmInternal.RunRemove(ctx, dockerCli, opts)
 }
 
-// addSwarmServiceLabels adds custom labels to the service containers in a Docker Swarm stack.
+// addSwarmServiceLabels adds custom labels to services in a Docker Swarm stack.
+// Volatile labels (timestamp, trigger) are placed on service-level deploy labels
+// to avoid altering the task template and triggering unnecessary rolling updates.
 func addSwarmServiceLabels(stack *composetypes.Config, deployConfig *config.DeployConfig, payload *webhook.ParsedPayload,
 	repoDir, appVersion, timestamp, latestCommit, projectHash string,
 ) {
-	customLabels := map[string]string{
+	containerLabels := map[string]string{
 		DocoCDLabels.Metadata.Manager:              config.AppName,
 		DocoCDLabels.Metadata.Version:              appVersion,
 		DocoCDLabels.Deployment.Name:               deployConfig.Name,
-		DocoCDLabels.Deployment.Timestamp:          timestamp,
 		DocoCDLabels.Deployment.ComposeHash:        projectHash,
 		DocoCDLabels.Deployment.WorkingDir:         repoDir,
-		DocoCDLabels.Deployment.Trigger:            payload.CommitSHA,
 		DocoCDLabels.Deployment.CommitSHA:          latestCommit,
 		DocoCDLabels.Deployment.TargetRef:          deployConfig.Reference,
 		DocoCDLabels.Deployment.ConfigHash:         deployConfig.Internal.Hash,
@@ -101,13 +101,26 @@ func addSwarmServiceLabels(stack *composetypes.Config, deployConfig *config.Depl
 		DocoCDLabels.Repository.URL:                payload.WebURL,
 	}
 
+	serviceLabels := map[string]string{
+		DocoCDLabels.Deployment.Timestamp: timestamp,
+		DocoCDLabels.Deployment.Trigger:   payload.CommitSHA,
+	}
+
 	for i, s := range stack.Services {
 		if s.Labels == nil {
 			s.Labels = make(map[string]string)
 		}
 
-		for key, val := range customLabels {
+		for key, val := range containerLabels {
 			s.Labels[key] = val
+		}
+
+		if s.Deploy.Labels == nil {
+			s.Deploy.Labels = make(map[string]string)
+		}
+
+		for key, val := range serviceLabels {
+			s.Deploy.Labels[key] = val
 		}
 
 		stack.Services[i] = s

--- a/internal/docker/swarm_test.go
+++ b/internal/docker/swarm_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v5"
+	composetypes "github.com/docker/cli/cli/compose/types"
 	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/encryption"
@@ -161,5 +162,101 @@ func TestDeploySwarmStack(t *testing.T) {
 		t.Fatalf("Failed to remove swarm stack: %v", err)
 	} else {
 		t.Logf("Swarm stack removed successfully")
+	}
+}
+
+func TestAddSwarmServiceLabels(t *testing.T) {
+	stack := &composetypes.Config{
+		Services: []composetypes.ServiceConfig{
+			{Name: "web", Labels: map[string]string{"user.label": "keep"}},
+			{Name: "db"},
+		},
+	}
+
+	deployConfig := &config.DeployConfig{
+		Name:      "my-stack",
+		Reference: "refs/heads/main",
+	}
+
+	payload := &webhook.ParsedPayload{
+		CommitSHA: "abc123",
+		FullName:  "user/repo",
+		WebURL:    "https://github.com/user/repo",
+	}
+
+	addSwarmServiceLabels(stack, deployConfig, payload, "/work", "1.0.0", "2025-01-01T00:00:00Z", "def456", "hash123")
+
+	for _, s := range stack.Services {
+		// Volatile labels should be in Deploy.Labels only
+		if _, ok := s.Labels[DocoCDLabels.Deployment.Timestamp]; ok {
+			t.Errorf("service %s: timestamp should not be in container labels", s.Name)
+		}
+
+		if _, ok := s.Labels[DocoCDLabels.Deployment.Trigger]; ok {
+			t.Errorf("service %s: trigger should not be in container labels", s.Name)
+		}
+
+		if s.Deploy.Labels[DocoCDLabels.Deployment.Timestamp] != "2025-01-01T00:00:00Z" {
+			t.Errorf("service %s: expected timestamp in deploy labels", s.Name)
+		}
+
+		if s.Deploy.Labels[DocoCDLabels.Deployment.Trigger] != "abc123" {
+			t.Errorf("service %s: expected trigger in deploy labels", s.Name)
+		}
+
+		// Stable labels should be in container labels
+		if s.Labels[DocoCDLabels.Deployment.Name] != "my-stack" {
+			t.Errorf("service %s: expected name in container labels", s.Name)
+		}
+
+		if s.Labels[DocoCDLabels.Deployment.CommitSHA] != "def456" {
+			t.Errorf("service %s: expected commit SHA in container labels", s.Name)
+		}
+	}
+
+	// Existing user labels should be preserved
+	if stack.Services[0].Labels["user.label"] != "keep" {
+		t.Error("existing user label was overwritten")
+	}
+}
+
+func TestSwarmServiceLabelsStability(t *testing.T) {
+	stack := &composetypes.Config{
+		Services: []composetypes.ServiceConfig{
+			{Name: "web"},
+		},
+	}
+
+	deployConfig := &config.DeployConfig{
+		Name:      "my-stack",
+		Reference: "refs/heads/main",
+	}
+
+	payload := &webhook.ParsedPayload{
+		CommitSHA: "abc123",
+		FullName:  "user/repo",
+	}
+
+	addSwarmServiceLabels(stack, deployConfig, payload, "/work", "1.0.0", "2025-01-01T00:00:00Z", "commit1", "hash1")
+
+	// Snapshot container labels after first call
+	firstLabels := make(map[string]string)
+	for k, v := range stack.Services[0].Labels {
+		firstLabels[k] = v
+	}
+
+	// Call again with different timestamp but same commit
+	addSwarmServiceLabels(stack, deployConfig, payload, "/work", "1.0.0", "2025-06-15T12:00:00Z", "commit1", "hash1")
+
+	// Container labels should be identical (timestamp is not in container labels)
+	for k, v := range stack.Services[0].Labels {
+		if firstLabels[k] != v {
+			t.Errorf("container label %s changed: %q -> %q", k, firstLabels[k], v)
+		}
+	}
+
+	// Deploy labels should reflect the new timestamp
+	if stack.Services[0].Deploy.Labels[DocoCDLabels.Deployment.Timestamp] != "2025-06-15T12:00:00Z" {
+		t.Error("deploy timestamp was not updated")
 	}
 }

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -26,6 +26,22 @@ var (
 	ErrContainerIDNotFound    = errors.New("container ID not found")
 )
 
+// mergeSwarmLabels merges service-level labels and container labels from a swarm service.
+// Container labels take precedence on key collisions.
+func mergeSwarmLabels(service swarm.Service) map[string]string {
+	merged := make(map[string]string)
+
+	for k, v := range service.Spec.Labels {
+		merged[k] = v
+	}
+
+	for k, v := range service.Spec.TaskTemplate.ContainerSpec.Labels {
+		merged[k] = v
+	}
+
+	return merged
+}
+
 // GetContainerID retrieves the container ID for a given service name.
 func GetContainerID(apiClient client.APIClient, name string) (id string, err error) {
 	result, err := apiClient.ContainerList(context.TODO(), client.ContainerListOptions{All: true})
@@ -59,7 +75,7 @@ func GetServiceLabels(ctx context.Context, cli *client.Client, stackName string)
 
 		result := make(map[Service]Labels)
 		for _, service := range services {
-			result[Service(service.Spec.Name)] = service.Spec.TaskTemplate.ContainerSpec.Labels
+			result[Service(service.Spec.Name)] = mergeSwarmLabels(service)
 		}
 
 		return result, nil
@@ -101,7 +117,7 @@ func GetLabeledServices(ctx context.Context, cli *client.Client, key, value stri
 
 		result := make(map[Service]map[string]string)
 		for _, service := range services {
-			result[Service(service.Spec.Name)] = service.Spec.TaskTemplate.ContainerSpec.Labels
+			result[Service(service.Spec.Name)] = mergeSwarmLabels(service)
 		}
 
 		return result, nil

--- a/internal/docker/utils_test.go
+++ b/internal/docker/utils_test.go
@@ -1,0 +1,42 @@
+package docker
+
+import (
+	"testing"
+
+	swarmTypes "github.com/moby/moby/api/types/swarm"
+)
+
+func TestMergeSwarmLabels(t *testing.T) {
+	service := swarmTypes.Service{
+		Spec: swarmTypes.ServiceSpec{
+			Annotations: swarmTypes.Annotations{
+				Labels: map[string]string{
+					"service.level": "from-service",
+					"shared.key":    "service-value",
+				},
+			},
+			TaskTemplate: swarmTypes.TaskSpec{
+				ContainerSpec: &swarmTypes.ContainerSpec{
+					Labels: map[string]string{
+						"container.level": "from-container",
+						"shared.key":      "container-value",
+					},
+				},
+			},
+		},
+	}
+
+	merged := mergeSwarmLabels(service)
+
+	if merged["service.level"] != "from-service" {
+		t.Error("expected service-level label to be present")
+	}
+
+	if merged["container.level"] != "from-container" {
+		t.Error("expected container-level label to be present")
+	}
+
+	if merged["shared.key"] != "container-value" {
+		t.Error("expected container labels to take precedence on collision")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1153

In swarm mode, every deployment triggered a rolling update on **all** services, even when only one service actually changed. This happened because volatile labels (deployment timestamp, trigger SHA) were placed in container labels (`s.Labels`), which map to `TaskTemplate.ContainerSpec.Labels` in the Swarm ServiceSpec. Any change there causes Docker Swarm to recreate tasks.

This PR moves volatile labels to service-level deploy labels (`s.Deploy.Labels`), which map to `ServiceSpec.Annotations.Labels`. Changes to service-level labels do **not** trigger task recreation.

## Changes

- **`internal/docker/swarm.go`** — Split `addSwarmServiceLabels` into stable container labels and volatile service-level labels
- **`internal/docker/utils.go`** — Add `mergeSwarmLabels` to combine both label sources when reading back; update `GetServiceLabels` and `GetLabeledServices` to use it
- **`internal/docker/swarm_test.go`** — Tests for label placement and stability across redeployments
- **`internal/docker/utils_test.go`** — Test for label merging with precedence

## Test plan

- [x] `TestAddSwarmServiceLabels` — volatile labels in deploy labels, stable in container labels, user labels preserved
- [x] `TestSwarmServiceLabelsStability` — container labels unchanged when only timestamp differs
- [x] `TestMergeSwarmLabels` — service + container labels merged correctly with container precedence
- [x] Full test suite passes (`make test-nobitwarden`)