### PR TITLE
fix: compile webhook JMESPath query at request time

### DIFF
--- a/internal/secretprovider/webhook/client.go
+++ b/internal/secretprovider/webhook/client.go
@@ -28,6 +28,7 @@ const (
 type ValueProvider struct {
 	endpoint      *template.Template
 	payload       *template.Template
+	queryTpl      *template.Template
 	query         *jmespath.JMESPath
 	client        *http.Client
 	customHeaders map[string]string
@@ -44,6 +45,11 @@ func NewValueProvider(ctx context.Context, cfg *Config) (*ValueProvider, error) 
 	result := &ValueProvider{
 		client:        &http.Client{Transport: rt},
 		customHeaders: cfg.CustomHeaders,
+	}
+
+	result.queryTpl, err = template.New("webhook-query").Parse(cfg.ResultJMESPath)
+	if err != nil {
+		return nil, err
 	}
 
 	result.query, err = jmespath.Compile(cfg.ResultJMESPath)
@@ -71,7 +77,7 @@ func NewValueProvider(ctx context.Context, cfg *Config) (*ValueProvider, error) 
 // expected to be JSON encoded as it will be passed to a JMESPath evaluator
 // in order to extract the resulting value.
 func (p *ValueProvider) GetSecret(ctx context.Context, id string) (string, error) {
-	req, err := p.newRequest(ctx, id)
+	req, query, err := p.newRequest(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -90,7 +96,7 @@ func (p *ValueProvider) GetSecret(ctx context.Context, id string) (string, error
 		return "", err
 	}
 
-	result, err := p.query.Search(data)
+	result, err := query.Search(data)
 	if err != nil {
 		return "", err
 	} else if value, ok := result.(string); ok {
@@ -100,7 +106,7 @@ func (p *ValueProvider) GetSecret(ctx context.Context, id string) (string, error
 	return "", fmt.Errorf("JMESPath query did not yield a string but a %T", result)
 }
 
-func (p *ValueProvider) newRequest(ctx context.Context, id string) (*http.Request, error) {
+func (p *ValueProvider) newRequest(ctx context.Context, id string) (*http.Request, *jmespath.JMESPath, error) {
 	var body io.Reader
 
 	buf := new(bytes.Buffer)
@@ -109,7 +115,7 @@ func (p *ValueProvider) newRequest(ctx context.Context, id string) (*http.Reques
 	}
 
 	if err := p.endpoint.Execute(buf, tplParams); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	url := buf.String()
@@ -121,13 +127,13 @@ func (p *ValueProvider) newRequest(ctx context.Context, id string) (*http.Reques
 		method = http.MethodPost
 
 		if err := p.payload.Execute(buf, tplParams); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if p.payload != nil {
@@ -141,5 +147,16 @@ func (p *ValueProvider) newRequest(ctx context.Context, id string) (*http.Reques
 		req.Header.Set(key, value)
 	}
 
-	return req, nil
+	// Render json_path template into a separate buffer, leaving the body buffer untouched
+	jsonPathBuf := new(bytes.Buffer)
+	if err := p.queryTpl.Execute(jsonPathBuf, tplParams); err != nil {
+		return nil, nil, err
+	}
+
+	query, err := jmespath.Compile(jsonPathBuf.String())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return req, query, nil
 }

--- a/internal/secretprovider/webhook/client_test.go
+++ b/internal/secretprovider/webhook/client_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -195,6 +196,13 @@ func TestValueProvider_GetSecret_Webhook(t *testing.T) {
 			haveBearerTokenFile: "testdata/does/not/exist.txt",
 			wantConfigErr:       true,
 		},
+		"post_auth": {
+			haveSecretID:    "bacgaff",
+			haveURLPath:     "/post",
+			haveRequestBody: `{"secret":"{{.remoteRef}}"}`,
+			haveBearerToken: "DEADBEEFCAFE",
+			wantSecret:      "BACGAFF",
+		},
 		"custom_headers": {
 			haveSecretID:      "x-custom-header",
 			haveCustomHeaders: `{"X-Custom-Header":"custom-value"}`,
@@ -290,8 +298,19 @@ func getSecret(w http.ResponseWriter, r *http.Request) {
 func postSecret(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(HeaderContentType, ContentTypeJSON+"; charset=utf-8")
 
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		httpRespondError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if r.ContentLength >= 0 && r.ContentLength != int64(len(bodyBytes)) {
+		httpRespondError(w, http.StatusBadRequest, errors.New("body length mismatch"))
+		return
+	}
+
 	var body map[string]string
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
 		httpRespondError(w, http.StatusBadRequest, err)
 		return
 	}


### PR DESCRIPTION
The JMESPath query was being compiled at init time, so any template variables in it never got substituted. Moved the compilation to request time so it happens after the template is executed with the actual parameters. Fixes #1224