### PR TITLE
feat(external-secrets): add support for 1Password Connect Server 

### DIFF
--- a/dev.compose.yaml
+++ b/dev.compose.yaml
@@ -23,7 +23,7 @@ services:
       proxy:
         condition: "service_started"
       apprise:
-        condition: "service_started"
+        condition: "service_healthy"
         required: false
     ports:
       - "80:80"
@@ -74,10 +74,11 @@ services:
       TZ: Europe/Berlin
       APPRISE_WORKER_COUNT: 1
     #healthcheck:
-    #  test: [ "CMD", "curl", "-f", "http://localhost:8000/" ]
-    #  interval: 2s
+    #  test: [ "CMD-SHELL", "curl -fsS http://localhost:8000/status >/dev/null || exit 1" ]
+    #  interval: 30s
     #  timeout: 5s
-    #  retries: 10
+    #  retries: 3
+    #  start_period: 20s
 
   grafana:
     # Dashboard: https://github.com/kimdre/doco-cd/discussions/583

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	filippo.io/age v1.3.1 // indirect
 	filippo.io/edwards25519 v1.1.1 // indirect
 	filippo.io/hpke v0.4.0 // indirect
+	github.com/1Password/connect-sdk-go v1.5.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
@@ -211,6 +212,7 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/onsi/gomega v1.37.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/oracle/oci-go-sdk/v65 v65.95.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
@@ -245,6 +247,8 @@ require (
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 // indirect
 	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
 	github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/urfave/cli v1.22.17 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
@@ -270,6 +274,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/mod v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
 filippo.io/hpke v0.4.0/go.mod h1:EmAN849/P3qdeK+PCMkDpDm83vRHM5cDipBJ8xbQLVY=
+github.com/1Password/connect-sdk-go v1.5.3 h1:KyjJ+kCKj6BwB2Y8tPM1Ixg5uIS6HsB0uWA8U38p/Uk=
+github.com/1Password/connect-sdk-go v1.5.3/go.mod h1:5rSymY4oIYtS4G3t0oMkGAXBeoYiukV3vkqlnEjIDJs=
 github.com/1password/onepassword-sdk-go v0.4.0 h1:Nou39yuC6Q0om03irkh5UurfPdX3wx26qZZhQeC9TBU=
 github.com/1password/onepassword-sdk-go v0.4.0/go.mod h1:j/CbzhucTywjlYrd6SE6k0LcQaFZ2l8OLBsAsOYtvD0=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -588,6 +590,8 @@ github.com/opencontainers/runtime-spec v1.3.0 h1:YZupQUdctfhpZy3TM39nN9Ika5CBWT5
 github.com/opencontainers/runtime-spec v1.3.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.13.1 h1:A8nNeceYngH9Ow++M+VVEwJVpdFmrlxsN22F+ISDCJE=
 github.com/opencontainers/selinux v1.13.1/go.mod h1:S10WXZ/osk2kWOYKy1x2f/eXF5ZHJoUs8UU/2caNRbg=
+github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
+github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/oracle/oci-go-sdk/v65 v65.95.2 h1:0HJ0AgpLydp/DtvYrF2d4str2BjXOVAeNbuW7E07g94=
 github.com/oracle/oci-go-sdk/v65 v65.95.2/go.mod h1:u6XRPsw9tPziBh76K7GrrRXPa8P8W3BQeqJ6ZZt9VLA=
 github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCyRCw=
@@ -710,6 +714,10 @@ github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
+github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
+github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
@@ -779,6 +787,8 @@ go.opentelemetry.io/otel/trace v1.42.0/go.mod h1:f3K9S+IFqnumBkKhRJMeaZeNk9epyhn
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=

--- a/internal/secretprovider/1password/client.go
+++ b/internal/secretprovider/1password/client.go
@@ -1,14 +1,11 @@
 package onepassword
 
 import (
+	"container/list"
 	"context"
 	"errors"
-	"fmt"
-	"strings"
 	"sync"
 	"time"
-
-	"github.com/1password/onepassword-sdk-go"
 
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
 )
@@ -19,15 +16,31 @@ const (
 
 var ErrInvalidClientID = errors.New("invalid client id")
 
+type authMode string
+
+const (
+	authModeServiceAccount authMode = "service_account"
+	authModeConnect        authMode = "connect"
+)
+
 type Provider struct {
-	Client      *onepassword.Client
-	accessToken string
-	version     string
+	mode authMode
+
+	serviceClient *serviceAccountClient
+	connectClient connectClient
+
+	accessToken  string
+	connectHost  string
+	connectToken string
+	version      string
 
 	cacheEnabled bool
 	cacheTTL     time.Duration
+	cacheMaxSize int
 	cacheMu      sync.RWMutex
 	cache        map[string]cacheEntry
+	cacheOrder   *list.List
+	cacheNodes   map[string]*list.Element
 }
 
 type cacheEntry struct {
@@ -39,40 +52,39 @@ func (p *Provider) Name() string {
 	return Name
 }
 
-// NewProvider creates a new Provider instance for 1Password and performs login using the provided service account token.
-func NewProvider(ctx context.Context, accessToken, version string, cacheEnabled bool, cacheTTL time.Duration) (*Provider, error) {
-	client, err := onepassword.NewClient(
-		ctx,
-		onepassword.WithServiceAccountToken(accessToken),
-		onepassword.WithIntegrationInfo("doco-cd", version),
-	)
-	if err != nil {
+// NewProvider creates a new Provider instance for 1Password using Connect if configured, otherwise service-account auth.
+func NewProvider(ctx context.Context, cfg *Config, version string) (*Provider, error) {
+	provider := &Provider{
+		accessToken:  cfg.AccessToken,
+		connectHost:  cfg.ConnectHost,
+		connectToken: cfg.ConnectToken,
+		version:      version,
+		cacheEnabled: cfg.CacheEnabled,
+		cacheTTL:     cfg.CacheTTL,
+		cacheMaxSize: cfg.CacheMaxSize,
+		cache:        make(map[string]cacheEntry),
+		cacheOrder:   list.New(),
+		cacheNodes:   make(map[string]*list.Element),
+	}
+
+	if cfg.UseConnect() {
+		provider.mode = authModeConnect
+		provider.cacheEnabled = false
+
+		if err := provider.initializeConnectClient(); err != nil {
+			return nil, err
+		}
+
+		return provider, nil
+	}
+
+	provider.mode = authModeServiceAccount
+
+	if err := provider.initializeServiceAccountClient(ctx); err != nil {
 		return nil, err
 	}
 
-	provider := &Provider{
-		Client:       client,
-		accessToken:  accessToken,
-		version:      version,
-		cacheEnabled: cacheEnabled,
-		cacheTTL:     cacheTTL,
-		cache:        make(map[string]cacheEntry),
-	}
-
 	return provider, nil
-}
-
-// renewSession renews the session for the Provider Client by creating a new Client instance with the same access token and version.
-func renewSession(ctx context.Context, p *Provider) error {
-	newProvider, err := NewProvider(ctx, p.accessToken, p.version, p.cacheEnabled, p.cacheTTL)
-	if err != nil {
-		return fmt.Errorf("failed to renew secret provider client session: %w", err)
-	}
-
-	// Set new client
-	p.Client = newProvider.Client
-
-	return nil
 }
 
 func (p *Provider) getCachedSecret(uri string) (string, bool) {
@@ -82,23 +94,24 @@ func (p *Provider) getCachedSecret(uri string) (string, bool) {
 
 	now := time.Now()
 
-	p.cacheMu.RLock()
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+
 	entry, ok := p.cache[uri]
-	p.cacheMu.RUnlock()
 
 	if !ok {
 		return "", false
 	}
 
 	if now.After(entry.expiresAt) {
-		p.cacheMu.Lock()
 		if current, exists := p.cache[uri]; exists && now.After(current.expiresAt) {
-			delete(p.cache, uri)
+			p.deleteCacheEntry(uri)
 		}
-		p.cacheMu.Unlock()
 
 		return "", false
 	}
+
+	p.touchCacheEntry(uri)
 
 	return entry.value, true
 }
@@ -109,35 +122,84 @@ func (p *Provider) setCachedSecret(uri, value string) {
 	}
 
 	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+
+	if p.cache == nil {
+		p.cache = make(map[string]cacheEntry)
+	}
+
+	if p.cacheOrder == nil {
+		p.cacheOrder = list.New()
+	}
+
+	if p.cacheNodes == nil {
+		p.cacheNodes = make(map[string]*list.Element)
+	}
+
+	if _, exists := p.cache[uri]; !exists && p.cacheMaxSize > 0 && len(p.cache) >= p.cacheMaxSize {
+		p.evictLeastRecentlyUsed()
+	}
+
 	p.cache[uri] = cacheEntry{value: value, expiresAt: time.Now().Add(p.cacheTTL)}
-	p.cacheMu.Unlock()
+	p.touchCacheEntry(uri)
+}
+
+func (p *Provider) touchCacheEntry(uri string) {
+	if p.cacheOrder == nil {
+		p.cacheOrder = list.New()
+	}
+
+	if p.cacheNodes == nil {
+		p.cacheNodes = make(map[string]*list.Element)
+	}
+
+	if node, ok := p.cacheNodes[uri]; ok {
+		p.cacheOrder.MoveToFront(node)
+
+		return
+	}
+
+	p.cacheNodes[uri] = p.cacheOrder.PushFront(uri)
+}
+
+func (p *Provider) deleteCacheEntry(uri string) {
+	delete(p.cache, uri)
+
+	if node, ok := p.cacheNodes[uri]; ok {
+		p.cacheOrder.Remove(node)
+		delete(p.cacheNodes, uri)
+	}
+}
+
+func (p *Provider) evictLeastRecentlyUsed() {
+	if p.cacheOrder == nil {
+		return
+	}
+
+	leastRecent := p.cacheOrder.Back()
+	if leastRecent == nil {
+		return
+	}
+
+	uri, ok := leastRecent.Value.(string)
+	if !ok {
+		p.cacheOrder.Remove(leastRecent)
+
+		return
+	}
+
+	p.deleteCacheEntry(uri)
 }
 
 // GetSecret retrieves a secret value from 1Password using the provided URI.
 func (p *Provider) GetSecret(ctx context.Context, uri string) (string, error) {
-	if err := onepassword.Secrets.ValidateSecretReference(ctx, uri); err != nil {
-		return "", err
-	}
-
 	if cachedSecret, ok := p.getCachedSecret(uri); ok {
 		return cachedSecret, nil
 	}
 
-	secret, err := p.Client.Secrets().Resolve(ctx, uri)
+	secret, err := p.resolveSecret(ctx, uri)
 	if err != nil {
-		if strings.Contains(err.Error(), ErrInvalidClientID.Error()) {
-			// Attempt to renew session and retry
-			if err = renewSession(ctx, p); err != nil {
-				return "", fmt.Errorf("failed to renew secret provider client session: %w", err)
-			}
-
-			secret, err = p.Client.Secrets().Resolve(ctx, uri)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve secret after renewing session: %w", err)
-			}
-		} else {
-			return "", err
-		}
+		return "", err
 	}
 
 	p.setCachedSecret(uri, secret)
@@ -147,12 +209,6 @@ func (p *Provider) GetSecret(ctx context.Context, uri string) (string, error) {
 
 // GetSecrets retrieves multiple secrets from 1Password using the provided list of secret references.
 func (p *Provider) GetSecrets(ctx context.Context, uris []string) (map[string]string, error) {
-	for _, uri := range uris {
-		if err := onepassword.Secrets.ValidateSecretReference(ctx, uri); err != nil {
-			return nil, err
-		}
-	}
-
 	result := make(map[string]string, len(uris))
 	missing := make([]string, 0, len(uris))
 
@@ -169,30 +225,14 @@ func (p *Provider) GetSecrets(ctx context.Context, uris []string) (map[string]st
 		return result, nil
 	}
 
-	secrets, err := p.Client.Secrets().ResolveAll(ctx, missing)
+	resolved, err := p.resolveSecrets(ctx, missing)
 	if err != nil {
-		if strings.Contains(err.Error(), ErrInvalidClientID.Error()) {
-			// Attempt to renew session and retry
-			if err = renewSession(ctx, p); err != nil {
-				return nil, fmt.Errorf("failed to renew secret provider client session: %w", err)
-			}
-
-			secrets, err = p.Client.Secrets().ResolveAll(ctx, missing)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve secrets after renewing session: %w", err)
-			}
-		} else {
-			return nil, err
-		}
+		return nil, err
 	}
 
-	for uri, secret := range secrets.IndividualResponses {
-		if secret.Error != nil {
-			return nil, fmt.Errorf("error resolving secret '%s': %s", uri, secret.Error.Type)
-		}
-
-		result[uri] = secret.Content.Secret
-		p.setCachedSecret(uri, secret.Content.Secret)
+	for uri, secret := range resolved {
+		result[uri] = secret
+		p.setCachedSecret(uri, secret)
 	}
 
 	return result, nil

--- a/internal/secretprovider/1password/client_cache_test.go
+++ b/internal/secretprovider/1password/client_cache_test.go
@@ -1,6 +1,7 @@
 package onepassword
 
 import (
+	"container/list"
 	"testing"
 	"time"
 )
@@ -9,7 +10,10 @@ func TestProviderCache_GetAndExpire(t *testing.T) {
 	provider := &Provider{
 		cacheEnabled: true,
 		cacheTTL:     15 * time.Millisecond,
+		cacheMaxSize: 100,
 		cache:        make(map[string]cacheEntry),
+		cacheOrder:   list.New(),
+		cacheNodes:   make(map[string]*list.Element),
 	}
 
 	provider.setCachedSecret("op://vault/item/field", "cached-value")
@@ -35,7 +39,10 @@ func TestProviderCache_Disabled(t *testing.T) {
 	provider := &Provider{
 		cacheEnabled: false,
 		cacheTTL:     time.Minute,
+		cacheMaxSize: 100,
 		cache:        make(map[string]cacheEntry),
+		cacheOrder:   list.New(),
+		cacheNodes:   make(map[string]*list.Element),
 	}
 
 	provider.setCachedSecret("op://vault/item/field", "cached-value")
@@ -43,5 +50,37 @@ func TestProviderCache_Disabled(t *testing.T) {
 	_, ok := provider.getCachedSecret("op://vault/item/field")
 	if ok {
 		t.Fatal("expected cache miss when cache is disabled")
+	}
+}
+
+func TestProviderCache_EvictsLeastRecentlyUsedWhenFull(t *testing.T) {
+	provider := &Provider{
+		cacheEnabled: true,
+		cacheTTL:     time.Minute,
+		cacheMaxSize: 2,
+		cache:        make(map[string]cacheEntry),
+		cacheOrder:   list.New(),
+		cacheNodes:   make(map[string]*list.Element),
+	}
+
+	provider.setCachedSecret("op://vault/item/a", "A")
+	provider.setCachedSecret("op://vault/item/b", "B")
+
+	if _, ok := provider.getCachedSecret("op://vault/item/a"); !ok {
+		t.Fatal("expected cache hit for A")
+	}
+
+	provider.setCachedSecret("op://vault/item/c", "C")
+
+	if _, ok := provider.getCachedSecret("op://vault/item/b"); ok {
+		t.Fatal("expected B to be evicted as least recently used")
+	}
+
+	if value, ok := provider.getCachedSecret("op://vault/item/a"); !ok || value != "A" {
+		t.Fatalf("expected A to remain in cache, got value=%q hit=%v", value, ok)
+	}
+
+	if value, ok := provider.getCachedSecret("op://vault/item/c"); !ok || value != "C" {
+		t.Fatalf("expected C to remain in cache, got value=%q hit=%v", value, ok)
 	}
 }

--- a/internal/secretprovider/1password/client_connect.go
+++ b/internal/secretprovider/1password/client_connect.go
@@ -3,10 +3,14 @@ package onepassword
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	connectsdk "github.com/1Password/connect-sdk-go/connect"
 	connectonepassword "github.com/1Password/connect-sdk-go/onepassword"
+	"github.com/opentracing/opentracing-go"
 )
+
+var connectGlobalTracerInit sync.Once
 
 type connectClient interface {
 	GetItem(itemQuery, vaultQuery string) (*connectonepassword.Item, error)
@@ -21,9 +25,18 @@ func (c connectSDKClient) GetItem(itemQuery, vaultQuery string) (*connectonepass
 }
 
 func (p *Provider) initializeConnectClient() error {
+	ensureConnectSDKGlobalTracerDisabled()
+
 	p.connectClient = connectSDKClient{inner: connectsdk.NewClientWithUserAgent(p.connectHost, p.connectToken, "doco-cd/"+p.version)}
 
 	return nil
+}
+
+func ensureConnectSDKGlobalTracerDisabled() {
+	connectGlobalTracerInit.Do(func() {
+		// Disable global tracing so the Connect SDK cannot initialize Jaeger tracing.
+		opentracing.SetGlobalTracer(opentracing.NoopTracer{})
+	})
 }
 
 func (p *Provider) resolveConnectSecret(_ context.Context, uri string) (string, error) {

--- a/internal/secretprovider/1password/client_connect.go
+++ b/internal/secretprovider/1password/client_connect.go
@@ -1,0 +1,104 @@
+package onepassword
+
+import (
+	"context"
+	"fmt"
+
+	connectsdk "github.com/1Password/connect-sdk-go/connect"
+	connectonepassword "github.com/1Password/connect-sdk-go/onepassword"
+)
+
+type connectClient interface {
+	GetItem(itemQuery, vaultQuery string) (*connectonepassword.Item, error)
+}
+
+type connectSDKClient struct {
+	inner connectsdk.Client
+}
+
+func (c connectSDKClient) GetItem(itemQuery, vaultQuery string) (*connectonepassword.Item, error) {
+	return c.inner.GetItem(itemQuery, vaultQuery)
+}
+
+func (p *Provider) initializeConnectClient() error {
+	p.connectClient = connectSDKClient{inner: connectsdk.NewClientWithUserAgent(p.connectHost, p.connectToken, "doco-cd/"+p.version)}
+
+	return nil
+}
+
+func (p *Provider) resolveConnectSecret(_ context.Context, uri string) (string, error) {
+	ref, err := ParseOPSecretReference(uri)
+	if err != nil {
+		return "", err
+	}
+
+	item, err := p.connectClient.GetItem(ref.Item, ref.Vault)
+	if err != nil {
+		return "", err
+	}
+
+	value, ok := findConnectFieldValue(item, ref)
+	if !ok {
+		return "", fmt.Errorf("secret field not found for reference: %s", uri)
+	}
+
+	return value, nil
+}
+
+func (p *Provider) resolveConnectSecrets(ctx context.Context, uris []string) (map[string]string, error) {
+	result := make(map[string]string, len(uris))
+
+	for _, uri := range uris {
+		secret, err := p.resolveConnectSecret(ctx, uri)
+		if err != nil {
+			return nil, err
+		}
+
+		result[uri] = secret
+	}
+
+	return result, nil
+}
+
+func findConnectFieldValue(item *connectonepassword.Item, ref *OPSecretReference) (string, bool) {
+	selector := ref.Field
+	if ref.Section != "" {
+		selector = ref.Section + "." + ref.Field
+	}
+
+	for _, field := range item.Fields {
+		if field == nil {
+			continue
+		}
+
+		if field.Label != ref.Field {
+			continue
+		}
+
+		if ref.Section != "" {
+			if field.Section == nil || field.Section.Label != ref.Section {
+				continue
+			}
+		}
+
+		if ref.Attribute == "otp" {
+			if field.TOTP == "" {
+				return "", false
+			}
+
+			return field.TOTP, true
+		}
+
+		return field.Value, true
+	}
+
+	if ref.Attribute == "otp" {
+		return "", false
+	}
+
+	if value := item.GetValue(selector); value != "" {
+		return value, true
+	}
+
+	return "", false
+}

--- a/internal/secretprovider/1password/client_connect_test.go
+++ b/internal/secretprovider/1password/client_connect_test.go
@@ -1,0 +1,122 @@
+package onepassword
+
+import (
+	"strings"
+	"testing"
+
+	connectonepassword "github.com/1Password/connect-sdk-go/onepassword"
+)
+
+type mockConnectClient struct {
+	item           *connectonepassword.Item
+	err            error
+	calls          int
+	lastItemQuery  string
+	lastVaultQuery string
+}
+
+func (m *mockConnectClient) GetItem(itemQuery, vaultQuery string) (*connectonepassword.Item, error) {
+	m.calls++
+	m.lastItemQuery = itemQuery
+	m.lastVaultQuery = vaultQuery
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return m.item, nil
+}
+
+func TestProvider_ResolveConnectSecret_FieldSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		uri           string
+		item          *connectonepassword.Item
+		expected      string
+		expectErr     bool
+		errContains   string
+		expectedItem  string
+		expectedVault string
+	}{
+		{
+			name: "section matching selects field from matching section",
+			uri:  "op://TestVault/TestItem/Production/password",
+			item: &connectonepassword.Item{
+				Fields: []*connectonepassword.ItemField{
+					{Label: "password", Value: "dev-secret", Section: &connectonepassword.ItemSection{Label: "Development"}},
+					{Label: "password", Value: "prod-secret", Section: &connectonepassword.ItemSection{Label: "Production"}},
+				},
+			},
+			expected:      "prod-secret",
+			expectedItem:  "TestItem",
+			expectedVault: "TestVault",
+		},
+		{
+			name: "otp attribute returns totp value",
+			uri:  "op://TestVault/TestItem/one-time%20password?attribute=otp",
+			item: &connectonepassword.Item{
+				Fields: []*connectonepassword.ItemField{
+					{Label: "one-time password", Value: "ignored", TOTP: "123456"},
+				},
+			},
+			expected:      "123456",
+			expectedItem:  "TestItem",
+			expectedVault: "TestVault",
+		},
+		{
+			name: "otp attribute fails when totp is missing",
+			uri:  "op://TestVault/TestItem/one-time%20password?attribute=otp",
+			item: &connectonepassword.Item{
+				Fields: []*connectonepassword.ItemField{
+					{Label: "one-time password", Value: "plain-value"},
+				},
+			},
+			expectErr:     true,
+			errContains:   "secret field not found",
+			expectedItem:  "TestItem",
+			expectedVault: "TestVault",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockConnectClient{item: tc.item}
+			provider := &Provider{connectClient: mock}
+
+			got, err := provider.resolveConnectSecret(t.Context(), tc.uri)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("expected error to contain %q, got %v", tc.errContains, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				if got != tc.expected {
+					t.Fatalf("expected %q, got %q", tc.expected, got)
+				}
+			}
+
+			if mock.calls != 1 {
+				t.Fatalf("expected connect client to be called once, got %d", mock.calls)
+			}
+
+			if mock.lastItemQuery != tc.expectedItem {
+				t.Fatalf("expected item query %q, got %q", tc.expectedItem, mock.lastItemQuery)
+			}
+
+			if mock.lastVaultQuery != tc.expectedVault {
+				t.Fatalf("expected vault query %q, got %q", tc.expectedVault, mock.lastVaultQuery)
+			}
+		})
+	}
+}

--- a/internal/secretprovider/1password/client_connect_test.go
+++ b/internal/secretprovider/1password/client_connect_test.go
@@ -2,7 +2,11 @@ package onepassword
 
 import (
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 
 	connectonepassword "github.com/1Password/connect-sdk-go/onepassword"
 )
@@ -118,5 +122,43 @@ func TestProvider_ResolveConnectSecret_FieldSelection(t *testing.T) {
 				t.Fatalf("expected vault query %q, got %q", tc.expectedVault, mock.lastVaultQuery)
 			}
 		})
+	}
+}
+
+func TestEnsureConnectSDKGlobalTracerDisabled_OverridesWithNoopTracer(t *testing.T) {
+	connectGlobalTracerInit = sync.Once{}
+
+	existingTracer := mocktracer.New()
+	opentracing.SetGlobalTracer(existingTracer)
+
+	ensureConnectSDKGlobalTracerDisabled()
+
+	if _, ok := opentracing.GlobalTracer().(opentracing.NoopTracer); !ok {
+		t.Fatal("expected global tracer to be opentracing.NoopTracer")
+	}
+}
+
+func TestProvider_InitializeConnectClient_DisablesGlobalTracing(t *testing.T) {
+	connectGlobalTracerInit = sync.Once{}
+
+	existingTracer := mocktracer.New()
+	opentracing.SetGlobalTracer(existingTracer)
+
+	provider := &Provider{
+		connectHost:  "http://op-connect-api:8080",
+		connectToken: "test-token",
+		version:      "test",
+	}
+
+	if err := provider.initializeConnectClient(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if provider.connectClient == nil {
+		t.Fatal("expected connect client to be initialized")
+	}
+
+	if _, ok := opentracing.GlobalTracer().(opentracing.NoopTracer); !ok {
+		t.Fatal("expected initializeConnectClient to set global tracer to opentracing.NoopTracer")
 	}
 }

--- a/internal/secretprovider/1password/client_resolver.go
+++ b/internal/secretprovider/1password/client_resolver.go
@@ -1,0 +1,28 @@
+package onepassword
+
+import (
+	"context"
+	"fmt"
+)
+
+func (p *Provider) resolveSecret(ctx context.Context, uri string) (string, error) {
+	switch p.mode {
+	case authModeConnect:
+		return p.resolveConnectSecret(ctx, uri)
+	case authModeServiceAccount:
+		return p.resolveServiceAccountSecret(ctx, uri)
+	default:
+		return "", fmt.Errorf("unsupported 1password auth mode: %s", p.mode)
+	}
+}
+
+func (p *Provider) resolveSecrets(ctx context.Context, uris []string) (map[string]string, error) {
+	switch p.mode {
+	case authModeConnect:
+		return p.resolveConnectSecrets(ctx, uris)
+	case authModeServiceAccount:
+		return p.resolveServiceAccountSecrets(ctx, uris)
+	default:
+		return nil, fmt.Errorf("unsupported 1password auth mode: %s", p.mode)
+	}
+}

--- a/internal/secretprovider/1password/client_service_account.go
+++ b/internal/secretprovider/1password/client_service_account.go
@@ -1,0 +1,94 @@
+package onepassword
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	opsdk "github.com/1password/onepassword-sdk-go"
+)
+
+type serviceAccountClient = opsdk.Client
+
+func (p *Provider) initializeServiceAccountClient(ctx context.Context) error {
+	client, err := opsdk.NewClient(
+		ctx,
+		opsdk.WithServiceAccountToken(p.accessToken),
+		opsdk.WithIntegrationInfo("doco-cd", p.version),
+	)
+	if err != nil {
+		return err
+	}
+
+	p.serviceClient = client
+
+	return nil
+}
+
+func (p *Provider) renewServiceAccountSession(ctx context.Context) error {
+	if err := p.initializeServiceAccountClient(ctx); err != nil {
+		return fmt.Errorf("failed to renew secret provider client session: %w", err)
+	}
+
+	return nil
+}
+
+func (p *Provider) resolveServiceAccountSecret(ctx context.Context, uri string) (string, error) {
+	if err := opsdk.Secrets.ValidateSecretReference(ctx, uri); err != nil {
+		return "", err
+	}
+
+	secret, err := p.serviceClient.Secrets().Resolve(ctx, uri)
+	if err != nil {
+		if strings.Contains(err.Error(), ErrInvalidClientID.Error()) {
+			if renewErr := p.renewServiceAccountSession(ctx); renewErr != nil {
+				return "", renewErr
+			}
+
+			secret, err = p.serviceClient.Secrets().Resolve(ctx, uri)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve secret after renewing session: %w", err)
+			}
+		} else {
+			return "", err
+		}
+	}
+
+	return secret, nil
+}
+
+func (p *Provider) resolveServiceAccountSecrets(ctx context.Context, uris []string) (map[string]string, error) {
+	for _, uri := range uris {
+		if err := opsdk.Secrets.ValidateSecretReference(ctx, uri); err != nil {
+			return nil, err
+		}
+	}
+
+	secrets, err := p.serviceClient.Secrets().ResolveAll(ctx, uris)
+	if err != nil {
+		if strings.Contains(err.Error(), ErrInvalidClientID.Error()) {
+			if renewErr := p.renewServiceAccountSession(ctx); renewErr != nil {
+				return nil, renewErr
+			}
+
+			secrets, err = p.serviceClient.Secrets().ResolveAll(ctx, uris)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve secrets after renewing session: %w", err)
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	result := make(map[string]string, len(uris))
+
+	for uri, secret := range secrets.IndividualResponses {
+		if secret.Error != nil {
+			return nil, fmt.Errorf("error resolving secret '%s': %s", uri, secret.Error.Type)
+		}
+
+		result[uri] = secret.Content.Secret
+	}
+
+	return result, nil
+}

--- a/internal/secretprovider/1password/client_test.go
+++ b/internal/secretprovider/1password/client_test.go
@@ -52,7 +52,7 @@ func TestProvider_GetSecret_OnePassword(t *testing.T) {
 		t.Fatalf("unable to get config: %v", err)
 	}
 
-	provider, err := NewProvider(t.Context(), cfg.AccessToken, "test", cfg.CacheEnabled, cfg.CacheTTL)
+	provider, err := NewProvider(t.Context(), cfg, "test")
 	if err != nil {
 		t.Fatalf("Failed to create OnePassword provider: %v", err)
 	}

--- a/internal/secretprovider/1password/config.go
+++ b/internal/secretprovider/1password/config.go
@@ -8,10 +8,18 @@ import (
 )
 
 type Config struct {
-	AccessToken     string        `env:"SECRET_PROVIDER_ACCESS_TOKEN" validate:"nonzero"`           // #nosec G117 -- Access token for authenticating with the secret provider
-	AccessTokenFile string        `env:"SECRET_PROVIDER_ACCESS_TOKEN_FILE,file"`                    // Path to a file containing the access token
-	CacheEnabled    bool          `env:"SECRET_PROVIDER_CACHE_ENABLED,notEmpty" envDefault:"false"` // Enables in-memory caching for resolved secrets
-	CacheTTL        time.Duration `env:"SECRET_PROVIDER_CACHE_TTL,notEmpty" envDefault:"5m"`        // Cache TTL for resolved secrets
+	AccessToken      string        `env:"SECRET_PROVIDER_ACCESS_TOKEN"`                                              // #nosec G117 -- Access token for authenticating with the secret provider
+	AccessTokenFile  string        `env:"SECRET_PROVIDER_ACCESS_TOKEN_FILE,file"`                                    // Path to a file containing the access token
+	ConnectHost      string        `env:"SECRET_PROVIDER_CONNECT_HOST"`                                              // Base URL of the 1Password Connect API
+	ConnectToken     string        `env:"SECRET_PROVIDER_CONNECT_TOKEN"`                                             // #nosec G117 -- Access token for authenticating with the Connect API
+	ConnectTokenFile string        `env:"SECRET_PROVIDER_CONNECT_TOKEN_FILE,file"`                                   // Path to a file containing the Connect API token
+	CacheEnabled     bool          `env:"SECRET_PROVIDER_CACHE_ENABLED,notEmpty" envDefault:"false"`                 // Enables in-memory caching for resolved secrets
+	CacheTTL         time.Duration `env:"SECRET_PROVIDER_CACHE_TTL,notEmpty" envDefault:"5m"`                        // Cache TTL for resolved secrets
+	CacheMaxSize     int           `env:"SECRET_PROVIDER_CACHE_MAX_SIZE,notEmpty" envDefault:"100" validate:"min=1"` // Maximum number of secrets stored in the in-memory cache
+}
+
+func (c Config) UseConnect() bool {
+	return c.ConnectHost != "" && c.ConnectToken != ""
 }
 
 // GetConfig retrieves and parses the configuration for the Bitwarden Secrets Manager from environment variables.
@@ -19,12 +27,31 @@ func GetConfig() (*Config, error) {
 	cfg := Config{}
 
 	mappings := []config.EnvVarFileMapping{
-		{EnvName: "SECRET_PROVIDER_ACCESS_TOKEN", EnvValue: &cfg.AccessToken, FileValue: &cfg.AccessTokenFile, AllowUnset: false},
+		{EnvName: "SECRET_PROVIDER_ACCESS_TOKEN", EnvValue: &cfg.AccessToken, FileValue: &cfg.AccessTokenFile, AllowUnset: true},
+		{EnvName: "SECRET_PROVIDER_CONNECT_TOKEN", EnvValue: &cfg.ConnectToken, FileValue: &cfg.ConnectTokenFile, AllowUnset: true},
 	}
 
 	err := config.ParseConfigFromEnv(&cfg, &mappings)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", config.ErrParseConfigFailed, err)
+	}
+
+	connectHostSet := cfg.ConnectHost != ""
+	connectTokenSet := cfg.ConnectToken != ""
+
+	if connectHostSet != connectTokenSet {
+		return nil, fmt.Errorf("%w: SECRET_PROVIDER_CONNECT_HOST and SECRET_PROVIDER_CONNECT_TOKEN (or SECRET_PROVIDER_CONNECT_TOKEN_FILE) must be set together", config.ErrParseConfigFailed)
+	}
+
+	if cfg.UseConnect() {
+		// Connect Server already caches vault data, so disable local cache in this mode.
+		cfg.CacheEnabled = false
+
+		return &cfg, nil
+	}
+
+	if cfg.AccessToken == "" {
+		return nil, fmt.Errorf("%w: SECRET_PROVIDER_ACCESS_TOKEN (or SECRET_PROVIDER_ACCESS_TOKEN_FILE) is required when SECRET_PROVIDER_CONNECT_HOST/SECRET_PROVIDER_CONNECT_TOKEN are not set", config.ErrParseConfigFailed)
 	}
 
 	if cfg.CacheEnabled && cfg.CacheTTL <= 0 {

--- a/internal/secretprovider/1password/config_test.go
+++ b/internal/secretprovider/1password/config_test.go
@@ -2,6 +2,7 @@ package onepassword
 
 import (
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -11,8 +12,12 @@ import (
 func TestGetConfig_DefaultCacheSettings(t *testing.T) {
 	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "test-token") // #nosec G101
 	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("OP_CONNECT_HOST", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN_FILE", "")
 	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "")
 	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "")
 
 	cfg, err := GetConfig()
 	if err != nil {
@@ -26,13 +31,25 @@ func TestGetConfig_DefaultCacheSettings(t *testing.T) {
 	if cfg.CacheTTL != 5*time.Minute {
 		t.Fatalf("expected default cache ttl 5m, got %s", cfg.CacheTTL)
 	}
+
+	if cfg.CacheMaxSize != 100 {
+		t.Fatalf("expected default cache max size 100, got %d", cfg.CacheMaxSize)
+	}
+
+	if cfg.UseConnect() {
+		t.Fatal("expected service-account mode by default")
+	}
 }
 
 func TestGetConfig_DisabledCacheAllowsZeroTTL(t *testing.T) {
 	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "test-token") // #nosec G101
 	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("OP_CONNECT_HOST", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN_FILE", "")
 	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "false")
 	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "0s")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "100")
 
 	cfg, err := GetConfig()
 	if err != nil {
@@ -51,8 +68,153 @@ func TestGetConfig_DisabledCacheAllowsZeroTTL(t *testing.T) {
 func TestGetConfig_EnabledCacheRequiresPositiveTTL(t *testing.T) {
 	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "test-token") // #nosec G101
 	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("OP_CONNECT_HOST", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN_FILE", "")
 	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "true")
 	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "0s")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "100")
+
+	_, err := GetConfig()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, config.ErrParseConfigFailed) {
+		t.Fatalf("expected ErrParseConfigFailed, got %v", err)
+	}
+}
+
+func TestGetConfig_ConnectModeWithToken(t *testing.T) {
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_HOST", "http://op-connect-api:8080")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN", "connect-token") // #nosec G101
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "true")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "5m")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "100")
+
+	cfg, err := GetConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !cfg.UseConnect() {
+		t.Fatal("expected connect mode")
+	}
+
+	if cfg.CacheEnabled {
+		t.Fatal("expected cache to be disabled in connect mode")
+	}
+}
+
+func TestGetConfig_ConnectModeWithTokenFile(t *testing.T) {
+	tokenFile, err := os.CreateTemp(t.TempDir(), "op-connect-token")
+	if err != nil {
+		t.Fatalf("failed to create temp token file: %v", err)
+	}
+
+	if _, err = tokenFile.WriteString("connect-token"); err != nil {
+		t.Fatalf("failed to write temp token file: %v", err)
+	}
+
+	if err = tokenFile.Close(); err != nil {
+		t.Fatalf("failed to close temp token file: %v", err)
+	}
+
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_HOST", "http://op-connect-api:8080")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN_FILE", tokenFile.Name()) // #nosec G101
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "false")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "5m")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "100")
+
+	cfg, err := GetConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !cfg.UseConnect() {
+		t.Fatal("expected connect mode")
+	}
+}
+
+func TestGetConfig_ConnectModeRequiresBothHostAndToken(t *testing.T) {
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_HOST", "http://op-connect-api:8080")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "false")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "5m")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "100")
+
+	_, err := GetConfig()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, config.ErrParseConfigFailed) {
+		t.Fatalf("expected ErrParseConfigFailed, got %v", err)
+	}
+}
+
+func TestGetConfig_ConnectPreferredOverServiceAccount(t *testing.T) {
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "service-token") // #nosec G101
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_HOST", "http://op-connect-api:8080")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN", "connect-token") // #nosec G101
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "true")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "5m")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "100")
+
+	cfg, err := GetConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !cfg.UseConnect() {
+		t.Fatal("expected connect mode to be preferred")
+	}
+
+	if cfg.CacheEnabled {
+		t.Fatal("expected cache to be disabled in connect mode")
+	}
+}
+
+func TestGetConfig_ServiceAccountRequiredWithoutConnect(t *testing.T) {
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_HOST", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN", "")
+	t.Setenv("SECRET_PROVIDER_CONNECT_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "false")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "5m")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "100")
+
+	_, err := GetConfig()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, config.ErrParseConfigFailed) {
+		t.Fatalf("expected ErrParseConfigFailed, got %v", err)
+	}
+}
+
+func TestGetConfig_CacheMaxSizeRequiresMinimumOfOne(t *testing.T) {
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN", "test-token") // #nosec G101
+	t.Setenv("SECRET_PROVIDER_ACCESS_TOKEN_FILE", "")
+	t.Setenv("OP_CONNECT_HOST", "")
+	t.Setenv("OP_CONNECT_TOKEN", "")
+	t.Setenv("OP_CONNECT_TOKEN_FILE", "")
+	t.Setenv("SECRET_PROVIDER_CACHE_ENABLED", "true")
+	t.Setenv("SECRET_PROVIDER_CACHE_TTL", "5m")
+	t.Setenv("SECRET_PROVIDER_CACHE_MAX_SIZE", "0")
 
 	_, err := GetConfig()
 	if err == nil {

--- a/internal/secretprovider/1password/connect_ref.go
+++ b/internal/secretprovider/1password/connect_ref.go
@@ -1,0 +1,78 @@
+package onepassword
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type OPSecretReference struct {
+	Vault     string
+	Item      string
+	Section   string
+	Field     string
+	Attribute string
+}
+
+func ParseOPSecretReference(ref string) (*OPSecretReference, error) {
+	parsed, err := url.Parse(ref)
+	if err != nil {
+		return nil, fmt.Errorf("invalid secret reference: %w", err)
+	}
+
+	if parsed.Scheme != "op" {
+		return nil, fmt.Errorf("invalid secret reference scheme: %s", parsed.Scheme)
+	}
+
+	vault, err := url.PathUnescape(parsed.Host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode vault segment: %w", err)
+	}
+
+	if strings.TrimSpace(vault) == "" {
+		return nil, errors.New("invalid secret reference: vault segment is required")
+	}
+
+	segments, err := parseReferencePathSegments(parsed.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	attribute := strings.TrimSpace(parsed.Query().Get("attribute"))
+	if attribute != "" && attribute != "otp" {
+		return nil, fmt.Errorf("unsupported secret reference attribute: %s", attribute)
+	}
+
+	out := &OPSecretReference{Vault: vault, Item: segments[0], Field: segments[len(segments)-1], Attribute: attribute}
+	if len(segments) == 3 {
+		out.Section = segments[1]
+	}
+
+	return out, nil
+}
+
+func parseReferencePathSegments(path string) ([]string, error) {
+	trimmed := strings.Trim(path, "/")
+
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 && len(parts) != 3 {
+		return nil, errors.New("invalid secret reference path: expected item/field or item/section/field")
+	}
+
+	segments := make([]string, 0, len(parts))
+	for _, part := range parts {
+		decoded, err := url.PathUnescape(part)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode secret reference segment: %w", err)
+		}
+
+		if strings.TrimSpace(decoded) == "" {
+			return nil, errors.New("invalid secret reference path: empty segment")
+		}
+
+		segments = append(segments, decoded)
+	}
+
+	return segments, nil
+}

--- a/internal/secretprovider/1password/connect_ref_test.go
+++ b/internal/secretprovider/1password/connect_ref_test.go
@@ -1,0 +1,80 @@
+package onepassword
+
+import "testing"
+
+func TestParseOPSecretReference(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		ref       string
+		wantVault string
+		wantItem  string
+		wantSect  string
+		wantField string
+		wantAttr  string
+		wantErr   bool
+	}{
+		{
+			name:      "item field",
+			ref:       "op://MyVault/MyItem/MyField",
+			wantVault: "MyVault",
+			wantItem:  "MyItem",
+			wantField: "MyField",
+		},
+		{
+			name:      "section field",
+			ref:       "op://MyVault/MyItem/MySection/MyField",
+			wantVault: "MyVault",
+			wantItem:  "MyItem",
+			wantSect:  "MySection",
+			wantField: "MyField",
+		},
+		{
+			name:      "otp attribute",
+			ref:       "op://MyVault/MyItem/one-time%20password?attribute=otp",
+			wantVault: "MyVault",
+			wantItem:  "MyItem",
+			wantField: "one-time password",
+			wantAttr:  "otp",
+		},
+		{
+			name:    "invalid scheme",
+			ref:     "http://MyVault/MyItem/MyField",
+			wantErr: true,
+		},
+		{
+			name:    "invalid path length",
+			ref:     "op://MyVault/MyItem",
+			wantErr: true,
+		},
+		{
+			name:    "unsupported attribute",
+			ref:     "op://MyVault/MyItem/MyField?attribute=foo",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseOPSecretReference(tc.ref)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected parse error")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got.Vault != tc.wantVault || got.Item != tc.wantItem || got.Section != tc.wantSect || got.Field != tc.wantField || got.Attribute != tc.wantAttr {
+				t.Fatalf("got %+v", got)
+			}
+		})
+	}
+}

