### PR TITLE
feat(docker): remember deploy status

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -569,6 +569,14 @@ func DeployStack(
 		}
 	}
 
+	// cache the deployment status after successful deployment
+	setDeployStatusToCache(gitInternal.GetRepoName(payload.CloneURL), deployConfig.Name,
+		deployStatus{
+			CommitSHA:   latestCommit,
+			ComposeHash: projectHash,
+		},
+	)
+
 	prometheus.DeploymentsTotal.WithLabelValues(deployConfig.Name).Inc()
 	prometheus.DeploymentDuration.WithLabelValues(deployConfig.Name).Observe(time.Since(startTime).Seconds())
 
@@ -863,7 +871,7 @@ func (i IgnoredInfo) IsEmpty() bool {
 }
 
 func (i IgnoredInfo) IsNeedSignal() bool {
-	return len(i.NeedSendSignal) == 0
+	return len(i.NeedSendSignal) > 0
 }
 
 type SignalService struct {

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -368,6 +368,26 @@ compose_files:
 			t.Fatalf("expected no labeled containers after destruction, got %d", len(serviceLabels))
 		}
 
+		stats, err := GetLatestDeployStatus(ctx, dockerClient, p.CloneURL, stackName)
+		if err != nil {
+			t.Fatalf("GetLatestDeployStatus err: %v", err)
+		}
+
+		t.Log("Verifying deployment status after destruction", stats)
+
+		if stats.GetDeploymentCommitSHA() != latestCommit {
+			t.Fatalf("expected latest deployed commit SHA to be '%s', got '%s'", latestCommit, stats.GetDeploymentCommitSHA())
+		}
+
+		projectHash, err := ProjectHash(project)
+		if err != nil {
+			t.Fatalf("ProjectHash err: %v", err)
+		}
+
+		if stats.GetDeploymentComposeHash() != projectHash {
+			t.Fatalf("expected latest deployed compose hash to be '%s', got '%s'", projectHash, stats.GetDeploymentComposeHash())
+		}
+
 		t.Log("Finished destroying deployment with no errors")
 	}
 }

--- a/internal/docker/service_utils.go
+++ b/internal/docker/service_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/compose/convert"
@@ -13,6 +14,7 @@ import (
 	"github.com/moby/moby/client"
 
 	swarmInternal "github.com/kimdre/doco-cd/internal/docker/swarm"
+	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/utils/set"
 )
 
@@ -32,35 +34,45 @@ type ServiceStatus struct {
 }
 
 type LatestServiceStatus struct {
-	// The labels may be different in different services, but project-level labels should be the same.
-	Labels Labels
+	deploymentCommitSHA   string
+	deploymentComposeHash string
 
 	DeployedStatus map[Service]ServiceStatus
 }
 
+func (l LatestServiceStatus) GetDeploymentCommitSHA() string {
+	return l.deploymentCommitSHA
+}
+
+func (l LatestServiceStatus) GetDeploymentComposeHash() string {
+	return l.deploymentComposeHash
+}
+
 // GetLatestDeployStatus retrieves the deployed status for a given repository and deploy name.
