### PR TITLE
feat(external-secrets): add client-side caching for 1Password secrets

### DIFF
--- a/internal/secretprovider/1password/client.go
+++ b/internal/secretprovider/1password/client.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/1password/onepassword-sdk-go"
 
@@ -21,6 +23,16 @@ type Provider struct {
 	Client      *onepassword.Client
 	accessToken string
 	version     string
+
+	cacheEnabled bool
+	cacheTTL     time.Duration
+	cacheMu      sync.RWMutex
+	cache        map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	value     string
+	expiresAt time.Time
 }
 
 func (p *Provider) Name() string {
@@ -28,7 +40,7 @@ func (p *Provider) Name() string {
 }
 
 // NewProvider creates a new Provider instance for 1Password and performs login using the provided service account token.
-func NewProvider(ctx context.Context, accessToken, version string) (*Provider, error) {
+func NewProvider(ctx context.Context, accessToken, version string, cacheEnabled bool, cacheTTL time.Duration) (*Provider, error) {
 	client, err := onepassword.NewClient(
 		ctx,
 		onepassword.WithServiceAccountToken(accessToken),
@@ -38,14 +50,21 @@ func NewProvider(ctx context.Context, accessToken, version string) (*Provider, e
 		return nil, err
 	}
 
-	provider := &Provider{Client: client, accessToken: accessToken, version: version}
+	provider := &Provider{
+		Client:       client,
+		accessToken:  accessToken,
+		version:      version,
+		cacheEnabled: cacheEnabled,
+		cacheTTL:     cacheTTL,
+		cache:        make(map[string]cacheEntry),
+	}
 
 	return provider, nil
 }
 
 // renewSession renews the session for the Provider Client by creating a new Client instance with the same access token and version.
 func renewSession(ctx context.Context, p *Provider) error {
-	newProvider, err := NewProvider(ctx, p.accessToken, p.version)
+	newProvider, err := NewProvider(ctx, p.accessToken, p.version, p.cacheEnabled, p.cacheTTL)
 	if err != nil {
 		return fmt.Errorf("failed to renew secret provider client session: %w", err)
 	}
@@ -56,10 +75,52 @@ func renewSession(ctx context.Context, p *Provider) error {
 	return nil
 }
 
+func (p *Provider) getCachedSecret(uri string) (string, bool) {
+	if !p.cacheEnabled {
+		return "", false
+	}
+
+	now := time.Now()
+
+	p.cacheMu.RLock()
+	entry, ok := p.cache[uri]
+	p.cacheMu.RUnlock()
+
+	if !ok {
+		return "", false
+	}
+
+	if now.After(entry.expiresAt) {
+		p.cacheMu.Lock()
+		if current, exists := p.cache[uri]; exists && now.After(current.expiresAt) {
+			delete(p.cache, uri)
+		}
+		p.cacheMu.Unlock()
+
+		return "", false
+	}
+
+	return entry.value, true
+}
+
+func (p *Provider) setCachedSecret(uri, value string) {
+	if !p.cacheEnabled {
+		return
+	}
+
+	p.cacheMu.Lock()
+	p.cache[uri] = cacheEntry{value: value, expiresAt: time.Now().Add(p.cacheTTL)}
+	p.cacheMu.Unlock()
+}
+
 // GetSecret retrieves a secret value from 1Password using the provided URI.
 func (p *Provider) GetSecret(ctx context.Context, uri string) (string, error) {
 	if err := onepassword.Secrets.ValidateSecretReference(ctx, uri); err != nil {
 		return "", err
+	}
+
+	if cachedSecret, ok := p.getCachedSecret(uri); ok {
+		return cachedSecret, nil
 	}
 
 	secret, err := p.Client.Secrets().Resolve(ctx, uri)
@@ -79,6 +140,8 @@ func (p *Provider) GetSecret(ctx context.Context, uri string) (string, error) {
 		}
 	}
 
+	p.setCachedSecret(uri, secret)
+
 	return secret, nil
 }
 
@@ -90,7 +153,23 @@ func (p *Provider) GetSecrets(ctx context.Context, uris []string) (map[string]st
 		}
 	}
 
-	secrets, err := p.Client.Secrets().ResolveAll(ctx, uris)
+	result := make(map[string]string, len(uris))
+	missing := make([]string, 0, len(uris))
+
+	for _, uri := range uris {
+		if cachedSecret, ok := p.getCachedSecret(uri); ok {
+			result[uri] = cachedSecret
+			continue
+		}
+
+		missing = append(missing, uri)
+	}
+
+	if len(missing) == 0 {
+		return result, nil
+	}
+
+	secrets, err := p.Client.Secrets().ResolveAll(ctx, missing)
 	if err != nil {
 		if strings.Contains(err.Error(), ErrInvalidClientID.Error()) {
 			// Attempt to renew session and retry
@@ -98,7 +177,7 @@ func (p *Provider) GetSecrets(ctx context.Context, uris []string) (map[string]st
 				return nil, fmt.Errorf("failed to renew secret provider client session: %w", err)
 			}
 
-			secrets, err = p.Client.Secrets().ResolveAll(ctx, uris)
+			secrets, err = p.Client.Secrets().ResolveAll(ctx, missing)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve secrets after renewing session: %w", err)
 			}
@@ -107,13 +186,13 @@ func (p *Provider) GetSecrets(ctx context.Context, uris []string) (map[string]st
 		}
 	}
 
-	result := make(map[string]string, len(secrets.IndividualResponses))
 	for uri, secret := range secrets.IndividualResponses {
 		if secret.Error != nil {
 			return nil, fmt.Errorf("error resolving secret '%s': %s", uri, secret.Error.Type)
 		}
 
 		result[uri] = secret.Content.Secret
+		p.setCachedSecret(uri, secret.Content.Secret)
 	}
 
 	return result, nil

--- a/internal/secretprovider/1password/client_cache_test.go
+++ b/internal/secretprovider/1password/client_cache_test.go
@@ -1,0 +1,47 @@
+package onepassword
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProviderCache_GetAndExpire(t *testing.T) {
+	provider := &Provider{
+		cacheEnabled: true,
+		cacheTTL:     15 * time.Millisecond,
+		cache:        make(map[string]cacheEntry),
+	}
+
+	provider.setCachedSecret("op://vault/item/field", "cached-value")
+
+	value, ok := provider.getCachedSecret("op://vault/item/field")
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+
+	if value != "cached-value" {
+		t.Fatalf("expected cached value, got %q", value)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	_, ok = provider.getCachedSecret("op://vault/item/field")
+	if ok {
+		t.Fatal("expected cache miss after ttl expiration")
+	}
+}
+
+func TestProviderCache_Disabled(t *testing.T) {
+	provider := &Provider{
+		cacheEnabled: false,
+		cacheTTL:     time.Minute,
+		cache:        make(map[string]cacheEntry),
+	}
+
+	provider.setCachedSecret("op://vault/item/field", "cached-value")
+
+	_, ok := provider.getCachedSecret("op://vault/item/field")
+	if ok {
+		t.Fatal("expected cache miss when cache is disabled")
+	}
+}

--- a/internal/secretprovider/1password/client_test.go
+++ b/internal/secretprovider/1password/client_test.go
@@ -52,7 +52,7 @@ func TestProvider_GetSecret_OnePassword(t *testing.T) {
 		t.Fatalf("unable to get config: %v", err)
 	}
 
-	provider, err := NewProvider(t.Context(), cfg.AccessToken, "test")
+	provider, err := NewProvider(t.Context(), cfg.AccessToken, "test", cfg.CacheEnabled, cfg.CacheTTL)
 	if err != nil {
 		t.Fatalf("Failed to create OnePassword provider: %v", err)
 	}

--- a/internal/secretprovider/1password/config.go
+++ b/internal/secretprovider/1password/config.go
@@ -2,13 +2,16 @@ package onepassword
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/kimdre/doco-cd/internal/config"
 )
 
 type Config struct {
-	AccessToken     string `env:"SECRET_PROVIDER_ACCESS_TOKEN" validate:"nonzero"` // #nosec G117 -- Access token for authenticating with the secret provider
-	AccessTokenFile string `env:"SECRET_PROVIDER_ACCESS_TOKEN_FILE,file"`          // Path to a file containing the access token
+	AccessToken     string        `env:"SECRET_PROVIDER_ACCESS_TOKEN" validate:"nonzero"`           // #nosec G117 -- Access token for authenticating with the secret provider
+	AccessTokenFile string        `env:"SECRET_PROVIDER_ACCESS_TOKEN_FILE,file"`                    // Path to a file containing the access token
+	CacheEnabled    bool          `env:"SECRET_PROVIDER_CACHE_ENABLED,notEmpty" envDefault:"false"` // Enables in-memory caching for resolved secrets
+	CacheTTL        time.Duration `env:"SECRET_PROVIDER_CACHE_TTL,notEmpty" envDefault:"5m"`        // Cache TTL for resolved secrets
 }
 
 // GetConfig retrieves and parses the configuration for the Bitwarden Secrets Manager from environment variables.
@@ -22,6 +25,10 @@ func GetConfig() (*Config, error) {
 	err := config.ParseConfigFromEnv(&cfg, &mappings)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", config.ErrParseConfigFailed, err)
+	}
+
+	if cfg.CacheEnabled && cfg.CacheTTL <= 0 {
+		return nil, fmt.Errorf("%w: SECRET_PROVIDER_CACHE_TTL must be greater than 0 when cache is enabled", config.ErrParseConfigFailed)
 	}
 
 	return &cfg, nil

--- a/internal/secretprovider/1password/config_test.go
+++ b/internal/secretprovider/1password/config_test.go
@@ -1,0 +1,65 @@
+package onepassword
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kimdre/doco-cd/internal/config"
+)
+
+func TestGetConfig_DefaultCacheSettings(t *testing.T) {
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "test-token") // #nosec G101
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "")
+
+	cfg, err := GetConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if cfg.CacheEnabled {
+		t.Fatalf("expected cache to be disabled by default")
+	}
+
+	if cfg.CacheTTL != 5*time.Minute {
+		t.Fatalf("expected default cache ttl 5m, got %s", cfg.CacheTTL)
+	}
+}
+
+func TestGetConfig_DisabledCacheAllowsZeroTTL(t *testing.T) {
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "test-token") // #nosec G101
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "false")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "0s")
+
+	cfg, err := GetConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if cfg.CacheEnabled {
+		t.Fatalf("expected cache to be disabled")
+	}
+
+	if cfg.CacheTTL != 0 {
+		t.Fatalf("expected cache ttl 0s, got %s", cfg.CacheTTL)
+	}
+}
+
+func TestGetConfig_EnabledCacheRequiresPositiveTTL(t *testing.T) {
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "test-token") // #nosec G101
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "true")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "0s")
+
+	_, err := GetConfig()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, config.ErrParseConfigFailed) {
+		t.Fatalf("expected ErrParseConfigFailed, got %v", err)
+	}
+}