--- a/internal/secretprovider/1password/testdata/.gitignore
+++ b/internal/secretprovider/1password/testdata/.gitignore
@@ -1,0 +1,1 @@
+1password-credentials.json

--- a/internal/secretprovider/1password/testdata/docker-compose.yml
+++ b/internal/secretprovider/1password/testdata/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  op-connect-api:
+    image: 1password/connect-api:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./internal/secretprovider/1password/testdata/1password-credentials.json:/home/opuser/.op/1password-credentials.json
+      - op_data:/home/opuser/.op/data
+
+  op-connect-sync:
+    image: 1password/connect-sync:latest
+    ports:
+      - "8081:8080"
+    volumes:
+      - ./internal/secretprovider/1password/testdata/1password-credentials.json:/home/opuser/.op/1password-credentials.json
+      - op_data:/home/opuser/.op/data
+
+  app: # doco-cd
+    environment:
+      SECRET_PROVIDER: 1password
+      SECRET_PROVIDER_CONNECT_HOST: http://op-connect-api:8080
+      SECRET_PROVIDER_CONNECT_TOKEN: ${SECRET_PROVIDER_CONNECT_TOKEN}
+    depends_on:
+      - op-connect-api
+
+volumes:
+  op_data:

--- a/internal/secretprovider/secretprovider.go
+++ b/internal/secretprovider/secretprovider.go
@@ -81,7 +81,7 @@ func Initialize(ctx context.Context, provider, version string) (SecretProvider, 
 			return nil, cfgErr
 		}
 