-func GetLatestDeployStatus(ctx context.Context, client client.APIClient, repoName, deployName string) (LatestServiceStatus, error) {
+func GetLatestDeployStatus(ctx context.Context, client client.APIClient, cloneURL string, deployName string) (LatestServiceStatus, error) {
 	serviceLabels, err := getDeployStatus(ctx, client, deployName)
 	if err != nil {
 		return LatestServiceStatus{}, fmt.Errorf("failed to retrieve service labels: %w", err)
 	}
 
-	return getLatestServiceStatus(serviceLabels, repoName), nil
+	return getLatestServiceStatus(&deployStatusCache, serviceLabels, cloneURL, deployName), nil
 }
 
-func getLatestServiceStatus(statusMap map[Service]ServiceStatus, repoName string) LatestServiceStatus {
+func getLatestServiceStatus(cacheMap *sync.Map, statusMap map[Service]ServiceStatus, cloneURL string, deployName string) LatestServiceStatus {
 	ret := LatestServiceStatus{
 		DeployedStatus: make(map[Service]ServiceStatus),
-		Labels:         make(Labels),
 	}
 
-	var latestTimestamp string
+	var (
+		latestLabels    Labels
+		latestTimestamp string
+	)
 
 	for serviceName, state := range statusMap {
 		labels := state.Labels
 
 		name, ok := labels[DocoCDLabels.Repository.Name]
-		if !ok || name != repoName {
+		if !ok || name != git.GetFullName(cloneURL) {
 			// When a service matches and others don't,
 			// using 'break' will return a random result.
 			continue
@@ -72,10 +84,19 @@ func getLatestServiceStatus(statusMap map[Service]ServiceStatus, repoName string
 		// TODO: If timestamps are equal, the result may be random for simultaneous deployments.
 		if timestamp >= latestTimestamp {
 			latestTimestamp = timestamp
-			ret.Labels = labels
+			latestLabels = labels
 		}
 
 		ret.DeployedStatus[serviceName] = state
+	}
+
+	cache, ok := getDeployStatusFromCache(cacheMap, git.GetRepoName(cloneURL), deployName)
+	if ok {
+		ret.deploymentCommitSHA = cache.CommitSHA
+		ret.deploymentComposeHash = cache.ComposeHash
+	} else {
+		ret.deploymentCommitSHA, _ = latestLabels.getDeploymentCommitSHA()
+		ret.deploymentComposeHash, _ = latestLabels.getDeploymentComposeHash()
 	}
 
 	return ret

--- a/internal/docker/service_utils_test.go
+++ b/internal/docker/service_utils_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,18 +23,26 @@ import (
 func Test_getLatestServiceState(t *testing.T) {
 	t.Parallel()
 
+	cache := &sync.Map{}
+	cache.Store(getDeployStatusCacheKey("github.com/owner/repo", "cache"), deployStatus{
+		ComposeHash: "cache_compose_hash",
+		CommitSHA:   "cache_commit_sha",
+	})
+
 	tests := []struct {
 		name          string
 		serviceStatus map[Service]ServiceStatus
 		repoName      string
+		deployName    string
+		cache         *sync.Map
 		want          LatestServiceStatus
 	}{
 		{
 			name:          "empty serviceLabels",
 			serviceStatus: map[Service]ServiceStatus{},
 			repoName:      "repo",
+			deployName:    "deploy",
 			want: LatestServiceStatus{
-				Labels:         Labels{},
 				DeployedStatus: map[Service]ServiceStatus{},
 			},
 		},
@@ -42,20 +51,81 @@ func Test_getLatestServiceState(t *testing.T) {
 			serviceStatus: map[Service]ServiceStatus{
 				"svc1": {
 					Labels: Labels{
-						DocoCDLabels.Repository.Name: "repo",
+						DocoCDLabels.Repository.Name:        "repo",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash",
 					},
 					Replicas: 1,
 				},
 			},
 			repoName: "repo",
 			want: LatestServiceStatus{
-				Labels: Labels{
-					DocoCDLabels.Repository.Name: "repo",
-				},
+				deploymentCommitSHA:   "commit_sha",
+				deploymentComposeHash: "compose_hash",
 				DeployedStatus: map[Service]ServiceStatus{
 					"svc1": {
 						Labels: Labels{
-							DocoCDLabels.Repository.Name: "repo",
+							DocoCDLabels.Repository.Name:        "repo",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash",
+						},
+						Replicas: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "single service but repo this is full clone URL",
+			serviceStatus: map[Service]ServiceStatus{
+				"svc1": {
+					Labels: Labels{
+						DocoCDLabels.Repository.Name:        "owner/repo",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash",
+					},
+					Replicas: 1,
+				},
+			},
+			repoName: "https://github.com/owner/repo.git",
+			want: LatestServiceStatus{
+				deploymentCommitSHA:   "commit_sha",
+				deploymentComposeHash: "compose_hash",
+				DeployedStatus: map[Service]ServiceStatus{
+					"svc1": {
+						Labels: Labels{
+							DocoCDLabels.Repository.Name:        "owner/repo",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash",
+						},
+						Replicas: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "cache hit, single service with no timestamp",
+			serviceStatus: map[Service]ServiceStatus{
+				"svc1": {
+					Labels: Labels{
+						DocoCDLabels.Repository.Name:        "owner/repo",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash",
+					},
+					Replicas: 1,
+				},
+			},
+			repoName:   "https://github.com/owner/repo.git",
+			deployName: "cache",
+			cache:      cache,
+			want: LatestServiceStatus{
+				deploymentCommitSHA:   "cache_commit_sha",
+				deploymentComposeHash: "cache_compose_hash",
+				DeployedStatus: map[Service]ServiceStatus{
+					"svc1": {
+						Labels: Labels{
+							DocoCDLabels.Repository.Name:        "owner/repo",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash",
 						},
 						Replicas: 1,
 					},
@@ -67,23 +137,25 @@ func Test_getLatestServiceState(t *testing.T) {
 			serviceStatus: map[Service]ServiceStatus{
 				"svc1": {
 					Labels: Labels{
-						DocoCDLabels.Repository.Name:      "repo",
-						DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
+						DocoCDLabels.Repository.Name:        "repo",
+						DocoCDLabels.Deployment.Timestamp:   "2006-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash",
 					},
 					Replicas: 1,
 				},
 			},
 			repoName: "repo",
 			want: LatestServiceStatus{
-				Labels: Labels{
-					DocoCDLabels.Repository.Name:      "repo",
-					DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
-				},
+				deploymentCommitSHA:   "commit_sha",
+				deploymentComposeHash: "compose_hash",
 				DeployedStatus: map[Service]ServiceStatus{
 					"svc1": {
 						Labels: Labels{
-							DocoCDLabels.Repository.Name:      "repo",
-							DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
+							DocoCDLabels.Repository.Name:        "repo",
+							DocoCDLabels.Deployment.Timestamp:   "2006-01-02T15:04:05Z07:00",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash",
 						},
 						Replicas: 1,
 					},
@@ -110,8 +182,9 @@ func Test_getLatestServiceState(t *testing.T) {
 			},
 			repoName: "repo",
 			want: LatestServiceStatus{
-				Labels:         Labels{},
-				DeployedStatus: map[Service]ServiceStatus{},
+				deploymentCommitSHA:   "",
+				deploymentComposeHash: "",
+				DeployedStatus:        map[Service]ServiceStatus{},
 			},
 		},
 		{
@@ -119,30 +192,34 @@ func Test_getLatestServiceState(t *testing.T) {
 			serviceStatus: map[Service]ServiceStatus{
 				"svc1": {
 					Labels: Labels{
-						DocoCDLabels.Repository.Name:      "repo",
-						DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
+						DocoCDLabels.Repository.Name:        "repo",
+						DocoCDLabels.Deployment.Timestamp:   "2006-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha1",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash1",
 					},
 					Replicas: 1,
 				},
 				"svc2": {
 					Labels: Labels{
-						DocoCDLabels.Repository.Name:      "repo-2",
-						DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
+						DocoCDLabels.Repository.Name:        "repo-2",
+						DocoCDLabels.Deployment.Timestamp:   "2016-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha2",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash2",
 					},
 					Replicas: 1,
 				},
 			},
 			repoName: "repo",
 			want: LatestServiceStatus{
-				Labels: Labels{
-					DocoCDLabels.Repository.Name:      "repo",
-					DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
-				},
+				deploymentCommitSHA:   "commit_sha1",
+				deploymentComposeHash: "compose_hash1",
 				DeployedStatus: map[Service]ServiceStatus{
 					"svc1": {
 						Labels: Labels{
-							DocoCDLabels.Repository.Name:      "repo",
-							DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
+							DocoCDLabels.Repository.Name:        "repo",
+							DocoCDLabels.Deployment.Timestamp:   "2006-01-02T15:04:05Z07:00",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha1",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash1",
 						},
 						Replicas: 1,
 					},
@@ -154,20 +231,23 @@ func Test_getLatestServiceState(t *testing.T) {
 			serviceStatus: map[Service]ServiceStatus{
 				"svc1": {
 					Labels: Labels{
-						DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.Timestamp:   "2006-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha1",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash1",
 					},
 					Replicas: 1,
 				},
 				"svc2": {
 					Labels: Labels{
-						DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.Timestamp:   "2016-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha2",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash2",
 					},
 					Replicas: 1,
 				},
 			},
 			repoName: "repo",
 			want: LatestServiceStatus{
-				Labels:         Labels{},
 				DeployedStatus: map[Service]ServiceStatus{},
 			},
 		},
@@ -176,37 +256,43 @@ func Test_getLatestServiceState(t *testing.T) {
 			serviceStatus: map[Service]ServiceStatus{
 				"svc1": {
 					Labels: Labels{
-						DocoCDLabels.Repository.Name:      "",
-						DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
+						DocoCDLabels.Repository.Name:        "",
+						DocoCDLabels.Deployment.Timestamp:   "2006-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha1",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash1",
 					},
 					Replicas: 1,
 				},
 				"svc2": {
 					Labels: Labels{
-						DocoCDLabels.Repository.Name:      "",
-						DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
+						DocoCDLabels.Repository.Name:        "",
+						DocoCDLabels.Deployment.Timestamp:   "2016-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha2",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash2",
 					},
 					Replicas: 2,
 				},
 			},
 			repoName: "",
 			want: LatestServiceStatus{
-				Labels: Labels{
-					DocoCDLabels.Repository.Name:      "",
-					DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
-				},
+				deploymentCommitSHA:   "commit_sha2",
+				deploymentComposeHash: "compose_hash2",
 				DeployedStatus: map[Service]ServiceStatus{
 					"svc2": {
 						Labels: Labels{
-							DocoCDLabels.Repository.Name:      "",
-							DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
+							DocoCDLabels.Repository.Name:        "",
+							DocoCDLabels.Deployment.Timestamp:   "2016-01-02T15:04:05Z07:00",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha2",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash2",
 						},
 						Replicas: 2,
 					},
 					"svc1": {
 						Labels: Labels{
-							DocoCDLabels.Repository.Name:      "",
-							DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
+							DocoCDLabels.Repository.Name:        "",
+							DocoCDLabels.Deployment.Timestamp:   "2006-01-02T15:04:05Z07:00",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha1",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash1",
 						},
 						Replicas: 1,
 					},
@@ -225,18 +311,18 @@ func Test_getLatestServiceState(t *testing.T) {
 				},
 				"svc2": {
 					Labels: Labels{
-						DocoCDLabels.Repository.Name:      "repo",
-						DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
+						DocoCDLabels.Repository.Name:        "repo",
+						DocoCDLabels.Deployment.Timestamp:   "2016-01-02T15:04:05Z07:00",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha2",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash2",
 					},
 					Replicas: 1,
 				},
 			},
 			repoName: "repo",
 			want: LatestServiceStatus{
-				Labels: Labels{
-					DocoCDLabels.Repository.Name:      "repo",
-					DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
-				},
+				deploymentCommitSHA:   "commit_sha2",
+				deploymentComposeHash: "compose_hash2",
 				DeployedStatus: map[Service]ServiceStatus{
 					"svc1": {
 						Labels: Labels{
@@ -247,8 +333,10 @@ func Test_getLatestServiceState(t *testing.T) {
 					},
 					"svc2": {
 						Labels: Labels{
-							DocoCDLabels.Repository.Name:      "repo",
-							DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
+							DocoCDLabels.Repository.Name:        "repo",
+							DocoCDLabels.Deployment.Timestamp:   "2016-01-02T15:04:05Z07:00",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha2",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash2",
 						},
 						Replicas: 1,
 					},
@@ -258,7 +346,12 @@ func Test_getLatestServiceState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getLatestServiceStatus(tt.serviceStatus, tt.repoName)
+			cache := &sync.Map{}
+			if tt.cache != nil {
+				cache = tt.cache
+			}
+
+			got := getLatestServiceStatus(cache, tt.serviceStatus, tt.repoName, tt.deployName)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetLatestServiceState() = %v, want %v", got, tt.want)

--- a/internal/docker/state.go
+++ b/internal/docker/state.go
@@ -1,0 +1,40 @@
+package docker
+
+import (
+	"strings"
+	"sync"
+)
+
+type deployStatus struct {
+	ComposeHash string
+	CommitSHA   string
+}
+
+// for case when some services(not all) are removed, the compose_hash, commit_sha will change,
+// but docker compose will not recreate the remaining services(compose_hash, commit_sha),
+// the next time when we compare the deployment status, we will get the old compose_hash and commit_sha.
+//
+// so we need to the cache the deployment status after successful deployment
+// https://github.com/kimdre/doco-cd/issues/1262
+
+// map[repoName:deployName]deployStatus
+// repoName should use git.RepoName() function to get host/owner/repo, e.g., github.com/kimdre/doco-cd.
+var deployStatusCache sync.Map
+
+func getDeployStatusCacheKey(repoName string, deployName string) string {
+	return strings.Join([]string{repoName, deployName}, ":")
+}
+
+func getDeployStatusFromCache(cacheMap *sync.Map, repoName string, deployName string) (deployStatus, bool) {
+	if value, ok := cacheMap.Load(getDeployStatusCacheKey(repoName, deployName)); ok {
+		if status, valid := value.(deployStatus); valid {
+			return status, true
+		}
+	}
+
+	return deployStatus{}, false
+}
+
+func setDeployStatusToCache(repoName string, deployName string, status deployStatus) {
+	deployStatusCache.Store(getDeployStatusCacheKey(repoName, deployName), status)
+}

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -54,11 +54,11 @@ func (l Labels) Get(key string) (string, bool) {
 	return v, ok
 }
 
-func (l Labels) GetDeploymentCommitSHA() (string, bool) {
+func (l Labels) getDeploymentCommitSHA() (string, bool) {
 	return l.Get(DocoCDLabels.Deployment.CommitSHA)
 }
 
-func (l Labels) GetDeploymentComposeHash() (string, bool) {
+func (l Labels) getDeploymentComposeHash() (string, bool) {
 	return l.Get(DocoCDLabels.Deployment.ComposeHash)
 }
 

--- a/internal/git/names.go
+++ b/internal/git/names.go
@@ -1,17 +1,14 @@
-package stages
+package git
 
 import (
 	"strings"
-
-	"github.com/kimdre/doco-cd/internal/config"
-	"github.com/kimdre/doco-cd/internal/git"
 )
 
-// getFullName extracts the full repository name without the domain part from the clone URL.
+// GetFullName extracts the full repository name without the domain part from the clone URL.
 // E.g., "github.com/kimdre/doco-cd" becomes "kimdre/doco-cd"
 // or "git.example.com/doco-cd" becomes "doco-cd".
-func getFullName(cloneURL config.HttpUrl) string {
-	repoName := git.GetRepoName(string(cloneURL))
+func GetFullName(cloneURL string) string {
+	repoName := GetRepoName(cloneURL)
 	parts := strings.Split(repoName, "/")
 	fullName := repoName
 

--- a/internal/git/names_test.go
+++ b/internal/git/names_test.go
@@ -1,9 +1,7 @@
-package stages
+package git
 
 import (
 	"testing"
-
-	"github.com/kimdre/doco-cd/internal/config"
 )
 
 func TestGetFullName(t *testing.T) {
@@ -49,7 +47,7 @@ func TestGetFullName(t *testing.T) {
 		t.Run(tt.cloneURL, func(t *testing.T) {
 			t.Parallel()
 
-			result := getFullName(config.HttpUrl(tt.cloneURL))
+			result := GetFullName(tt.cloneURL)
 			if result != tt.expected {
 				t.Errorf("getFullName failed for %s: expected %s, got %s", tt.cloneURL, tt.expected, result)
 			}

--- a/internal/stages/stage_1_init.go
+++ b/internal/stages/stage_1_init.go
@@ -145,7 +145,7 @@ func (s *StageManager) RunInitStage(ctx context.Context, stageLog *slog.Logger) 
 		for _, labels := range serviceLabels {
 			name, ok := labels[docker.DocoCDLabels.Repository.Name]
 
-			if !ok || name != getFullName(s.Repository.CloneURL) {
+			if !ok || name != git.GetFullName(string(s.Repository.CloneURL)) {
 				correctRepo = false
 				break
 			}
@@ -181,7 +181,7 @@ func (s *StageManager) RunInitStage(ctx context.Context, stageLog *slog.Logger) 
 			Name:      git.GetRepoName(string(s.Repository.CloneURL)),
 			Ref:       s.DeployConfig.Reference,
 			CommitSHA: string(JobTriggerPoll),
-			FullName:  getFullName(s.Repository.CloneURL),
+			FullName:  git.GetFullName(string(s.Repository.CloneURL)),
 			CloneURL:  string(s.Repository.CloneURL),
 			WebURL:    string(s.Repository.CloneURL),
 		}

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -27,7 +27,7 @@ func shouldSkipDeployment(composeChanged bool,
 ) bool {
 	return !composeChanged &&
 		len(changedServices) == 0 &&
-		ignoredInfo.IsNeedSignal() &&
+		!ignoredInfo.IsNeedSignal() &&
 		!imagesChanged &&
 		len(mismatchServices) == 0
 }
@@ -73,12 +73,12 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 		return fmt.Errorf("failed to hash deploy configuration: %w", err)
 	}
 
-	deployedState, err := docker.GetLatestDeployStatus(ctx, s.Docker.Cmd.Client(), getFullName(s.Repository.CloneURL), s.DeployConfig.Name)
+	deployedState, err := docker.GetLatestDeployStatus(ctx, s.Docker.Cmd.Client(), string(s.Repository.CloneURL), s.DeployConfig.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get latest state from deployed services: %w", err)
 	}
 
-	if deployedCommit, _ := deployedState.Labels.GetDeploymentCommitSHA(); deployedCommit != "" {
+	if deployedCommit := deployedState.GetDeploymentCommitSHA(); deployedCommit != "" {
 		latestCommit, err := git.GetLatestCommit(s.Repository.Git, s.DeployConfig.Reference)
 		if err != nil {
 			return fmt.Errorf("failed to get latest commit: %w", err)
@@ -138,7 +138,7 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 			return fmt.Errorf("failed to get project hash: %w", err)
 		}
 
-		curProjectHash, _ := deployedState.Labels.GetDeploymentComposeHash()
+		curProjectHash := deployedState.GetDeploymentComposeHash()
 
 		composeChanged := newHash != curProjectHash
 		if composeChanged {


### PR DESCRIPTION
In a multi-service project, when I remove service A, service B remains unchanged.

However, doco-cd keeps trying to redeploy the project repeatedly. Docker Compose ignores the deployment since service B has not changed.


https://github.com/kimdre/doco-cd/issues/1262