--- a/internal/secretprovider/secretprovider.go
+++ b/internal/secretprovider/secretprovider.go
@@ -81,7 +81,7 @@ func Initialize(ctx context.Context, provider, version string) (SecretProvider, 
 			return nil, cfgErr
 		}
 
-		p, err = onepassword.NewProvider(ctx, cfg.AccessToken, version)
+		p, err = onepassword.NewProvider(ctx, cfg.AccessToken, version, cfg.CacheEnabled, cfg.CacheTTL)
 	case infisical.Name:
 		cfg, cfgErr := infisical.GetConfig()
 		if cfgErr != nil {

--- a/wiki/docs/External-Secrets/1Password.md
+++ b/wiki/docs/External-Secrets/1Password.md
@@ -20,6 +20,9 @@ To use 1Password, you need to set the following environment variables:
 | `SECRET_PROVIDER_ACCESS_TOKEN`      | Access token of a service account, see [the docs](https://developer.1password.com/docs/service-accounts/security/) and [here](https://developer.1password.com/docs/sdks/setup-tutorial/#part-1-set-up-a-1password-service-account) |
 | `SECRET_PROVIDER_ACCESS_TOKEN_FILE` | Path to the file containing the access token inside the container                                                                                                                                                                  |
 
+!!! tip "API Rate Limit"
+    If you hit the API rate limit, you can also enable client-side caching for resolved secrets. See the [Client-Side Caching](#client-side-caching) section below for more details.
+
 ## Deployment configuration
 
 Add a mapping/reference between the environment variable you want to set in the docker compose project/stack and the URI to the secret in 1Password.
@@ -44,3 +47,14 @@ name: myapp
 external_secrets:
   DB_PASSWORD: "op://vault/item/field"
 ```
+
+## Client-Side Caching
+
+Optional client-side caching reduces 1Password API calls. Enable and configure caching with the following environment variables:
+
+| Key                             | Value                                                                                   | Default |
+|---------------------------------|-----------------------------------------------------------------------------------------|:--------|
+| `SECRET_PROVIDER_CACHE_ENABLED` | Enables in-memory caching for resolved secrets                                          | `false` |
+| `SECRET_PROVIDER_CACHE_TTL`     | Cache TTL for resolved secrets as a Go duration string (for example: `30s`, `5m`, `1h`) | `5m`    |
+
+!!! warning "If the cache TTL is too long, secrets may become outdated."


### PR DESCRIPTION
This PR adds optional client-side caching to reduce 1Password API calls. Enable and configure caching with the following environment variables:

| Key                             | Value                                                                                   | Default |
|---------------------------------|-----------------------------------------------------------------------------------------|:--------|
| `SECRET_PROVIDER_CACHE_ENABLED` | Enables in-memory caching for resolved secrets                                          | `false` |
| `SECRET_PROVIDER_CACHE_TTL`     | Cache TTL for resolved secrets as a Go duration string (for example: `30s`, `5m`, `1h`) | `5m`    |

> [!WARNING] 
> If the cache TTL is too long, secrets may become outdated.

Related to #1283