### PR TITLE
Revert "ci: build doco-cd for riscv64"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     with:
       build-args: |
         APP_VERSION=${{ github.ref_name }}
-      platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
+      platforms: linux/amd64,linux/arm64,linux/arm/v7
       cache: true
       cache-mode: max
       output: image

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,14 @@ ARG TARGETVARIANT
 # Set destination for COPY
 WORKDIR /app
 
-# Automatically disable Bitwarden for armv7 and riscv64
-# The Bitwarden Go SDK does not support 32-bit ARM architecture or RISC-V 64-bit architecture
-RUN if ([ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]) || ([ "$TARGETARCH" = "riscv64" ]); then \
-    echo "Detected unsupported ${TARGETARCH} ${TARGETVARIANT} architecture - Bitwarden support will be disabled"; \
+# Automatically disable Bitwarden for armv7
+# The Bitwarden Go SDK does not support 32-bit ARM architecture
+RUN if [ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]; then \
+    echo "Detected armv7 architecture - Bitwarden support will be disabled"; \
     fi
 
-# Install prerequisites for Bitwarden SDK (only if not disabled and not armv7 or riscv64)
-RUN if [ "$DISABLE_BITWARDEN" != "true" ] && ! ([ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]) && ! ([ "$TARGETARCH" = "riscv64" ]); then \
+# Install prerequisites for Bitwarden SDK (only if not disabled and not armv7)
+RUN if [ "$DISABLE_BITWARDEN" != "true" ] && ! ([ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]); then \
     apt-get update && apt-get install -y \
     musl-tools \
     && rm -rf /var/lib/apt/lists/*; \
@@ -45,13 +45,13 @@ ARG TARGETVARIANT
 COPY . .
 
 # Build with or without Bitwarden support
-# armv7 and riscv64 builds are automatically built without Bitwarden
+# armv7 builds are automatically built without Bitwarden
 # CGO_ENABLED=1 and CC=musl-gcc are required for Bitwarden SDK when enabled
 # For builds without Bitwarden, CGO is not needed
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target="/root/.cache/go-build" \
     --mount=type=bind,target=. \
-    if [ "$DISABLE_BITWARDEN" = "true" ] || ([ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]) || ([ "$TARGETARCH" = "riscv64" ]); then \
+    if [ "$DISABLE_BITWARDEN" = "true" ] || ([ "$TARGETARCH" = "arm" ] && [ "$TARGETVARIANT" = "v7" ]); then \
         echo "Building without Bitwarden support"; \
         CGO_ENABLED=1 go build -tags nobitwarden -ldflags="-s -w -X github.com/kimdre/doco-cd/internal/config.AppVersion=${APP_VERSION}" -o / ./...; \
     else \


### PR DESCRIPTION
Reverts kimdre/doco-cd#1256

I need to revert this for now unfortunately. I just tested the build performance and it's very bad when I build it via QEMU since I cannot use runners with riscv hardware.
I'm waiting for a feature request for the build action to allow specifying custom runners so I can use a riscv runner provided by RISE: https://github.com/docker/github-builder/issues/161
https://github.com/apps/rise-risc-v-runners-personal