-		p, err = onepassword.NewProvider(ctx, cfg.AccessToken, version, cfg.CacheEnabled, cfg.CacheTTL)
+		p, err = onepassword.NewProvider(ctx, cfg, version)
 	case infisical.Name:
 		cfg, cfgErr := infisical.GetConfig()
 		if cfgErr != nil {

--- a/wiki/docs/Advanced/Pre-Post-Deployment-Scripts.md
+++ b/wiki/docs/Advanced/Pre-Post-Deployment-Scripts.md
@@ -19,7 +19,7 @@ Available options to run scripts/commands during deployment or container lifecyc
 - [Sidecar Containers](#sidecar-containers)
 - [Compose Lifecycle Hooks](#compose-lifecycle-hooks)
 
---8<-- "wiki/docs/_snippets/reconciliation-note.md"
+--8<-- "wiki/includes/reconciliation-note.md"
 
 ## Init Containers
 

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -233,7 +233,7 @@ The following settings can be used to configure periodic reconciliation.
 | `enabled`  | boolean | Enable periodic reconciliation.                      | `true`        |
 | `interval` | number  | The time in seconds between two reconciliation runs. | `60`          |
 
---8<-- "wiki/docs/_snippets/reconciliation-note.md"
+--8<-- "wiki/includes/reconciliation-note.md"
 
 !!! example
     ```yaml title=".doco-cd.yml"

--- a/wiki/docs/External-Secrets/1Password-Connect.md
+++ b/wiki/docs/External-Secrets/1Password-Connect.md
@@ -9,40 +9,36 @@ tags:
 
 [1Password Connect Server](https://developer.1password.com/docs/connect/) is a self-hosted proxy that caches vault data locally and serves secrets over a simple HTTP API. This is useful when you are deploying frequently or have multiple instances that would otherwise hit 1Password API rate limits.
 
-Unlike service account authentication (which makes direct calls to the 1Password cloud API), Connect Server allows you to:
+Unlike service account authentication (see the [1Password provider](1Password.md)) (which makes direct calls to the 1Password cloud API), Connect Server allows you to:
 
 - Avoid rate limiting by caching vault data locally
 - Reduce latency for secret lookups
 - Keep all secret requests within your infrastructure
 
-!!! info
-    Client-side caching is automatically disabled when using Connect Server because Connect already handles caching for you.
-
 ## Environment Variables
 
 To use 1Password Connect, configure these variables for the `doco-cd` container:
 
-| Key                                  | Value                                                                                                  |
-|--------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `SECRET_PROVIDER`                    | `1password`                                                                                            |
-| `SECRET_PROVIDER_CONNECT_HOST`       | Base URL of your Connect API Server (for example: `http://op-connect-api:8080`).                       |
-| `SECRET_PROVIDER_CONNECT_TOKEN`      | API token used by `doco-cd` to authenticate against Connect API. Generated in 1Password Connect setup. |
-| `SECRET_PROVIDER_CONNECT_TOKEN_FILE` | Path to the file containing the Connect API token inside the container.                                |
+| Key                                  | Value                                                                                                                                                                                           |
+|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SECRET_PROVIDER`                    | `1password`                                                                                                                                                                                     |
+| `SECRET_PROVIDER_CONNECT_HOST`       | Base URL of your Connect API Server (for example: `http://op-connect-api:8080`).                                                                                                                |
+| `SECRET_PROVIDER_CONNECT_TOKEN`      | API token used by `doco-cd` to authenticate against Connect API. Generated in [1Password Connect setup][1password-connect-setup]. Mutually exclusive with `SECRET_PROVIDER_CONNECT_TOKEN_FILE`. |
+| `SECRET_PROVIDER_CONNECT_TOKEN_FILE` | Path to the file containing the Connect API token inside the container. Mutually exclusive with `SECRET_PROVIDER_CONNECT_TOKEN`.                                                                |
 
-!!! info
-    Use **either** `SECRET_PROVIDER_CONNECT_TOKEN` **or** `SECRET_PROVIDER_CONNECT_TOKEN_FILE`.
-
-For the Connect containers themselves, you also need a credentials file:
-
-| File | Purpose | Source |
-|------|---------|--------|
-| `./1password-credentials.json` | Authenticates `op-connect-api`/`op-connect-sync` with your 1Password account and allows vault sync. | Downloaded from your 1Password Connect setup |
+For the Connect containers themselves, you also need a `1password-credentials.json` credentials file 
+to authenticate `op-connect-api`/`op-connect-sync` with your 1Password account and allow vault sync.
+Download it from your [1Password Connect setup][1password-connect-setup].
 
 ## Setup Steps
 
 ### Example Compose Setup
 
 Deploy 1Password Connect alongside doco-cd:
+
+- Follow the [1Password Connect Server documentation](https://developer.1password.com/docs/connect/get-started/?deploy=docker) to get your Connect server credentials and set up the `op-connect-api` and `op-connect-sync` containers.
+- For the server configuration options, refer to the [1Password Connect Server Configuration](https://developer.1password.com/docs/connect/server-configuration/) docs.
+- Place `1password-credentials.json` next to your compose file (as shown below), or adjust the bind mount path to your preferred secure location (For a token file example, see the [Using a token file](#configuring-doco-cd-to-authenticate-with-connect-server-using-a-token-file) section below).
 
 ```yaml title="docker-compose.yml" hl_lines="2-16 21-25 27-28"
 services:
@@ -51,23 +47,23 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - "./1password-credentials.json:/home/opuser/.op/1password-credentials.json"
-      - "op_data:/home/opuser/.op/data"
+      - ./1password-credentials.json:/home/opuser/.op/1password-credentials.json # (1)!
+      - op_data:/home/opuser/.op/data
 
   op-connect-sync:
     image: 1password/connect-sync:latest
     ports:
       - "8081:8080"
     volumes:
-      - "./1password-credentials.json:/home/opuser/.op/1password-credentials.json"
-      - "op_data:/home/opuser/.op/data"
+      - ./1password-credentials.json:/home/opuser/.op/1password-credentials.json # (2)!
+      - op_data:/home/opuser/.op/data
 
-  doco-cd:
+  app: # your doco-cd container
     image: kimdre/doco-cd:latest
     environment:
       SECRET_PROVIDER: 1password
       SECRET_PROVIDER_CONNECT_HOST: http://op-connect-api:8080
-      SECRET_PROVIDER_CONNECT_TOKEN: ${SECRET_PROVIDER_CONNECT_TOKEN}
+      SECRET_PROVIDER_CONNECT_TOKEN: ${SECRET_PROVIDER_CONNECT_TOKEN} # (3)!
     depends_on:
       - op-connect-api
 
@@ -75,48 +71,54 @@ volumes:
   op_data:
 ```
 
+1. Download the `1password-credentials.json` file from your [Secrets Automation workflow][1password-connect-setup] and mount it into both `op-connect-api` and `op-connect-sync` containers.
+2. Download the `1password-credentials.json` file from your [Secrets Automation workflow][1password-connect-setup] and mount it into both `op-connect-api` and `op-connect-sync` containers.
+3. Create the Connect server _Secrets Automation_ workflow by following the [docs][1password-connect-setup]. 
+
 Example `.env` values for the compose file above:
 
-```bash
-# Used by doco-cd to call op-connect-api
-SECRET_PROVIDER_CONNECT_TOKEN=xxxxxx
+```bash title=".env"
+SECRET_PROVIDER_CONNECT_TOKEN=xxxxxx # (1)!
 ```
 
-Place `1password-credentials.json` next to your compose file (as shown above), or adjust the bind mount path to your preferred secure location.
+1. Used by doco-cd to call op-connect-api
 
+### Configuring doco-cd to authenticate with Connect Server
 
-### Configuring doco-cd to use Connect Server
+Set these [environment variables](#environment-variables) to use 1Password Connect Sever in your `doco-cd` container:
 
-Set these [environment variables](#environment-variables) to use 1Password Connect instead of service account authentication:
+=== "Using a direct token"
 
-```bash
-SECRET_PROVIDER=1password
-SECRET_PROVIDER_CONNECT_HOST=http://op-connect-api:8080
-SECRET_PROVIDER_CONNECT_TOKEN=your-connect-token
-```
+    ```bash title="Environment Variables for doco-cd"
+    SECRET_PROVIDER=1password
+    SECRET_PROVIDER_CONNECT_HOST=http://op-connect-api:8080
+    SECRET_PROVIDER_CONNECT_TOKEN=your-connect-token
+    ```
 
-Or use a file-based token:
+=== "Using a token file"
 
-```bash
-SECRET_PROVIDER=1password
-SECRET_PROVIDER_CONNECT_HOST=http://op-connect-api:8080
-SECRET_PROVIDER_CONNECT_TOKEN_FILE=/run/secrets/op_connect_token
-```
+    ```bash title="Environment Variables for doco-cd"
+    SECRET_PROVIDER=1password
+    SECRET_PROVIDER_CONNECT_HOST=http://op-connect-api:8080
+    SECRET_PROVIDER_CONNECT_TOKEN_FILE=/run/secrets/op_connect_token
+    ```
 
-!!! tip
-    Prefer `SECRET_PROVIDER_CONNECT_TOKEN_FILE` in production so the token is mounted as a secret file instead of a plain environment variable.
+    Mount the Connect token file as a secret or volume into the `doco-cd` container at the specified path:
 
-### Getting your Connect Server credentials
+    ```yaml title="docker-compose.yml"
+    services:
+      app:
+        image: kimdre/doco-cd:latest
+        environment:
+          SECRET_PROVIDER: 1password
+          SECRET_PROVIDER_CONNECT_HOST: http://op-connect-api:8080
+          SECRET_PROVIDER_CONNECT_TOKEN_FILE: /run/secrets/op_connect_token
+        secrets:
+          - op_connect_token
+    
+    secrets:
+      op_connect_token:
+        file: ./op_connect_token.txt
+    ```
 
-For detailed setup instructions, refer to the [1Password Connect Server documentation](https://developer.1password.com/docs/connect/).
-
-To generate a Connect token:
-
-1. Open 1Password
-2. Go to the Admin Console
-3. Select the 1Password Connect integration (or create a new one)
-4. Generate a new token
-5. Save the token in a secure location
-
-To generate the `1password-credentials.json` file used by `op-connect-api` and `op-connect-sync`, follow the [1Password Connect authentication guide](https://developer.1password.com/docs/connect/authentication/).
-
+[1password-connect-setup]: https://developer.1password.com/docs/connect/get-started/?deploy=docker#step-1

--- a/wiki/docs/External-Secrets/1Password-Connect.md
+++ b/wiki/docs/External-Secrets/1Password-Connect.md
@@ -1,0 +1,122 @@
+---
+tags:
+  - Advanced
+  - Secrets
+  - Configuration
+---
+
+# 1Password Connect Server
+
+[1Password Connect Server](https://developer.1password.com/docs/connect/) is a self-hosted proxy that caches vault data locally and serves secrets over a simple HTTP API. This is useful when you are deploying frequently or have multiple instances that would otherwise hit 1Password API rate limits.
+
+Unlike service account authentication (which makes direct calls to the 1Password cloud API), Connect Server allows you to:
+
+- Avoid rate limiting by caching vault data locally
+- Reduce latency for secret lookups
+- Keep all secret requests within your infrastructure
+
+!!! info
+    Client-side caching is automatically disabled when using Connect Server because Connect already handles caching for you.
+
+## Environment Variables
+
+To use 1Password Connect, configure these variables for the `doco-cd` container:
+
+| Key                                  | Value                                                                                                  |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `SECRET_PROVIDER`                    | `1password`                                                                                            |
+| `SECRET_PROVIDER_CONNECT_HOST`       | Base URL of your Connect API Server (for example: `http://op-connect-api:8080`).                       |
+| `SECRET_PROVIDER_CONNECT_TOKEN`      | API token used by `doco-cd` to authenticate against Connect API. Generated in 1Password Connect setup. |
+| `SECRET_PROVIDER_CONNECT_TOKEN_FILE` | Path to the file containing the Connect API token inside the container.                                |
+
+!!! info
+    Use **either** `SECRET_PROVIDER_CONNECT_TOKEN` **or** `SECRET_PROVIDER_CONNECT_TOKEN_FILE`.
+
+For the Connect containers themselves, you also need a credentials file:
+
+| File | Purpose | Source |
+|------|---------|--------|
+| `./1password-credentials.json` | Authenticates `op-connect-api`/`op-connect-sync` with your 1Password account and allows vault sync. | Downloaded from your 1Password Connect setup |
+
+## Setup Steps
+
+### Example Compose Setup
+
+Deploy 1Password Connect alongside doco-cd:
+
+```yaml title="docker-compose.yml" hl_lines="2-16 21-25 27-28"
+services:
+  op-connect-api:
+    image: 1password/connect-api:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - "./1password-credentials.json:/home/opuser/.op/1password-credentials.json"
+      - "op_data:/home/opuser/.op/data"
+
+  op-connect-sync:
+    image: 1password/connect-sync:latest
+    ports:
+      - "8081:8080"
+    volumes:
+      - "./1password-credentials.json:/home/opuser/.op/1password-credentials.json"
+      - "op_data:/home/opuser/.op/data"
+
+  doco-cd:
+    image: kimdre/doco-cd:latest
+    environment:
+      SECRET_PROVIDER: 1password
+      SECRET_PROVIDER_CONNECT_HOST: http://op-connect-api:8080
+      SECRET_PROVIDER_CONNECT_TOKEN: ${SECRET_PROVIDER_CONNECT_TOKEN}
+    depends_on:
+      - op-connect-api
+
+volumes:
+  op_data:
+```
+
+Example `.env` values for the compose file above:
+
+```bash
+# Used by doco-cd to call op-connect-api
+SECRET_PROVIDER_CONNECT_TOKEN=xxxxxx
+```
+
+Place `1password-credentials.json` next to your compose file (as shown above), or adjust the bind mount path to your preferred secure location.
+
+
+### Configuring doco-cd to use Connect Server
+
+Set these [environment variables](#environment-variables) to use 1Password Connect instead of service account authentication:
+
+```bash
+SECRET_PROVIDER=1password
+SECRET_PROVIDER_CONNECT_HOST=http://op-connect-api:8080
+SECRET_PROVIDER_CONNECT_TOKEN=your-connect-token
+```
+
+Or use a file-based token:
+
+```bash
+SECRET_PROVIDER=1password
+SECRET_PROVIDER_CONNECT_HOST=http://op-connect-api:8080
+SECRET_PROVIDER_CONNECT_TOKEN_FILE=/run/secrets/op_connect_token
+```
+
+!!! tip
+    Prefer `SECRET_PROVIDER_CONNECT_TOKEN_FILE` in production so the token is mounted as a secret file instead of a plain environment variable.
+
+### Getting your Connect Server credentials
+
+For detailed setup instructions, refer to the [1Password Connect Server documentation](https://developer.1password.com/docs/connect/).
+
+To generate a Connect token:
+
+1. Open 1Password
+2. Go to the Admin Console
+3. Select the 1Password Connect integration (or create a new one)
+4. Generate a new token
+5. Save the token in a secure location
+
+To generate the `1password-credentials.json` file used by `op-connect-api` and `op-connect-sync`, follow the [1Password Connect authentication guide](https://developer.1password.com/docs/connect/authentication/).
+

--- a/wiki/docs/External-Secrets/1Password.md
+++ b/wiki/docs/External-Secrets/1Password.md
@@ -53,15 +53,16 @@ external_secrets:
 
 ## Client-Side Caching
 
-Optional client-side caching reduces 1Password API calls when using service account authentication. Enable and configure caching with the following environment variables:
+Optional client-side caching[^1] reduces 1Password API calls when using service account authentication. Enable and configure caching with the following environment variables:
 
-| Key                              | Type                                                | Value                                                                                    | Default |
-|----------------------------------|-----------------------------------------------------|------------------------------------------------------------------------------------------|:--------|
-| `SECRET_PROVIDER_CACHE_ENABLED`  | `boolean`                                           | Enables in-memory caching for resolved secrets                                           | `false` |
-| `SECRET_PROVIDER_CACHE_TTL`      | [`duration`](https://pkg.go.dev/time#ParseDuration) | Cache TTL for resolved secrets as a Go duration string (for example: `30s`, `5m`, `1h`)  | `5m`    |
-| `SECRET_PROVIDER_CACHE_MAX_SIZE` | `int`                                               | Maximum number of secrets stored in cache before least-recently-used entries are evicted | `100`   |
+| Key                              | Type      | Value                                                                                                                            | Default |
+|----------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------|:--------|
+| `SECRET_PROVIDER_CACHE_ENABLED`  | `boolean` | Enables in-memory caching for resolved secrets                                                                                   | `false` |
+| `SECRET_PROVIDER_CACHE_TTL`      | `string`  | Cache TTL for resolved secrets as a [Go duration](https://pkg.go.dev/time#ParseDuration) string (for example: `30s`, `5m`, `1h`) | `5m`    |
+| `SECRET_PROVIDER_CACHE_MAX_SIZE` | `number`  | Maximum number of secrets stored in cache before least-recently-used entries are evicted                                         | `100`   |
 
 !!! warning "If the cache TTL is too long, secrets may become outdated."
 
-!!! info
-    Client-side caching can only be used with service account authentication. When using [1Password Connect Server](1Password-Connect.md), client-side caching is automatically disabled because Connect already handles caching for you.
+[^1]: 
+    Client-side caching can only be used with service account authentication. 
+    When using [1Password Connect Server](1Password-Connect.md), client-side caching is automatically disabled because the Connect Server already handles caching for you.

--- a/wiki/docs/External-Secrets/1Password.md
+++ b/wiki/docs/External-Secrets/1Password.md
@@ -10,15 +10,18 @@ tags:
 !!! info
     The start time and memory usage of the doco-cd container, as well as the runtime of a job, can increase significantly when using this secret provider.
 
+!!! tip "Using 1Password Connect Server"
+    For improved performance and to avoid API rate limits in high-volume deployments, consider using [1Password Connect Server](1Password-Connect.md) instead of service account authentication.
+
 ## Environment Variables
 
-To use 1Password, you need to set the following environment variables:
+To use 1Password, configure these variables for the `doco-cd` container
 
-| Key                                 | Value                                                                                                                                                                                                                              |
-|-------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `SECRET_PROVIDER`                   | `1password`                                                                                                                                                                                                                        |
-| `SECRET_PROVIDER_ACCESS_TOKEN`      | Access token of a service account, see [the docs](https://developer.1password.com/docs/service-accounts/security/) and [here](https://developer.1password.com/docs/sdks/setup-tutorial/#part-1-set-up-a-1password-service-account) |
-| `SECRET_PROVIDER_ACCESS_TOKEN_FILE` | Path to the file containing the access token inside the container                                                                                                                                                                  |
+| Key                                  | Value                                                                                                                                                                                                                              |
+|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SECRET_PROVIDER`                    | `1password`                                                                                                                                                                                                                        |
+| `SECRET_PROVIDER_ACCESS_TOKEN`       | Access token of a service account, see [the docs](https://developer.1password.com/docs/service-accounts/security/) and [here](https://developer.1password.com/docs/sdks/setup-tutorial/#part-1-set-up-a-1password-service-account) |
+| `SECRET_PROVIDER_ACCESS_TOKEN_FILE`  | Path to the file containing the service account token inside the container                                                                                                                                                         |
 
 !!! tip "API Rate Limit"
     If you hit the API rate limit, you can also enable client-side caching for resolved secrets. See the [Client-Side Caching](#client-side-caching) section below for more details.
@@ -50,11 +53,15 @@ external_secrets:
 
 ## Client-Side Caching
 
-Optional client-side caching reduces 1Password API calls. Enable and configure caching with the following environment variables:
+Optional client-side caching reduces 1Password API calls when using service account authentication. Enable and configure caching with the following environment variables:
 
-| Key                             | Value                                                                                   | Default |
-|---------------------------------|-----------------------------------------------------------------------------------------|:--------|
-| `SECRET_PROVIDER_CACHE_ENABLED` | Enables in-memory caching for resolved secrets                                          | `false` |
-| `SECRET_PROVIDER_CACHE_TTL`     | Cache TTL for resolved secrets as a Go duration string (for example: `30s`, `5m`, `1h`) | `5m`    |
+| Key                              | Type                                                | Value                                                                                    | Default |
+|----------------------------------|-----------------------------------------------------|------------------------------------------------------------------------------------------|:--------|
+| `SECRET_PROVIDER_CACHE_ENABLED`  | `boolean`                                           | Enables in-memory caching for resolved secrets                                           | `false` |
+| `SECRET_PROVIDER_CACHE_TTL`      | [`duration`](https://pkg.go.dev/time#ParseDuration) | Cache TTL for resolved secrets as a Go duration string (for example: `30s`, `5m`, `1h`)  | `5m`    |
+| `SECRET_PROVIDER_CACHE_MAX_SIZE` | `int`                                               | Maximum number of secrets stored in cache before least-recently-used entries are evicted | `100`   |
 
 !!! warning "If the cache TTL is too long, secrets may become outdated."
+
+!!! info
+    Client-side caching can only be used with service account authentication. When using [1Password Connect Server](1Password-Connect.md), client-side caching is automatically disabled because Connect already handles caching for you.

--- a/wiki/docs/External-Secrets/Webhook.md
+++ b/wiki/docs/External-Secrets/Webhook.md
@@ -181,9 +181,11 @@ Functions can be chained with `|` from left to right.
     - `{{ "hello world" | urlencode }}` -> `hello+world`
     - `{{ "hello+world" | urldecode }}` -> `hello world`
     - `{{ .remote_ref.data | json }}` -> `{"key":"value"}`
+    - `{{ .remote_ref.data | json | b64enc }}` -> `eyJrZXkiOiJ2YWx1ZSJ9` (JSON string encoded in Base64)
     - `{{ "hello" | toUpper }}` -> `HELLO`
     - `{{ "HELLO" | toLower }}` -> `hello`
     - `{{ "  hello  " | trim }}` -> `hello`
+    - `{{ "  hello  " | trim | toUpper }}` -> `HELLO`
 
 ## Examples
 

--- a/wiki/includes/abbreviations.md
+++ b/wiki/includes/abbreviations.md
@@ -1,0 +1,6 @@
+[This is the global docs glossary]: <> (https://zensical.org/docs/authoring/tooltips/?h=glos#add-a-glossary)
+
+*[AWS]: Amazon Web Services
+*[ARN]: Amazon Resource Name (ARN): A unique identifier for resources within Amazon Web Services (AWS)
+*[TTL]: Time To Live: A caching term that refers to the duration for which a cached item is considered valid before it needs to be refreshed or re-fetched from the original source.
+*[UUID]: Universally Unique Identifier

--- a/wiki/includes/reconciliation-note.md
+++ b/wiki/includes/reconciliation-note.md
@@ -1,4 +1,4 @@
-!!! note "[Reconciliation](../Deploy-Settings.md#reconciliation-settings) for non-Swarm deployments follows classic Compose `restart` semantics"
+!!! note "[Reconciliation](../docs/Deploy-Settings.md#reconciliation-settings) for non-Swarm deployments follows classic Compose `restart` semantics"
 
     - Services with `#!yaml restart: always` or `#!yaml restart: unless-stopped` are expected to stay running.
     - Services with no explicit `restart` policy are treated as `#!yaml restart: "no"`.

--- a/wiki/zensical.toml
+++ b/wiki/zensical.toml
@@ -42,6 +42,7 @@ nav = [
       { "Bitwarden Secrets Manager" = "External-Secrets/Bitwarden-Secrets-Manager.md" },
       { "Bitwarden Vault / Vaultwarden" = "External-Secrets/Bitwarden-Vault-Vaultwarden.md" },
       { "1Password" = "External-Secrets/1Password.md" },
+      { "1Password Connect" = "External-Secrets/1Password-Connect.md" },
       { Infisical = "External-Secrets/Infisical.md" },
       { OpenBao = "External-Secrets/Openbao.md" },
       { Webhook = "External-Secrets/Webhook.md" }] },

--- a/wiki/zensical.toml
+++ b/wiki/zensical.toml
@@ -86,6 +86,7 @@ features = [
   "content.code.select",
   "content.code.copy",
   "content.code.annotate",
+  "content.footnote.tooltips",
   "navigation.footer",
   "navigation.indexes",
   "navigation.instant",
@@ -184,6 +185,8 @@ custom_checkbox = true
 
 [project.markdown_extensions.pymdownx.tilde]
 [project.markdown_extensions.pymdownx.snippets]
+auto_append = ["wiki/includes/abbreviations.md"]
+check_paths = true
 
 # zensical
 [project.markdown_extensions.zensical.extensions.preview]


### PR DESCRIPTION
This PR  adds support for 1Password Connect Server and enhances caching options.

# 1Password Connect Server

[1Password Connect Server](https://developer.1password.com/docs/connect/) is a self-hosted proxy that caches vault data locally and serves secrets over a simple HTTP API. This is useful when you are deploying frequently or have multiple instances that would otherwise hit 1Password API rate limits.

Unlike service account authentication (see the [1Password provider](1Password.md)) (which makes direct calls to the 1Password cloud API), Connect Server allows you to:

- Avoid rate limiting by caching vault data locally
- Reduce latency for secret lookups
- Keep all secret requests within your infrastructure

## Environment Variables

To use 1Password Connect, configure these variables for the `doco-cd` container:

| Key                                  | Value                                                                                                                                                                                           |
|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `SECRET_PROVIDER`                    | `1password`                                                                                                                                                                                     |
| `SECRET_PROVIDER_CONNECT_HOST`       | Base URL of your Connect API Server (for example: `http://op-connect-api:8080`).                                                                                                                |
| `SECRET_PROVIDER_CONNECT_TOKEN`      | API token used by `doco-cd` to authenticate against Connect API. Generated in [1Password Connect setup][1password-connect-setup]. Mutually exclusive with `SECRET_PROVIDER_CONNECT_TOKEN_FILE`. |
| `SECRET_PROVIDER_CONNECT_TOKEN_FILE` | Path to the file containing the Connect API token inside the container. Mutually exclusive with `SECRET_PROVIDER_CONNECT_TOKEN`.                                                                |

For the Connect containers themselves, you also need a `1password-credentials.json` credentials file 
to authenticate `op-connect-api`/`op-connect-sync` with your 1Password account and allow vault sync.
Download it from your [1Password Connect setup][1password-connect-setup].

## Setup Steps

### Example Compose Setup

Deploy 1Password Connect alongside doco-cd:

- Follow the [1Password Connect Server documentation](https://developer.1password.com/docs/connect/get-started/?deploy=docker) to get your Connect server credentials and set up the `op-connect-api` and `op-connect-sync` containers.
- For the server configuration options, refer to the [1Password Connect Server Configuration](https://developer.1password.com/docs/connect/server-configuration/) docs.
- Place `1password-credentials.json` next to your compose file (as shown below), or adjust the bind mount path to your preferred secure location (For a token file example, see the [Using a token file](#configuring-doco-cd-to-authenticate-with-connect-server-using-a-token-file) section below).

```yaml title="docker-compose.yml" hl_lines="2-16 21-25 27-28"
services:
  op-connect-api:
    image: 1password/connect-api:latest
    ports:
      - "8080:8080"
    volumes:
      - ./1password-credentials.json:/home/opuser/.op/1password-credentials.json # (1)!
      - op_data:/home/opuser/.op/data

  op-connect-sync:
    image: 1password/connect-sync:latest
    ports:
      - "8081:8080"
    volumes:
      - ./1password-credentials.json:/home/opuser/.op/1password-credentials.json # (2)!
      - op_data:/home/opuser/.op/data

  app: # your doco-cd container
    image: kimdre/doco-cd:latest
    environment:
      SECRET_PROVIDER: 1password
      SECRET_PROVIDER_CONNECT_HOST: http://op-connect-api:8080
      SECRET_PROVIDER_CONNECT_TOKEN: ${SECRET_PROVIDER_CONNECT_TOKEN} # (3)!
    depends_on:
      - op-connect-api

volumes:
  op_data:
```

1. Download the `1password-credentials.json` file from your [Secrets Automation workflow][1password-connect-setup] and mount it into both `op-connect-api` and `op-connect-sync` containers.
2. Download the `1password-credentials.json` file from your [Secrets Automation workflow][1password-connect-setup] and mount it into both `op-connect-api` and `op-connect-sync` containers.
3. Create the Connect server _Secrets Automation_ workflow by following the [docs][1password-connect-setup]. 

Example `.env` values for the compose file above:

```bash title=".env"
SECRET_PROVIDER_CONNECT_TOKEN=xxxxxx # (1)!
```

1. Used by doco-cd to call op-connect-api

### Configuring doco-cd to authenticate with Connect Server

Set these [environment variables](#environment-variables) to use 1Password Connect Sever in your `doco-cd` container:

=== "Using a direct token"

    ```bash title="Environment Variables for doco-cd"
    SECRET_PROVIDER=1password
    SECRET_PROVIDER_CONNECT_HOST=http://op-connect-api:8080
    SECRET_PROVIDER_CONNECT_TOKEN=your-connect-token
    ```

=== "Using a token file"

    ```bash title="Environment Variables for doco-cd"
    SECRET_PROVIDER=1password
    SECRET_PROVIDER_CONNECT_HOST=http://op-connect-api:8080
    SECRET_PROVIDER_CONNECT_TOKEN_FILE=/run/secrets/op_connect_token
    ```

    Mount the Connect token file as a secret or volume into the `doco-cd` container at the specified path:

    ```yaml title="docker-compose.yml"
    services:
      app:
        image: kimdre/doco-cd:latest
        environment:
          SECRET_PROVIDER: 1password
          SECRET_PROVIDER_CONNECT_HOST: http://op-connect-api:8080
          SECRET_PROVIDER_CONNECT_TOKEN_FILE: /run/secrets/op_connect_token
        secrets:
          - op_connect_token
    
    secrets:
      op_connect_token:
        file: ./op_connect_token.txt
    ```

[1password-connect-setup]: https://developer.1password.com/docs/connect/get-started/?deploy=docker#step-1