### PR TITLE
fix(reconciliation): change default trigger events for reconciliation

### DIFF
--- a/internal/config/deploy_config.go
+++ b/internal/config/deploy_config.go
@@ -82,12 +82,12 @@ type DeployConfig struct {
 		Delete    bool `yaml:"delete" json:"delete" default:"true"` // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
 	} `yaml:"auto_discover_opts" json:"auto_discover_opts"` // AutoDiscoverOpts are options for the autodiscovery feature
 	Reconciliation struct {
-		Enabled        bool     `yaml:"enabled" json:"enabled" default:"true"`                   // Enabled enables the reconciliation feature
-		Events         []string `yaml:"events" json:"events" default:"[\"die\", \"unhealthy\"]"` // Events is the list of Docker container actions that trigger reconciliation
-		RestartTimeout int      `yaml:"restart_timeout" json:"restart_timeout" default:"10"`     // RestartTimeout is the timeout in seconds to wait before killing a container during a restart (used for restart-oriented reconciliation events)
-		RestartSignal  string   `yaml:"restart_signal" json:"restart_signal" default:""`         // RestartSignal is the signal sent to stop containers during a restart. If not set, the default of the Docker daemon is used (SIGTERM).
-		RestartLimit   int      `yaml:"restart_limit" json:"restart_limit" default:"5"`          // RestartLimit suppresses further unhealthy-triggered restarts after this many restarts in the configured window. Set to 0 to disable suppression.
-		RestartWindow  int      `yaml:"restart_window" json:"restart_window" default:"300"`      // RestartWindow is the time window in seconds used with RestartLimit.
+		Enabled        bool     `yaml:"enabled" json:"enabled" default:"true"`               // Enabled enables the reconciliation feature
+		Events         []string `yaml:"events" json:"events" default:"[\"unhealthy\"]"`      // Events is the list of Docker container actions that trigger reconciliation
+		RestartTimeout int      `yaml:"restart_timeout" json:"restart_timeout" default:"10"` // RestartTimeout is the timeout in seconds to wait before killing a container during a restart (used for restart-oriented reconciliation events)
+		RestartSignal  string   `yaml:"restart_signal" json:"restart_signal" default:""`     // RestartSignal is the signal sent to stop containers during a restart. If not set, the default of the Docker daemon is used (SIGTERM).
+		RestartLimit   int      `yaml:"restart_limit" json:"restart_limit" default:"5"`      // RestartLimit suppresses further unhealthy-triggered restarts after this many restarts in the configured window. Set to 0 to disable suppression.
+		RestartWindow  int      `yaml:"restart_window" json:"restart_window" default:"300"`  // RestartWindow is the time window in seconds used with RestartLimit.
 	} `yaml:"reconciliation" json:"reconciliation"` // Reconciliation is the configuration for the reconciliation feature
 	Internal struct {
 		File        string            `yaml:"-"` // File is the path to the deployment configuration file in the repository (if RepositoryUrl is not set) or in the cloned repository (if RepositoryUrl is set)

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -109,6 +109,13 @@ func TestDeploy(t *testing.T) {
 	dcs[0].Reconciliation.Enabled = false
 	dcs[1].Reconciliation.Events = []string{"stop"}
 
+	// The default reconciliation events don't include "die".
+	// Explicitly enable it for dcs[2..4] so the test's forceful container
+	// removal (which emits a "die" event) triggers reconciliation as expected.
+	for _, dc := range dcs[2:] {
+		dc.Reconciliation.Events = []string{"die"}
+	}
+
 	t.Cleanup(func() {
 		for _, dc := range dcs {
 			waitForStackDeploymentToFinish(t, repoName, dc.Name, 20*time.Second)

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -50,7 +50,7 @@ The docker compose deployment can be configured inside the [deployment configura
 | `git_depth`        | number           | Limits the number of commits fetched during clone/fetch (shallow clone). `0` means use the global [`GIT_CLONE_DEPTH`](App-Settings.md) value. A positive integer overrides the global setting for this deployment. When a requested ref (tag/SHA) is outside the shallow depth, doco-cd automatically deepens incrementally before falling back to a full fetch. Changing this value on an existing repo triggers an automatic re-clone.                                             | `0` (use global)                                                                                                       |
 | `destroy`          | boolean          | (⚠️ Destructive) Remove the deployed compose stack/project and its resources from the Docker host. Can be further configured using the [destroy_opts](#destroy-settings) setting.                                                                                                                                                                                                                                                                                                    | `false`                                                                                                                |
 | `auto_discover`    | boolean          | Enables autodiscovery of services to deploy in the working directory by scanning for subdirectories with docker-compose files with the naming `docker-compose.y(a)ml` or `compose.y(a)ml`. Can be further configured using the [auto_discover_opts](#auto-discover-settings) setting.                                                                                                                                                                                                | `false`                                                                                                                |
-| `reconciliation`   | object           | Enables event-driven reconciliation for deployments. See [reconciliation settings](#reconciliation-settings) for more details.                                                                                                                                                                                                                                                                                                                                                       | `{enabled: true, events: [die, destroy], restart_timeout: 10}`                                                         |
+| `reconciliation`   | object           | Enables event-driven reconciliation for deployments. See [reconciliation settings](#reconciliation-settings) for more details.                                                                                                                                                                                                                                                                                                                                                       | see [Reconciliation Settings](#reconciliation-settings)                                                                |
 
 
 !!! example
@@ -231,7 +231,7 @@ The following settings can be used to configure reconciliation triggers.
 | Key               | Type             | Description                                                                                                                   | Default value          |
 |-------------------|------------------|-------------------------------------------------------------------------------------------------------------------------------|------------------------|
 | `enabled`         | boolean          | Enable reconciliation.                                                                                                        | `true`                 |
-| `events`          | array of strings | Docker container/service events that trigger reconciliation. See [supported events](#supported-events) below.                 | `['die', 'unhealthy']` |
+| `events`          | array of strings | Docker container/service events that trigger reconciliation. See [supported events](#supported-events) below.                 | `['unhealthy']`        |
 | `restart_timeout` | number           | Timeout in seconds used when restarting containers for reconciliation [events](#supported-events) that trigger a restart.     | `10`                   |
 | `restart_signal`  | string           | Signal used for reconciliation restarts. If not set, the `StopSignal` of the container image is used (defaults to `SIGTERM`). |                        |
 | `restart_limit`   | number           | Maximum number of automatic restarts allowed for a container in the restart window. Set to `0` to disable suppression.        | `5`                    |
@@ -288,18 +288,15 @@ reconciliation:
   restart_limit: 5
   restart_window: 300
   events:
-    - die
-    - stop
-    - kill
+    - destroy
     - unhealthy
-    - oom
 ```
 
 ```yaml title=".doco-cd.yml"
 name: some-project
 reconciliation:
   enabled: true
-  events: [die, destroy]
+  events: [unhealthy]
 ```
 
 ### Webhook Filter

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -260,7 +260,7 @@ The following events are supported as reconciliation triggers in Docker (Standal
         For `unhealthy` events, doco-cd suppresses further automatic restarts after `restart_limit` restarts within `restart_window` seconds (See [reconciliation settings](#reconciliation-settings)).
 
     !!! warning "Overlapping events"
-        Some events, like the `die` event, also get triggered when a container is stopped or killed, so make sure to 
+        Some events, like the `die` event, also get triggered when a container is restarted, stopped or killed, so make sure to 
         configure the events according to the desired behavior.
 
         To prevent unexpected behavior, doco-cd suppresses follow-up events for a container after the first event 


### PR DESCRIPTION
Changed the default trigger events for reconciliation from `[die, unhealthy]` to  `[unhealthy]`.