### PR TITLE
feat(docker): lookup registry image digest via HEAD

### DIFF
--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -62,9 +62,13 @@ func registryAuthForImage(dockerCli command.Cli, imageRef string) string {
 // registryDigestForRef queries the registry for the current manifest digest of
 // the given image reference without downloading any image layers.
 func registryDigestForRef(ctx context.Context, dockerCli command.Cli, imageRef string) (string, error) {
-	if digest, err := registryDigestHeadLookup(ctx, dockerCli, imageRef); err == nil {
+	digest, err := registryDigestHeadLookup(ctx, dockerCli, imageRef)
+	if err == nil {
+		slog.Debug("registry HEAD digest lookup successful", slog.String("ref", imageRef), slog.String("digest", digest))
 		return digest, nil
 	}
+
+	slog.Debug("registry HEAD digest lookup failed, falling back to distribution inspect", slog.String("ref", imageRef), slog.String("err", err.Error()))
 
 	return registryDigestDistributionLookup(ctx, dockerCli, imageRef)
 }

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -2,14 +2,20 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	distreference "github.com/distribution/reference"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/compose/convert"
+	"github.com/docker/cli/cli/config/configfile"
+	configtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
 	"github.com/moby/moby/api/types/container"
@@ -20,6 +26,26 @@ import (
 )
 
 var ErrNoSuchImage = errors.New("no such image") // Image does not exist
+
+const (
+	dockerHubDomain        = "docker.io"
+	dockerHubIndexDomain   = "index.docker.io"
+	dockerHubRegistryHost  = "registry-1.docker.io"
+	dockerHubAuthConfigKey = "https://index.docker.io/v1/"
+	dockerContentDigest    = "Docker-Content-Digest"
+	wwwAuthenticateHeader  = "Www-Authenticate"
+	registryAuthBearer     = "Bearer"
+)
+
+var (
+	registryManifestAccepts = strings.Join([]string{
+		"application/vnd.oci.image.index.v1+json",
+		"application/vnd.oci.image.manifest.v1+json",
+		"application/vnd.docker.distribution.manifest.list.v2+json",
+		"application/vnd.docker.distribution.manifest.v2+json",
+	}, ",")
+	registryDigestHTTPClient = http.DefaultClient
+)
 
 // registryAuthForImage returns a base64-encoded auth string for the registry
 // that hosts the given image ref, sourced from the Docker config file.
@@ -36,6 +62,16 @@ func registryAuthForImage(dockerCli command.Cli, imageRef string) string {
 // registryDigestForRef queries the registry for the current manifest digest of
 // the given image reference without downloading any image layers.
 func registryDigestForRef(ctx context.Context, dockerCli command.Cli, imageRef string) (string, error) {
+	if digest, err := registryDigestHeadLookup(ctx, dockerCli, imageRef); err == nil {
+		return digest, nil
+	}
+
+	return registryDigestDistributionLookup(ctx, dockerCli, imageRef)
+}
+
+// registryDigestForRefViaDistributionInspect asks the Docker Engine API for
+// the remote descriptor digest of the image reference.
+func registryDigestForRefViaDistributionInspect(ctx context.Context, dockerCli command.Cli, imageRef string) (string, error) {
 	info, err := dockerCli.Client().DistributionInspect(ctx, imageRef, client.DistributionInspectOptions{
 		EncodedRegistryAuth: registryAuthForImage(dockerCli, imageRef),
 	})
@@ -44,6 +80,255 @@ func registryDigestForRef(ctx context.Context, dockerCli command.Cli, imageRef s
 	}
 
 	return info.Descriptor.Digest.String(), nil
+}
+
+// registryDigestForRefViaHEAD queries the registry manifest endpoint directly
+// using HEAD and returns Docker-Content-Digest when available.
+func registryDigestForRefViaHEAD(ctx context.Context, dockerCli command.Cli, imageRef string) (string, error) {
+	return registryDigestForRefViaHEADWithClient(ctx, dockerCli.ConfigFile(), imageRef, registryDigestHTTPClient)
+}
+
+func registryDigestForRefViaHEADWithClient(ctx context.Context, cfg *configfile.ConfigFile, imageRef string, httpClient *http.Client) (string, error) {
+	manifestURL, authConfigKey, scope, err := registryManifestURL(imageRef)
+	if err != nil {
+		return "", fmt.Errorf("invalid image reference %q: %w", imageRef, err)
+	}
+
+	authConfig := registryAuthConfigForKey(cfg, authConfigKey)
+
+	digest, err := registryManifestDigestHEAD(ctx, httpClient, manifestURL, scope, authConfig)
+	if err != nil {
+		return "", fmt.Errorf("registry HEAD inspect failed for %s: %w", imageRef, err)
+	}
+
+	return digest, nil
+}
+
+func registryManifestURL(imageRef string) (string, string, string, error) {
+	namedRef, err := distreference.ParseNormalizedNamed(imageRef)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	domain := distreference.Domain(namedRef)
+	registryHost := domain
+
+	authConfigKey := domain
+	if domain == dockerHubDomain || domain == dockerHubIndexDomain {
+		registryHost = dockerHubRegistryHost
+		authConfigKey = dockerHubAuthConfigKey
+	}
+
+	repositoryPath := distreference.Path(namedRef)
+
+	manifestRef := ""
+	if taggedRef, ok := distreference.TagNameOnly(namedRef).(distreference.NamedTagged); ok {
+		manifestRef = taggedRef.Tag()
+	}
+
+	if canonicalRef, ok := namedRef.(distreference.Canonical); ok {
+		manifestRef = canonicalRef.Digest().String()
+	}
+
+	if manifestRef == "" {
+		return "", "", "", errors.New("manifest reference could not be resolved")
+	}
+
+	manifestURL := fmt.Sprintf("https://%s/v2/%s/manifests/%s", registryHost, repositoryPath, url.PathEscape(manifestRef))
+	scope := fmt.Sprintf("repository:%s:pull", repositoryPath)
+
+	return manifestURL, authConfigKey, scope, nil
+}
+
+func registryAuthConfigForKey(cfg *configfile.ConfigFile, authConfigKey string) configtypes.AuthConfig {
+	if cfg == nil {
+		return configtypes.AuthConfig{}
+	}
+
+	authConfig, err := cfg.GetAuthConfig(authConfigKey)
+	if err != nil {
+		return configtypes.AuthConfig{}
+	}
+
+	return authConfig
+}
+
+func registryManifestDigestHEAD(ctx context.Context, httpClient *http.Client, manifestURL, scope string, authConfig configtypes.AuthConfig) (string, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := executeRegistryManifestHeadRequest(ctx, httpClient, manifestURL, authConfig, "")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		challenge, parseErr := parseBearerAuthChallenge(resp.Header.Get(wwwAuthenticateHeader))
+		if parseErr != nil {
+			return "", fmt.Errorf("registry unauthorized and challenge parse failed: %w", parseErr)
+		}
+
+		token, tokenErr := fetchRegistryBearerToken(ctx, httpClient, challenge, scope, authConfig)
+		if tokenErr != nil {
+			return "", tokenErr
+		}
+
+		retryResp, retryErr := executeRegistryManifestHeadRequest(ctx, httpClient, manifestURL, authConfig, token)
+		if retryErr != nil {
+			return "", retryErr
+		}
+		defer retryResp.Body.Close()
+
+		return digestFromRegistryResponse(retryResp)
+	}
+
+	return digestFromRegistryResponse(resp)
+}
+
+func executeRegistryManifestHeadRequest(ctx context.Context, httpClient *http.Client, manifestURL string, authConfig configtypes.AuthConfig, bearerToken string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, manifestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", registryManifestAccepts)
+
+	switch {
+	case bearerToken != "":
+		req.Header.Set("Authorization", registryAuthBearer+" "+bearerToken)
+	case authConfig.RegistryToken != "":
+		req.Header.Set("Authorization", registryAuthBearer+" "+authConfig.RegistryToken)
+	case authConfig.IdentityToken != "":
+		req.Header.Set("Authorization", registryAuthBearer+" "+authConfig.IdentityToken)
+	case authConfig.Username != "" || authConfig.Password != "":
+		req.SetBasicAuth(authConfig.Username, authConfig.Password)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func digestFromRegistryResponse(resp *http.Response) (string, error) {
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("registry returned status %d", resp.StatusCode)
+	}
+
+	digest := strings.TrimSpace(resp.Header.Get(dockerContentDigest))
+	if digest == "" {
+		return "", fmt.Errorf("registry response missing %s header", dockerContentDigest)
+	}
+
+	return digest, nil
+}
+
+type bearerAuthChallenge struct {
+	Realm   string
+	Service string
+	Scope   string
+}
+
+func parseBearerAuthChallenge(value string) (bearerAuthChallenge, error) {
+	scheme, params, ok := strings.Cut(strings.TrimSpace(value), " ")
+	if !ok || !strings.EqualFold(scheme, registryAuthBearer) {
+		return bearerAuthChallenge{}, fmt.Errorf("unsupported challenge %q", value)
+	}
+
+	challenge := bearerAuthChallenge{}
+
+	for _, pair := range strings.Split(params, ",") {
+		key, rawVal, found := strings.Cut(strings.TrimSpace(pair), "=")
+		if !found {
+			continue
+		}
+
+		val := strings.Trim(strings.TrimSpace(rawVal), "\"")
+
+		switch strings.ToLower(key) {
+		case "realm":
+			challenge.Realm = val
+		case "service":
+			challenge.Service = val
+		case "scope":
+			challenge.Scope = val
+		}
+	}
+
+	if challenge.Realm == "" {
+		return bearerAuthChallenge{}, errors.New("challenge missing realm")
+	}
+
+	return challenge, nil
+}
+
+func fetchRegistryBearerToken(ctx context.Context, httpClient *http.Client, challenge bearerAuthChallenge, fallbackScope string, authConfig configtypes.AuthConfig) (string, error) {
+	tokenURL, err := url.Parse(challenge.Realm)
+	if err != nil {
+		return "", fmt.Errorf("invalid bearer realm %q: %w", challenge.Realm, err)
+	}
+
+	query := tokenURL.Query()
+	if challenge.Service != "" {
+		query.Set("service", challenge.Service)
+	}
+
+	scope := challenge.Scope
+	if scope == "" {
+		scope = fallbackScope
+	}
+
+	if scope != "" {
+		query.Set("scope", scope)
+	}
+
+	tokenURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	switch {
+	case authConfig.RegistryToken != "":
+		req.Header.Set("Authorization", registryAuthBearer+" "+authConfig.RegistryToken)
+	case authConfig.Username != "" || authConfig.Password != "":
+		req.SetBasicAuth(authConfig.Username, authConfig.Password)
+	case authConfig.IdentityToken != "":
+		req.Header.Set("Authorization", registryAuthBearer+" "+authConfig.IdentityToken)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("token service returned status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+
+	if payload.Token != "" {
+		return payload.Token, nil
+	}
+
+	if payload.AccessToken != "" {
+		return payload.AccessToken, nil
+	}
+
+	return "", errors.New("token response missing token")
 }
 
 // digestFromReference extracts the digest part from an image reference in
@@ -205,8 +490,10 @@ func PullImages(ctx context.Context, dockerCli command.Cli, projectName string) 
 
 // vars used to allow overriding in tests without needing to mock the entire function.
 var (
-	registryDigestLookup        = registryDigestForRef           // registryDigestLookup fetches registry digests for image refs, can be overridden in tests
-	deployedServiceDigestLookup = getDeployedServiceImageDigests // deployedServiceDigestLookup fetches deployed service image digests, can be overridden in tests
+	registryDigestLookup             = registryDigestForRef           // registryDigestLookup fetches registry digests for image refs, can be overridden in tests
+	deployedServiceDigestLookup      = getDeployedServiceImageDigests // deployedServiceDigestLookup fetches deployed service image digests, can be overridden in tests
+	registryDigestHeadLookup         = registryDigestForRefViaHEAD
+	registryDigestDistributionLookup = registryDigestForRefViaDistributionInspect
 )
 
 // HaveDeployedServiceImageDigestsChanged checks if any currently deployed

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -68,7 +68,7 @@ func registryDigestForRef(ctx context.Context, dockerCli command.Cli, imageRef s
 		return digest, nil
 	}
 
-	slog.Debug("registry HEAD digest lookup failed, falling back to distribution inspect", slog.String("ref", imageRef), slog.String("err", err.Error()))
+	slog.Warn("registry HEAD digest lookup failed, falling back to distribution inspect", slog.String("ref", imageRef), slog.String("err", err.Error()))
 
 	return registryDigestDistributionLookup(ctx, dockerCli, imageRef)
 }

--- a/internal/docker/images_test.go
+++ b/internal/docker/images_test.go
@@ -3,12 +3,18 @@ package docker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config/configfile"
 )
 
 func TestDigestFromReference(t *testing.T) {
@@ -55,6 +61,77 @@ func TestDigestFromRepoDigests(t *testing.T) {
 
 			if got := digestFromRepoDigests(tc.repoDigests); got != tc.want {
 				t.Fatalf("digestFromRepoDigests() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRegistryManifestURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		imageRef    string
+		wantURL     string
+		wantAuthKey string
+		wantScope   string
+	}{
+		{
+			name:        "gcr.io",
+			imageRef:    "gcr.io/google-containers/pause:3.9",
+			wantURL:     "https://gcr.io/v2/google-containers/pause/manifests/3.9",
+			wantAuthKey: "gcr.io",
+			wantScope:   "repository:google-containers/pause:pull",
+		},
+		{
+			name:        "ghcr.io",
+			imageRef:    "ghcr.io/octo-org/octo-image:1.2.3",
+			wantURL:     "https://ghcr.io/v2/octo-org/octo-image/manifests/1.2.3",
+			wantAuthKey: "ghcr.io",
+			wantScope:   "repository:octo-org/octo-image:pull",
+		},
+		{
+			name:        "registry.gitlab.com",
+			imageRef:    "registry.gitlab.com/group/project/image:latest",
+			wantURL:     "https://registry.gitlab.com/v2/group/project/image/manifests/latest",
+			wantAuthKey: "registry.gitlab.com",
+			wantScope:   "repository:group/project/image:pull",
+		},
+		{
+			name:        "docker.io maps to Docker Hub registry host and auth key",
+			imageRef:    "docker.io/library/nginx:latest",
+			wantURL:     "https://registry-1.docker.io/v2/library/nginx/manifests/latest",
+			wantAuthKey: "https://index.docker.io/v1/",
+			wantScope:   "repository:library/nginx:pull",
+		},
+		{
+			name:        "index.docker.io maps to Docker Hub registry host and auth key",
+			imageRef:    "index.docker.io/library/nginx:latest",
+			wantURL:     "https://registry-1.docker.io/v2/library/nginx/manifests/latest",
+			wantAuthKey: "https://index.docker.io/v1/",
+			wantScope:   "repository:library/nginx:pull",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotURL, gotAuthKey, gotScope, err := registryManifestURL(tc.imageRef)
+			if err != nil {
+				t.Fatalf("registryManifestURL(%q) error = %v", tc.imageRef, err)
+			}
+
+			if gotURL != tc.wantURL {
+				t.Fatalf("registryManifestURL(%q) url = %q, want %q", tc.imageRef, gotURL, tc.wantURL)
+			}
+
+			if gotAuthKey != tc.wantAuthKey {
+				t.Fatalf("registryManifestURL(%q) auth key = %q, want %q", tc.imageRef, gotAuthKey, tc.wantAuthKey)
+			}
+
+			if gotScope != tc.wantScope {
+				t.Fatalf("registryManifestURL(%q) scope = %q, want %q", tc.imageRef, gotScope, tc.wantScope)
 			}
 		})
 	}
@@ -206,5 +283,141 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRegistryDigestForRefPrefersHEAD(t *testing.T) {
+	t.Parallel()
+
+	oldHeadLookup := registryDigestHeadLookup
+	oldDistributionLookup := registryDigestDistributionLookup
+
+	t.Cleanup(func() {
+		registryDigestHeadLookup = oldHeadLookup
+		registryDigestDistributionLookup = oldDistributionLookup
+	})
+
+	registryDigestHeadLookup = func(context.Context, command.Cli, string) (string, error) {
+		return "sha256:head", nil
+	}
+	registryDigestDistributionLookup = func(context.Context, command.Cli, string) (string, error) {
+		t.Fatal("distribution inspect fallback should not be called")
+		return "", nil
+	}
+
+	got, err := registryDigestForRef(context.Background(), nil, "nginx:latest")
+	if err != nil {
+		t.Fatalf("registryDigestForRef() unexpected error: %v", err)
+	}
+
+	if got != "sha256:head" {
+		t.Fatalf("registryDigestForRef() = %q, want %q", got, "sha256:head")
+	}
+}
+
+func TestRegistryDigestForRefFallsBackToDistributionInspect(t *testing.T) {
+	t.Parallel()
+
+	oldHeadLookup := registryDigestHeadLookup
+	oldDistributionLookup := registryDigestDistributionLookup
+
+	t.Cleanup(func() {
+		registryDigestHeadLookup = oldHeadLookup
+		registryDigestDistributionLookup = oldDistributionLookup
+	})
+
+	registryDigestHeadLookup = func(context.Context, command.Cli, string) (string, error) {
+		return "", errors.New("head failed")
+	}
+	registryDigestDistributionLookup = func(context.Context, command.Cli, string) (string, error) {
+		return "sha256:fallback", nil
+	}
+
+	got, err := registryDigestForRef(context.Background(), nil, "nginx:latest")
+	if err != nil {
+		t.Fatalf("registryDigestForRef() unexpected error: %v", err)
+	}
+
+	if got != "sha256:fallback" {
+		t.Fatalf("registryDigestForRef() = %q, want %q", got, "sha256:fallback")
+	}
+}
+
+func TestRegistryDigestForRefViaHEADWithClientUsesHEAD(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Fatalf("unexpected method: got %s, want %s", r.Method, http.MethodHead)
+		}
+
+		if r.URL.Path != "/v2/team/app/manifests/latest" {
+			t.Fatalf("unexpected path: got %s", r.URL.Path)
+		}
+
+		w.Header().Set(dockerContentDigest, "sha256:from-head")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	imageRef := parsed.Host + "/team/app:latest"
+
+	got, err := registryDigestForRefViaHEADWithClient(context.Background(), &configfile.ConfigFile{}, imageRef, server.Client())
+	if err != nil {
+		t.Fatalf("registryDigestForRefViaHEADWithClient() unexpected error: %v", err)
+	}
+
+	if got != "sha256:from-head" {
+		t.Fatalf("registryDigestForRefViaHEADWithClient() = %q, want %q", got, "sha256:from-head")
+	}
+}
+
+func TestRegistryDigestForRefViaHEADWithClientBearerChallenge(t *testing.T) {
+	t.Parallel()
+
+	var tokenURL string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"token":"registry-token"}`))
+		case "/v2/team/app/manifests/latest":
+			if !strings.HasPrefix(r.Header.Get("Authorization"), registryAuthBearer+" ") || r.Header.Get("Authorization") != registryAuthBearer+" registry-token" {
+				w.Header().Set(wwwAuthenticateHeader, fmt.Sprintf(`Bearer realm=%q,service=%q,scope=%q`, tokenURL, "test-registry", "repository:team/app:pull"))
+				w.WriteHeader(http.StatusUnauthorized)
+
+				return
+			}
+
+			w.Header().Set(dockerContentDigest, "sha256:from-bearer")
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	tokenURL = server.URL + "/token"
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	imageRef := parsed.Host + "/team/app:latest"
+
+	got, err := registryDigestForRefViaHEADWithClient(context.Background(), &configfile.ConfigFile{}, imageRef, server.Client())
+	if err != nil {
+		t.Fatalf("registryDigestForRefViaHEADWithClient() unexpected error: %v", err)
+	}
+
+	if got != "sha256:from-bearer" {
+		t.Fatalf("registryDigestForRefViaHEADWithClient() = %q, want %q", got, "sha256:from-bearer")
 	}
 }

--- a/internal/docker/images_test.go
+++ b/internal/docker/images_test.go
@@ -361,8 +361,8 @@ func TestRegistryDigestForRefFallsBackWhenHEADMissingDigestHeader(t *testing.T) 
 	imageRef := parsed.Host + "/team/app:latest"
 
 	// Confirm the HEAD path alone returns an error.
-	_, headErr := registryDigestForRefViaHEADWithClient(context.Background(), &configfile.ConfigFile{}, imageRef, server.Client())
-	if headErr == nil {
+	_, hErr := registryDigestForRefViaHEADWithClient(context.Background(), &configfile.ConfigFile{}, imageRef, server.Client())
+	if hErr == nil {
 		t.Fatal("expected HEAD lookup to fail without Docker-Content-Digest header, but it succeeded")
 	}
 

--- a/internal/docker/images_test.go
+++ b/internal/docker/images_test.go
@@ -343,6 +343,57 @@ func TestRegistryDigestForRefFallsBackToDistributionInspect(t *testing.T) {
 	}
 }
 
+func TestRegistryDigestForRefFallsBackWhenHEADMissingDigestHeader(t *testing.T) {
+	t.Parallel()
+
+	// HEAD server returns 200 but omits Docker-Content-Digest, so the HEAD path errors.
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// deliberately omit the Docker-Content-Digest header
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	imageRef := parsed.Host + "/team/app:latest"
+
+	// Confirm the HEAD path alone returns an error.
+	_, headErr := registryDigestForRefViaHEADWithClient(context.Background(), &configfile.ConfigFile{}, imageRef, server.Client())
+	if headErr == nil {
+		t.Fatal("expected HEAD lookup to fail without Docker-Content-Digest header, but it succeeded")
+	}
+
+	// Now wire up the full registryDigestForRef call:
+	// - override the HEAD lookup to use the test server's HTTP client
+	// - override the distribution lookup to return a known digest (simulating Docker Engine fallback)
+	oldHeadLookup := registryDigestHeadLookup
+	oldDistributionLookup := registryDigestDistributionLookup
+
+	t.Cleanup(func() {
+		registryDigestHeadLookup = oldHeadLookup
+		registryDigestDistributionLookup = oldDistributionLookup
+	})
+
+	registryDigestHeadLookup = func(ctx context.Context, _ command.Cli, ref string) (string, error) {
+		return registryDigestForRefViaHEADWithClient(ctx, &configfile.ConfigFile{}, ref, server.Client())
+	}
+	registryDigestDistributionLookup = func(_ context.Context, _ command.Cli, _ string) (string, error) {
+		return "sha256:from-distribution-fallback", nil
+	}
+
+	got, err := registryDigestForRef(context.Background(), nil, imageRef)
+	if err != nil {
+		t.Fatalf("registryDigestForRef() unexpected error: %v", err)
+	}
+
+	if got != "sha256:from-distribution-fallback" {
+		t.Fatalf("registryDigestForRef() = %q, want %q", got, "sha256:from-distribution-fallback")
+	}
+}
+
 func TestRegistryDigestForRefViaHEADWithClientUsesHEAD(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR implements registry digest lookup via HEAD requests with a fallback to the previous distribution inspect logic (uses GET requests).