### PR TITLE
fix(docker): stop false-positive "service not deployed" loop for containers missing cd.doco.* labels

### DIFF
--- a/internal/docker/service_utils.go
+++ b/internal/docker/service_utils.go
@@ -69,6 +69,14 @@ func getLatestServiceStatus(cacheMap *sync.Map, statusMap map[Service]ServiceSta
 	)
 
 	for serviceName, state := range statusMap {
+		// Always include the service in the deployed inventory, regardless of whether it has
+		// cd.doco.* labels. Containers that are missing those labels (e.g. started via the
+		// Docker CLI directly or deployed before doco-cd stamped them) are still genuinely
+		// running and must not be reported as "service not deployed" by CheckServiceMismatch.
+		ret.DeployedStatus[serviceName] = state
+
+		// Only use containers that carry doco-cd repository labels for deployment metadata
+		// (latest commit SHA, compose hash). This keeps the two concerns separate.
 		labels := state.Labels
 
 		name, ok := labels[DocoCDLabels.Repository.Name]
@@ -86,8 +94,6 @@ func getLatestServiceStatus(cacheMap *sync.Map, statusMap map[Service]ServiceSta
 			latestTimestamp = timestamp
 			latestLabels = labels
 		}
-
-		ret.DeployedStatus[serviceName] = state
 	}
 
 	cache, ok := getDeployStatusFromCache(cacheMap, git.GetRepoName(cloneURL), deployName)

