### PR TITLE
fix(external-secrets): prevent webhook body corruption during template rendering in newRequest

### DIFF
--- a/internal/secretprovider/webhook/client.go
+++ b/internal/secretprovider/webhook/client.go
@@ -123,26 +123,28 @@ func (p *ValueProvider) GetSecret(ctx context.Context, id string) (string, error
 func (p *ValueProvider) newRequest(ctx context.Context, store *Store, remoteRef map[string]any) (*http.Request, string, error) {
 	var body io.Reader
 
-	buf := new(bytes.Buffer)
 	tplParams := map[string]any{
 		"remote_ref": remoteRef,
 		"auth":       p.auth,
 	}
 
-	if err := store.urlTemplate.Execute(buf, tplParams); err != nil {
+	urlBuf := new(bytes.Buffer)
+
+	if err := store.urlTemplate.Execute(urlBuf, tplParams); err != nil {
 		return nil, "", err
 	}
 
-	url := buf.String()
+	url := urlBuf.String()
 	method := store.Method
 
 	if store.bodyTemplate != nil {
-		buf.Reset() // reuse buffer for payload rendering
-		body = buf
+		bodyBuf := new(bytes.Buffer)
 
-		if err := store.bodyTemplate.Execute(buf, tplParams); err != nil {
+		if err := store.bodyTemplate.Execute(bodyBuf, tplParams); err != nil {
 			return nil, "", err
 		}
+
+		body = bytes.NewReader(bodyBuf.Bytes())
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
@@ -157,22 +159,22 @@ func (p *ValueProvider) newRequest(ctx context.Context, store *Store, remoteRef 
 	req.Header.Set(HeaderAccept, ContentTypeJSON)
 
 	for key, tpl := range store.headerTemplates {
-		buf.Reset()
+		headerBuf := new(bytes.Buffer)
 
-		if err := tpl.Execute(buf, tplParams); err != nil {
+		if err := tpl.Execute(headerBuf, tplParams); err != nil {
 			return nil, "", err
 		}
 
-		req.Header.Set(key, buf.String())
+		req.Header.Set(key, headerBuf.String())
 	}
 
-	buf.Reset()
+	jsonPathBuf := new(bytes.Buffer)
 
-	if err := store.jsonPathTemplate.Execute(buf, tplParams); err != nil {
+	if err := store.jsonPathTemplate.Execute(jsonPathBuf, tplParams); err != nil {
 		return nil, "", err
 	}
 
-	renderedJSONPath := buf.String()
+	renderedJSONPath := jsonPathBuf.String()
 	if renderedJSONPath == "" {
 		return nil, "", fmt.Errorf("store %q rendered an empty json_path", store.Name)
 	}

--- a/internal/secretprovider/webhook/client_test.go
+++ b/internal/secretprovider/webhook/client_test.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -199,6 +200,58 @@ func TestGetConfig_WebhookStores_DefaultVersion(t *testing.T) {
 	}
 }
 
+func TestValueProvider_newRequest_BodyNotCorruptedByTemplateRendering(t *testing.T) {
+	stores := `stores:
+  post-auth:
+    version: v1
+    url: "https://example.com/post"
+    method: POST
+    headers:
+      Authorization: 'Basic {{ print .auth.username ":" .auth.password | b64enc }}'
+      Content-Type: application/json
+    body: '{"secret":"{{ .remote_ref.key }}"}'
+    json_path: "x"
+`
+
+	t.Setenv("SECRET_PROVIDER_WEBHOOK_STORES", stores)
+	t.Setenv("SECRET_PROVIDER_AUTH_USERNAME", "username")
+	t.Setenv("SECRET_PROVIDER_AUTH_PASSWORD", "password")
+
+	cfg, err := GetConfig()
+	if err != nil {
+		t.Fatalf("unexpected config error: %v", err)
+	}
+
+	subject, err := NewValueProvider(t.Context(), cfg)
+	if err != nil {
+		t.Fatalf("failed to create webhook value provider: %v", err)
+	}
+
+	store := cfg.Stores["post-auth"]
+
+	req, renderedJSONPath, err := subject.newRequest(t.Context(), store, map[string]any{"key": "token"})
+	if err != nil {
+		t.Fatalf("unexpected request creation error: %v", err)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+
+	if got, want := string(body), `{"secret":"token"}`; got != want {
+		t.Fatalf("got body %q, want %q", got, want)
+	}
+
+	if got, want := renderedJSONPath, "x"; got != want {
+		t.Fatalf("got json_path %q, want %q", got, want)
+	}
+
+	if got, want := req.ContentLength, int64(len(body)); got != want {
+		t.Fatalf("got content length %d, want %d", got, want)
+	}
+}
+
 func mustJSONRef(t *testing.T, ref SecretRefPayload) string {
 	t.Helper()
 
@@ -243,7 +296,15 @@ func getSecret(w http.ResponseWriter, r *http.Request) {
 func postSecret(w http.ResponseWriter, r *http.Request) {
 	var payload map[string]string
 
-	_ = json.NewDecoder(r.Body).Decode(&payload)
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if payload["secret"] != "token" {
+		http.Error(w, "unexpected secret payload", http.StatusBadRequest)
+		return
+	}
 
 	body := map[string]any{
 		"result": map[string]string{


### PR DESCRIPTION
Previously, one shared `bytes.Buffer` was used for all template executions; when later templates rendered (especially `json_path`), that could mutate the same underlying body buffer and lead to request body/content-length mismatch.

`newRequest` now renders templates with separate buffers.