### PR TITLE
fix(docker): improve reconciliation for one time service

### DIFF
--- a/internal/docker/service_utils.go
+++ b/internal/docker/service_utils.go
@@ -180,10 +180,10 @@ type ServiceMismatchReason struct {
 func CheckServiceMismatch(swarmModeEnabled bool, deployed map[Service]ServiceStatus, services types.Services) []ServiceMismatch {
 	var mismatches []ServiceMismatch
 
-	// In non-Swarm mode, services with "on-failure" or "no" restart policy can be considered as "stopped" and won't cause a mismatch.
+	// In non-Swarm mode, services with unset, "on-failure", or "no" restart policy can be considered as "stopped" and won't cause a mismatch.
 	allowStoppedForRestartPolicy := func(svc types.ServiceConfig) bool {
 		restart := strings.ToLower(strings.TrimSpace(svc.Restart))
-		return strings.HasPrefix(restart, "on-failure") || restart == "no"
+		return restart == "" || strings.HasPrefix(restart, "on-failure") || restart == "no"
 	}
 
 	getSvcMode := func(svc types.ServiceConfig) swarmInternal.DeployMode {

--- a/internal/docker/service_utils.go
+++ b/internal/docker/service_utils.go
@@ -81,11 +81,11 @@ func getLatestServiceStatus(statusMap map[Service]ServiceStatus, repoName string
 	return ret
 }
 
-func getDeployStatus(ctx context.Context, apiClient client.APIClient, deployName string) (map[Service]ServiceStatus, error) {
+func getDeployStatus(ctx context.Context, client client.APIClient, deployName string) (map[Service]ServiceStatus, error) {
 	result := make(map[Service]ServiceStatus)
 
 	if swarmInternal.GetModeEnabled() {
-		services, err := swarmInternal.GetStackServices(ctx, apiClient, deployName)
+		services, err := swarmInternal.GetStackServices(ctx, client, deployName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get services for stack %s: %w", deployName, err)
 		}
@@ -115,7 +115,7 @@ func getDeployStatus(ctx context.Context, apiClient client.APIClient, deployName
 			result[Service(name)] = status
 		}
 	} else {
-		containers, err := GetLabeledContainers(ctx, apiClient, api.ProjectLabel, deployName, true)
+		containers, err := GetLabeledContainers(ctx, client, api.ProjectLabel, deployName, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get containers for project %s: %w", deployName, err)
 		}

--- a/internal/docker/service_utils.go
+++ b/internal/docker/service_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/compose/convert"
@@ -80,11 +81,11 @@ func getLatestServiceStatus(statusMap map[Service]ServiceStatus, repoName string
 	return ret
 }
 
-func getDeployStatus(ctx context.Context, client client.APIClient, deployName string) (map[Service]ServiceStatus, error) {
+func getDeployStatus(ctx context.Context, apiClient client.APIClient, deployName string) (map[Service]ServiceStatus, error) {
 	result := make(map[Service]ServiceStatus)
 
 	if swarmInternal.GetModeEnabled() {
-		services, err := swarmInternal.GetStackServices(ctx, client, deployName)
+		services, err := swarmInternal.GetStackServices(ctx, apiClient, deployName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get services for stack %s: %w", deployName, err)
 		}
@@ -114,7 +115,7 @@ func getDeployStatus(ctx context.Context, client client.APIClient, deployName st
 			result[Service(name)] = status
 		}
 	} else {
-		containers, err := GetLabeledContainers(ctx, client, api.ProjectLabel, deployName)
+		containers, err := GetLabeledContainers(ctx, apiClient, api.ProjectLabel, deployName, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get containers for project %s: %w", deployName, err)
 		}
@@ -130,22 +131,27 @@ func getServiceStatusFromContainerStatus(projectName string, containers []contai
 	result := make(map[Service]ServiceStatus)
 
 	for _, cont := range containers {
-		if cont.State == container.StateRunning && cont.Labels[api.ProjectLabel] == projectName {
-			serviceName := cont.Labels[api.ServiceLabel]
-
-			status, ok := result[Service(serviceName)]
-			if !ok {
-				// the labels may be different between containers, but they should be the same for the same service,
-				// except com.docker.compose.container-number, com.docker.compose.replace
-				// so just use the labels of the first container we encounter for each service
-				status = ServiceStatus{}
-				status.Labels = cont.Labels
-			}
-
-			status.Replicas++
-
-			result[Service(serviceName)] = status
+		if cont.Labels[api.ProjectLabel] != projectName {
+			continue
 		}
+
+		serviceName := cont.Labels[api.ServiceLabel]
+
+		status, ok := result[Service(serviceName)]
+		if !ok {
+			// the labels may be different between containers, but they should be the same for the same service,
+			// except com.docker.compose.container-number, com.docker.compose.replace
+			// so just use the labels of the first container we encounter for each service
+			status = ServiceStatus{}
+			status.Labels = cont.Labels
+		}
+
+		if cont.State == container.StateRunning {
+			status.Replicas++
+		}
+
+		// Keep service presence even when all containers are stopped.
+		result[Service(serviceName)] = status
 	}
 
 	return result
@@ -174,6 +180,12 @@ type ServiceMismatchReason struct {
 func CheckServiceMismatch(swarmModeEnabled bool, deployed map[Service]ServiceStatus, services types.Services) []ServiceMismatch {
 	var mismatches []ServiceMismatch
 
+	// In non-Swarm mode, services with "on-failure" or "no" restart policy can be considered as "stopped" and won't cause a mismatch.
+	allowStoppedForRestartPolicy := func(svc types.ServiceConfig) bool {
+		restart := strings.ToLower(strings.TrimSpace(svc.Restart))
+		return strings.HasPrefix(restart, "on-failure") || restart == "no"
+	}
+
 	getSvcMode := func(svc types.ServiceConfig) swarmInternal.DeployMode {
 		if !swarmModeEnabled {
 			return ""
@@ -189,12 +201,13 @@ func CheckServiceMismatch(swarmModeEnabled bool, deployed map[Service]ServiceSta
 		status, ok := deployed[Service(svcName)]
 
 		reasons := []ServiceMismatchReason{}
-		if !ok {
-			reasons = append(reasons, ServiceMismatchReason{
-				Reason: ServiceMismatchReasonNotDeployed,
-			})
-		} else {
-			if swarmModeEnabled {
+
+		if swarmModeEnabled {
+			if !ok {
+				reasons = append(reasons, ServiceMismatchReason{
+					Reason: ServiceMismatchReasonNotDeployed,
+				})
+			} else {
 				svcMode := getSvcMode(svc)
 				if status.SwarmMode != svcMode {
 					reasons = append(reasons, ServiceMismatchReason{
@@ -215,14 +228,18 @@ func CheckServiceMismatch(swarmModeEnabled bool, deployed map[Service]ServiceSta
 						}
 					}
 				}
-			} else { //nolint:gocritic
-				if uint64(svc.GetScale()) != status.Replicas { //nolint:gosec
-					reasons = append(reasons, ServiceMismatchReason{
-						Reason: ServiceMismatchReasonReplicas,
-						Want:   svc.GetScale(),
-						Got:    status.Replicas,
-					})
-				}
+			}
+		} else if !allowStoppedForRestartPolicy(svc) {
+			if !ok {
+				reasons = append(reasons, ServiceMismatchReason{
+					Reason: ServiceMismatchReasonNotDeployed,
+				})
+			} else if uint64(svc.GetScale()) != status.Replicas { //nolint:gosec
+				reasons = append(reasons, ServiceMismatchReason{
+					Reason: ServiceMismatchReasonReplicas,
+					Want:   svc.GetScale(),
+					Got:    status.Replicas,
+				})
 			}
 		}
 

--- a/internal/docker/service_utils_test.go
+++ b/internal/docker/service_utils_test.go
@@ -606,13 +606,14 @@ func TestCheckServiceMismatch(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "swarmMode=false, mismatch replicas",
+			name: "swarmMode=false, mismatch replicas for restart always",
 			deployed: map[Service]ServiceStatus{
 				"foo": {Replicas: 1},
 			},
 			swarmModeEnable: false,
 			services: types.Services{
 				"foo": {
+					Restart: "always",
 					Scale: new(2),
 				},
 			},
@@ -630,11 +631,12 @@ func TestCheckServiceMismatch(t *testing.T) {
 			},
 		},
 		{
-			name:            "swarmMode=false, no deployed",
+			name:            "swarmMode=false, no deployed for restart always",
 			deployed:        map[Service]ServiceStatus{},
 			swarmModeEnable: false,
 			services: types.Services{
 				"foo": {
+					Restart: "always",
 					Scale: new(2),
 				},
 			},
@@ -648,6 +650,15 @@ func TestCheckServiceMismatch(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name:            "swarmMode=false, no restart policy may remain stopped",
+			deployed:        map[Service]ServiceStatus{},
+			swarmModeEnable: false,
+			services: types.Services{
+				"job": {},
+			},
+			want: nil,
 		},
 		{
 			name:            "swarmMode=false, restart on-failure may remain stopped",

--- a/internal/docker/service_utils_test.go
+++ b/internal/docker/service_utils_test.go
@@ -614,7 +614,7 @@ func TestCheckServiceMismatch(t *testing.T) {
 			services: types.Services{
 				"foo": {
 					Restart: "always",
-					Scale: new(2),
+					Scale:   new(2),
 				},
 			},
 			want: []ServiceMismatch{
@@ -637,7 +637,7 @@ func TestCheckServiceMismatch(t *testing.T) {
 			services: types.Services{
 				"foo": {
 					Restart: "always",
-					Scale: new(2),
+					Scale:   new(2),
 				},
 			},
 			want: []ServiceMismatch{

--- a/internal/docker/service_utils_test.go
+++ b/internal/docker/service_utils_test.go
@@ -650,6 +650,76 @@ func TestCheckServiceMismatch(t *testing.T) {
 			},
 		},
 		{
+			name:            "swarmMode=false, restart on-failure may remain stopped",
+			deployed:        map[Service]ServiceStatus{},
+			swarmModeEnable: false,
+			services: types.Services{
+				"job": {
+					Restart: "on-failure",
+				},
+			},
+			want: nil,
+		},
+		{
+			name:            "swarmMode=false, restart no may remain stopped",
+			deployed:        map[Service]ServiceStatus{},
+			swarmModeEnable: false,
+			services: types.Services{
+				"job": {
+					Restart: "no",
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "swarmMode=false, restart always should stay running",
+			deployed: map[Service]ServiceStatus{
+				"web": {Replicas: 0},
+			},
+			swarmModeEnable: false,
+			services: types.Services{
+				"web": {
+					Restart: "always",
+				},
+			},
+			want: []ServiceMismatch{
+				{
+					ServiceName: "web",
+					Reasons: []ServiceMismatchReason{
+						{
+							Reason: ServiceMismatchReasonReplicas,
+							Want:   1,
+							Got:    uint64(0),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "swarmMode=false, restart unless-stopped should stay running",
+			deployed: map[Service]ServiceStatus{
+				"web": {Replicas: 0},
+			},
+			swarmModeEnable: false,
+			services: types.Services{
+				"web": {
+					Restart: "unless-stopped",
+				},
+			},
+			want: []ServiceMismatch{
+				{
+					ServiceName: "web",
+					Reasons: []ServiceMismatchReason{
+						{
+							Reason: ServiceMismatchReasonReplicas,
+							Want:   1,
+							Got:    uint64(0),
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "swarmMode=true, no missing",
 			deployed: map[Service]ServiceStatus{
 				"foo":         {Replicas: 1, SwarmMode: swarm.DeployModeReplicated},

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -78,7 +78,7 @@ func GetServiceLabels(ctx context.Context, cli client.APIClient, stackName strin
 		return result, nil
 	}
 
-	containers, err := GetLabeledContainers(ctx, cli, api.ProjectLabel, stackName)
+	containers, err := GetLabeledContainers(ctx, cli, api.ProjectLabel, stackName, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get containers for stack %s: %w", stackName, err)
 	}
@@ -92,10 +92,10 @@ func GetServiceLabels(ctx context.Context, cli client.APIClient, stackName strin
 }
 
 // GetLabeledContainers retrieves all containers with a specific label key and value.
-func GetLabeledContainers(ctx context.Context, cli client.APIClient, key, value string) (containers []container.Summary, err error) {
+func GetLabeledContainers(ctx context.Context, cli client.APIClient, key, value string, all bool) (containers []container.Summary, err error) {
 	result, err := cli.ContainerList(ctx, client.ContainerListOptions{
 		Filters: make(client.Filters).Add("label", key+"="+value),
-		All:     false,
+		All:     all,
 	})
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func GetLabeledServices(ctx context.Context, cli client.APIClient, key, value st
 		return result, nil
 	}
 
-	containers, err := GetLabeledContainers(ctx, cli, key, value)
+	containers, err := GetLabeledContainers(ctx, cli, key, value, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get containers with label %s=%s: %w", key, value, err)
 	}

--- a/wiki/docs/Advanced/Pre-Post-Deployment-Scripts.md
+++ b/wiki/docs/Advanced/Pre-Post-Deployment-Scripts.md
@@ -19,6 +19,14 @@ Available options to run scripts/commands during deployment or container lifecyc
 - [Sidecar Containers](#sidecar-containers)
 - [Compose Lifecycle Hooks](#compose-lifecycle-hooks)
 
+!!! note "Reconciliation behavior for script-style one-time services"
+    In non-Swarm deployments, periodic reconciliation follows classic Compose `restart` semantics:
+    
+    - Services with `#!yaml restart: always` or `#!yaml restart: unless-stopped` are expected to stay running.
+    - Services with `#!yaml restart: on-failure` and `#!yaml restart: "no"` are treated as one-time behavior and may remain stopped after completion.
+
+    See [Reconciliation settings](../Deploy-Settings.md#reconciliation-settings), [Known Limitations](../Known-Limitations.md#reconciliation-behavior-for-one-time-services) and [Docker Compose specification](https://docs.docker.com/reference/compose-file/services/#restart).
+
 ## Init Containers
 
 Init containers are containers that run before the main application containers in your Docker Compose setup and complete their tasks before the main containers start. They are useful for performing setup tasks, such as initializing databases, running migrations, or preparing configuration files.
@@ -31,6 +39,9 @@ Some common use cases for init containers include:
 
 We use the `depends_on` option with the `condition: service_completed_successfully` condition to ensure that the main application container waits for the init container to complete successfully before starting. The init container will run its specified commands and exit with a status code of 0 to indicate success, allowing the main application container to start afterward.
 
+!!! success "Recommended Restart Policy for One-Time Script Services"
+    It is recommended to use `#!yaml restart: on-failure` for one-time script services to allow them to remain stopped after successful completion, while still enabling automatic restarts in case of failures.
+
 ### Example
 
 ```yaml title="docker-compose.yml" hl_lines="1-2 4-18 23 28-30"
@@ -40,6 +51,7 @@ x-common-env: &common-env
 services:
   init:
     image: busybox
+    restart: on-failure:3 # (3)!
     environment:
       <<: *common-env
     entrypoint: "sh -c"  # Use sh -c as the entrypoint to run multiple commands in "command" section
@@ -68,6 +80,7 @@ services:
 
 1. Double dollar-sign (`$$`) is required to use variables in the shell script, otherwise Docker Compose will try to resolve it as a variable in the `docker-compose.yml` file instead of passing it to the container.
 2. Wait for init container to complete/stop with exit code 0
+3. Using `restart: on-failure:3` allows the init container to be retried up to 3 times in case of failure during script execution, while still allowing it to remain stopped after successful completion. To retry indefinitely, you can use `restart: on-failure` without a retry limit.
 
 - If you have a shell script in your repo for the init stuff, you can remove `entrypoint` and mount the script directly and run it via the `command` option:
   ```yaml title="docker-compose.yml"
@@ -118,6 +131,7 @@ services:
 
   sidecar:
     image: busybox
+    restart: always # (1)!
     volumes:
       - webdata:/webdata
     depends_on:
@@ -131,6 +145,8 @@ services:
           sleep 60
         done
 ```
+
+1. Using `restart: always` ensures that the sidecar container continues to run and perform its tasks as long as the main application container is running.
 
 ## Compose Lifecycle Hooks
 
@@ -199,3 +215,5 @@ services:
 - [Using lifecycle hooks with Compose](https://docs.docker.com/compose/how-tos/lifecycle/)
 - [Docker Compose Post Start Hook Documentation](https://docs.docker.com/reference/compose-file/services/#post_start)
 - [Docker Compose Pre Stop Hook Documentation](https://docs.docker.com/reference/compose-file/services/#pre_stop)
+- [Reconciliation settings](../Deploy-Settings.md#reconciliation-settings)
+- [Known Limitations: Reconciliation behavior for one-time services](../Known-Limitations.md#reconciliation-behavior-for-one-time-services)

--- a/wiki/docs/Advanced/Pre-Post-Deployment-Scripts.md
+++ b/wiki/docs/Advanced/Pre-Post-Deployment-Scripts.md
@@ -19,14 +19,7 @@ Available options to run scripts/commands during deployment or container lifecyc
 - [Sidecar Containers](#sidecar-containers)
 - [Compose Lifecycle Hooks](#compose-lifecycle-hooks)
 
-!!! note "Reconciliation behavior for script-style one-time services"
-    In non-Swarm deployments, periodic reconciliation follows classic Compose `restart` semantics:
-    
-    - Services with `#!yaml restart: always` or `#!yaml restart: unless-stopped` are expected to stay running.
-    - Services with no explicit `restart` policy are treated as `#!yaml restart: "no"`.
-    - Services with `#!yaml restart: on-failure` and `#!yaml restart: "no"` are treated as one-time behavior and may remain stopped after completion.
-
-    See [Reconciliation settings](../Deploy-Settings.md#reconciliation-settings), [Known Limitations](../Known-Limitations.md#reconciliation-behavior-for-one-time-services) and [Docker Compose specification](https://docs.docker.com/reference/compose-file/services/#restart).
+--8<-- "wiki/docs/_snippets/reconciliation-note.md"
 
 ## Init Containers
 

--- a/wiki/docs/Advanced/Pre-Post-Deployment-Scripts.md
+++ b/wiki/docs/Advanced/Pre-Post-Deployment-Scripts.md
@@ -23,6 +23,7 @@ Available options to run scripts/commands during deployment or container lifecyc
     In non-Swarm deployments, periodic reconciliation follows classic Compose `restart` semantics:
     
     - Services with `#!yaml restart: always` or `#!yaml restart: unless-stopped` are expected to stay running.
+    - Services with no explicit `restart` policy are treated as `#!yaml restart: "no"`.
     - Services with `#!yaml restart: on-failure` and `#!yaml restart: "no"` are treated as one-time behavior and may remain stopped after completion.
 
     See [Reconciliation settings](../Deploy-Settings.md#reconciliation-settings), [Known Limitations](../Known-Limitations.md#reconciliation-behavior-for-one-time-services) and [Docker Compose specification](https://docs.docker.com/reference/compose-file/services/#restart).

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -219,15 +219,25 @@ destroy_opts:
 
 ### Reconciliation settings
 
+Reconciliation is an optional periodic check that compares the currently running services with the expected deployment state.
+If drift is detected, doco-cd automatically reapplies the deployment to bring the stack back to the desired state.
+
 The following settings can be used to configure periodic reconciliation.
 
 !!! warning
     The currently implemented state will be lost when doco-cd restarts.
 
 | Key        | Type    | Description                                          | Default value |
-| ---------- | ------- | ---------------------------------------------------- | ------------- |
+|------------|---------|------------------------------------------------------|---------------|
 | `enable`   | boolean | Enable periodic reconciliation.                      | `true`        |
 | `interval` | int     | The time in seconds between two reconciliation runs. | `60`          |
+
+!!! note
+    Reconciliation for non-Swarm deployments follows classic Compose `restart` semantics.
+
+    - Services with `#!yaml restart: always` or `#!yaml restart: unless-stopped` are expected to stay running.
+    - Services with `#!yaml restart: on-failure` may remain exited after success, and `#!yaml restart: "no"` is treated as one-time behavior and is not reconciled back to running.
+    - Swarm handling is separate and uses Swarm service modes and `#!yaml deploy.restart_policy` behavior.
 
 ```yaml title=".doco-cd.yml"
 name: some-project

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -50,7 +50,7 @@ The docker compose deployment can be configured inside the [deployment configura
 | `git_depth`        | number           | Limits the number of commits fetched during clone/fetch (shallow clone). `0` means use the global [`GIT_CLONE_DEPTH`](App-Settings.md) value. A positive integer overrides the global setting for this deployment. When a requested ref (tag/SHA) is outside the shallow depth, doco-cd automatically deepens incrementally before falling back to a full fetch. Changing this value on an existing repo triggers an automatic re-clone.                                             | `0` (use global)                                                                                                       |
 | `destroy`          | boolean          | (⚠️ Destructive) Remove the deployed compose stack/project and its resources from the Docker host. Can be further configured using the [destroy_opts](#destroy-settings) setting.                                                                                                                                                                                                                                                                                                    | `false`                                                                                                                |
 | `auto_discover`    | boolean          | Enables autodiscovery of services to deploy in the working directory by scanning for subdirectories with docker-compose files with the naming `docker-compose.y(a)ml` or `compose.y(a)ml`. Can be further configured using the [auto_discover_opts](#auto-discover-settings) setting.                                                                                                                                                                                                | `false`                                                                                                                |
-| `reconciliation`   | object           | Enables periodic reconciliation. See [reconciliation settings](#reconciliation-settings) for more details.                                                                                                                                                                                                                                                                                                                                                                           | `{enable: true, interval: 60}`                                                                                         |
+| `reconciliation`   | object           | Enables periodic reconciliation. See [reconciliation settings](#reconciliation-settings) for more details.                                                                                                                                                                                                                                                                                                                                                                           | `{enabled: true, interval: 60}`                                                                                        |
 
 
 ### Example
@@ -229,7 +229,7 @@ The following settings can be used to configure periodic reconciliation.
 
 | Key        | Type    | Description                                          | Default value |
 |------------|---------|------------------------------------------------------|---------------|
-| `enable`   | boolean | Enable periodic reconciliation.                      | `true`        |
+| `enabled`  | boolean | Enable periodic reconciliation.                      | `true`        |
 | `interval` | int     | The time in seconds between two reconciliation runs. | `60`          |
 
 !!! note
@@ -242,7 +242,7 @@ The following settings can be used to configure periodic reconciliation.
 ```yaml title=".doco-cd.yml"
 name: some-project
 reconciliation:
-  enable: true
+  enabled: true
   interval: 60
 ```
 

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -236,8 +236,11 @@ The following settings can be used to configure periodic reconciliation.
     Reconciliation for non-Swarm deployments follows classic Compose `restart` semantics.
 
     - Services with `#!yaml restart: always` or `#!yaml restart: unless-stopped` are expected to stay running.
+    - Services with no explicit `restart` policy are treated as `#!yaml restart: "no"`.
     - Services with `#!yaml restart: on-failure` may remain exited after success, and `#!yaml restart: "no"` is treated as one-time behavior and is not reconciled back to running.
     - Swarm handling is separate and uses Swarm service modes and `#!yaml deploy.restart_policy` behavior.
+
+    More information on the restart policies can be found in the [Docker Compose specification](https://docs.docker.com/reference/compose-file/services/#restart) and the [Docker Swarm documentation](https://docs.docker.com/engine/swarm/how-swarm-mode-works/swarm-task-states/).
 
 ```yaml title=".doco-cd.yml"
 name: some-project

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -232,15 +232,7 @@ The following settings can be used to configure periodic reconciliation.
 | `enabled`  | boolean | Enable periodic reconciliation.                      | `true`        |
 | `interval` | int     | The time in seconds between two reconciliation runs. | `60`          |
 
-!!! note
-    Reconciliation for non-Swarm deployments follows classic Compose `restart` semantics.
-
-    - Services with `#!yaml restart: always` or `#!yaml restart: unless-stopped` are expected to stay running.
-    - Services with no explicit `restart` policy are treated as `#!yaml restart: "no"`.
-    - Services with `#!yaml restart: on-failure` may remain exited after success, and `#!yaml restart: "no"` is treated as one-time behavior and is not reconciled back to running.
-    - Swarm handling is separate and uses Swarm service modes and `#!yaml deploy.restart_policy` behavior.
-
-    More information on the restart policies can be found in the [Docker Compose specification](https://docs.docker.com/reference/compose-file/services/#restart) and the [Docker Swarm documentation](https://docs.docker.com/engine/swarm/how-swarm-mode-works/swarm-task-states/).
+--8<-- "wiki/docs/_snippets/reconciliation-note.md"
 
 ```yaml title=".doco-cd.yml"
 name: some-project

--- a/wiki/docs/_snippets/reconciliation-note.md
+++ b/wiki/docs/_snippets/reconciliation-note.md
@@ -1,0 +1,9 @@
+!!! note
+    [Reconciliation](../Deploy-Settings.md#reconciliation-settings) for non-Swarm deployments follows classic Compose `restart` semantics:
+
+    - Services with `#!yaml restart: always` or `#!yaml restart: unless-stopped` are expected to stay running.
+    - Services with no explicit `restart` policy are treated as `#!yaml restart: "no"`.
+    - Services with `#!yaml restart: on-failure` may remain exited after success, and `#!yaml restart: "no"` is treated as one-time behavior and is not reconciled back to running.
+    - Swarm handling is separate and uses Swarm service modes and `#!yaml deploy.restart_policy` behavior.
+
+    More information on the restart policies can be found in the [Docker Compose specification](https://docs.docker.com/reference/compose-file/services/#restart).


### PR DESCRIPTION
This pull request improves how the system handles reconciliation and status checks for one-time script-style services in non-Swarm (classic Compose) deployments. It updates the service status logic, adjusts the mismatch detection to respect `restart` policies, and enhances documentation to clarify expected behaviors for different restart policies. Several new tests are added to ensure correct handling of these scenarios.

fixed typo in docs: `reconciliation.enable` -> `reconciliation.enabled`