--- a/internal/docker/service_utils_test.go
+++ b/internal/docker/service_utils_test.go
@@ -163,6 +163,8 @@ func Test_getLatestServiceState(t *testing.T) {
 			},
 		},
 		{
+			// All project containers are included in DeployedStatus regardless of repo label.
+			// The repo-name filter only governs metadata selection (commit SHA, compose hash).
 			name: "two service with timestamp but repo not match",
 			serviceStatus: map[Service]ServiceStatus{
 				"svc1": {
@@ -184,10 +186,27 @@ func Test_getLatestServiceState(t *testing.T) {
 			want: LatestServiceStatus{
 				deploymentCommitSHA:   "",
 				deploymentComposeHash: "",
-				DeployedStatus:        map[Service]ServiceStatus{},
+				DeployedStatus: map[Service]ServiceStatus{
+					"svc1": {
+						Labels: Labels{
+							DocoCDLabels.Repository.Name:      "repo-2",
+							DocoCDLabels.Deployment.Timestamp: "2006-01-02T15:04:05Z07:00",
+						},
+						Replicas: 1,
+					},
+					"svc2": {
+						Labels: Labels{
+							DocoCDLabels.Repository.Name:      "repo-2",
+							DocoCDLabels.Deployment.Timestamp: "2016-01-02T15:04:05Z07:00",
+						},
+						Replicas: 1,
+					},
+				},
 			},
 		},
 		{
+			// svc2 has a different repo label but is still part of the project — it must appear
+			// in DeployedStatus. Only metadata (commit SHA, compose hash) is drawn from svc1.
 			name: "two service with timestamp but repo mixed",
 			serviceStatus: map[Service]ServiceStatus{
 				"svc1": {
@@ -223,10 +242,21 @@ func Test_getLatestServiceState(t *testing.T) {
 						},
 						Replicas: 1,
 					},
+					"svc2": {
+						Labels: Labels{
+							DocoCDLabels.Repository.Name:        "repo-2",
+							DocoCDLabels.Deployment.Timestamp:   "2016-01-02T15:04:05Z07:00",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha2",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash2",
+						},
+						Replicas: 1,
+					},
 				},
 			},
 		},
 		{
+			// Containers without a cd.doco.repository.name label contribute no metadata but
+			// are still counted as deployed so CheckServiceMismatch does not flag them.
 			name: "two service with timestamp but repo mismatch",
 			serviceStatus: map[Service]ServiceStatus{
 				"svc1": {
@@ -248,7 +278,26 @@ func Test_getLatestServiceState(t *testing.T) {
 			},
 			repoName: "repo",
 			want: LatestServiceStatus{
-				DeployedStatus: map[Service]ServiceStatus{},
+				deploymentCommitSHA:   "",
+				deploymentComposeHash: "",
+				DeployedStatus: map[Service]ServiceStatus{
+					"svc1": {
+						Labels: Labels{
+							DocoCDLabels.Deployment.Timestamp:   "2006-01-02T15:04:05Z07:00",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha1",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash1",
+						},
+						Replicas: 1,
+					},
+					"svc2": {
+						Labels: Labels{
+							DocoCDLabels.Deployment.Timestamp:   "2016-01-02T15:04:05Z07:00",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha2",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash2",
+						},
+						Replicas: 1,
+					},
+				},
 			},
 		},
 		{
@@ -294,6 +343,49 @@ func Test_getLatestServiceState(t *testing.T) {
 							DocoCDLabels.Deployment.CommitSHA:   "commit_sha1",
 							DocoCDLabels.Deployment.ComposeHash: "compose_hash1",
 						},
+						Replicas: 1,
+					},
+				},
+			},
+		},
+		{
+			// Regression test: containers that have no cd.doco.* labels at all (e.g. recreated
+			// via the Docker CLI directly or started before doco-cd first deployed the stack)
+			// must still appear in DeployedStatus so CheckServiceMismatch does not produce a
+			// false "service not deployed" mismatch and trigger an infinite redeployment loop.
+			name: "some services missing cd.doco.* labels entirely",
+			serviceStatus: map[Service]ServiceStatus{
+				"labeled": {
+					Labels: Labels{
+						DocoCDLabels.Repository.Name:        "repo",
+						DocoCDLabels.Deployment.Timestamp:   "2026-01-01T00:00:00Z",
+						DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+						DocoCDLabels.Deployment.ComposeHash: "compose_hash",
+					},
+					Replicas: 1,
+				},
+				"unlabeled": {
+					// No cd.doco.* labels — simulates a container recreated outside doco-cd.
+					Labels:   Labels{},
+					Replicas: 1,
+				},
+			},
+			repoName: "repo",
+			want: LatestServiceStatus{
+				deploymentCommitSHA:   "commit_sha",
+				deploymentComposeHash: "compose_hash",
+				DeployedStatus: map[Service]ServiceStatus{
+					"labeled": {
+						Labels: Labels{
+							DocoCDLabels.Repository.Name:        "repo",
+							DocoCDLabels.Deployment.Timestamp:   "2026-01-01T00:00:00Z",
+							DocoCDLabels.Deployment.CommitSHA:   "commit_sha",
+							DocoCDLabels.Deployment.ComposeHash: "compose_hash",
+						},
+						Replicas: 1,
+					},
+					"unlabeled": {
+						Labels:   Labels{},
 						Replicas: 1,
 					},
 				},


### PR DESCRIPTION
## Problem

When a container belonging to a doco-cd-managed stack is missing `cd.doco.*` labels, doco-cd enters an infinite redeployment loop on every reconciliation cycle. I encountered this problem when I manually restarted the postgres container in one of my compose stacks to perform a major upgrade. This was before the v0.82.0 update which added periodic reconciliation. After updating to v0.82.0 I got a notification every 60s, that changes were detected and the stack needs to be redeployed.

This happens because `getLatestServiceStatus` uses the `cd.doco.repository.name` label as a gate for **both** concerns:

1. Selecting deployment metadata (latest commit SHA, compose hash)
2. Building the running service inventory (`DeployedStatus`)

Containers without the label are silently excluded from `DeployedStatus`. `CheckServiceMismatch` then reports them as `"service not deployed"`, which causes `shouldSkipDeployment` to return `false`. Since the container spec has not actually changed, Docker Compose does not recreate the container, so the labels are never stamped and the loop continues indefinitely.

## How to reproduce

1. Have a stack managed by doco-cd with `restart: always` or `restart: unless-stopped` services.
2. Recreate one of its containers outside of doco-cd (e.g. `docker compose up -d <service>` run directly on the host, or `docker rm -f <container>` followed by a manual `docker compose up`).
3. Make sure no compose spec change exists that would cause doco-cd to recreate the container on its own.
4. Enable the reconciliation interval (`reconciliation.interval > 0`).
5. Observe doco-cd attempting a redeployment on every poll cycle.

## Fix

Decouple the two concerns in `getLatestServiceStatus`:

- **`DeployedStatus`**: populated from *all* containers returned by `getDeployStatus` (already scoped to the project via `com.docker.compose.project=<name>`). No `cd.doco.*` label required.
- **Metadata** (commit SHA, compose hash): still selected only from containers that carry a matching `cd.doco.repository.name` label, preserving the existing semantics.

I'm not 100% sure that this proposed fix is the ideal solution for the observed problem, one could argue that when doing gitops you're simply not supposed to manually mess with the containers. Maybe you have a better/different solution for this, then feel free to close this PR.

---
> Disclaimer: The root cause analysis, fix, and unit tests were developed with AI assistance. I manually reviewed and validated the fix in my real deployment environment to confirm it resolves the issue.
