### PR TITLE
feat(git): add support for domain-scoped Git credentials

### DIFF
--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -55,6 +55,8 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 	pollConfig poll.Config,
 	payload webhook.ParsedPayload,
 ) error {
+	git.ConfigureAuthResolver(appConfig.GitAuthDomains, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken)
+
 	repoName := git.GetRepoName(cloneURL)
 
 	jobLog = jobLog.With(

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -94,8 +94,20 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	}
 
 	cloneUrl := payload.CloneURL
-	if appConfig.SSHPrivateKey != "" {
-		cloneUrl = payload.SSHUrl
+
+	git.ConfigureAuthResolver(appConfig.GitAuthDomains, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken)
+
+	if payload.SSHUrl != "" {
+		sshAuth, authErr := git.GetAuthMethod(payload.SSHUrl, "", "", "")
+		if authErr != nil {
+			onError(w, jobLog.With(logger.ErrAttr(authErr)), "failed to resolve SSH auth method", authErr.Error(), http.StatusInternalServerError, metadata)
+
+			return
+		}
+
+		if sshAuth != nil {
+			cloneUrl = payload.SSHUrl
+		}
 	}
 
 	deployErr := handle(ctx, jobLog,

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -97,8 +97,9 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 
 	git.ConfigureAuthResolver(appConfig.GitAuthDomains, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken)
 
-	if payload.SSHUrl != "" {
-		sshAuth, authErr := git.GetAuthMethod(payload.SSHUrl, "", "", "")
+	// Only attempt SSH clone if we have SSH credentials (either global or domain-scoped)
+	if payload.SSHUrl != "" && (appConfig.SSHPrivateKey != "" || len(appConfig.GitAuthDomains) > 0) {
+		sshAuth, authErr := git.GetAuthMethod(payload.SSHUrl, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken)
 		if authErr != nil {
 			onError(w, jobLog.With(logger.ErrAttr(authErr)), "failed to resolve SSH auth method", authErr.Error(), http.StatusInternalServerError, metadata)
 

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
+	"github.com/kimdre/doco-cd/internal/git"
 
 	"github.com/kimdre/doco-cd/internal/git/ssh"
 	"github.com/kimdre/doco-cd/internal/graceful"
@@ -114,6 +115,8 @@ func run() error {
 		log.Critical("failed to get application configuration", logger.ErrAttr(err))
 		return err
 	}
+
+	git.ConfigureAuthResolver(c.GitAuthDomains, c.SSHPrivateKey, c.SSHPrivateKeyPassphrase, c.GitAccessToken)
 
 	// Parse the log level from the app configuration
 	logLevel, err := logger.ParseLevel(c.LogLevel)

--- a/internal/config/app/app_config.go
+++ b/internal/config/app/app_config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/poll"
+	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/notification"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -34,6 +35,9 @@ type Config struct {
 	WebhookSecretFile           string                 `env:"WEBHOOK_SECRET_FILE,file"`                                            // WebhookSecretFile is the file containing the WebhookSecret
 	GitAccessToken              string                 `env:"GIT_ACCESS_TOKEN"`                                                    // GitAccessToken is the access token used to authenticate with the Git server (e.g. GitHub) for private repositories
 	GitAccessTokenFile          string                 `env:"GIT_ACCESS_TOKEN_FILE,file"`                                          // GitAccessTokenFile is the file containing the GitAccessToken
+	GitAuthDomainsYAML          string                 `env:"GIT_AUTH_DOMAINS"`                                                    // GitAuthDomainsYAML is the YAML configuration for domain-scoped Git credentials
+	GitAuthDomainsFile          string                 `env:"GIT_AUTH_DOMAINS_FILE,file"`                                          // GitAuthDomainsFile is the file containing the YAML configuration for domain-scoped Git credentials
+	GitAuthDomains              []git.ScopedAuthConfig `yaml:"-"`                                                                  // GitAuthDomains holds parsed domain-scoped Git credentials
 	GitCloneDepth               int                    `env:"GIT_CLONE_DEPTH,notEmpty" envDefault:"0" validate:"min=0"`            // GitCloneDepth limits the number of commits to fetch. 0 means full clone (no depth limit). A positive value enables shallow clones.
 	GitCloneSubmodules          bool                   `env:"GIT_CLONE_SUBMODULES,notEmpty" envDefault:"true"`                     // GitCloneSubmodules controls whether git submodules are cloned
 	SSHPrivateKey               string                 `env:"SSH_PRIVATE_KEY"`                                                     // SSHPrivateKey is the SSH private key used for SSH authentication with Git repositories
@@ -68,6 +72,7 @@ func GetConfig() (*Config, error) {
 		{EnvName: "API_SECRET", EnvValue: &cfg.ApiSecret, FileValue: &cfg.ApiSecretFile, AllowUnset: true},
 		{EnvName: "APPRISE_NOTIFY_URLS", EnvValue: &cfg.AppriseNotifyUrls, FileValue: &cfg.AppriseNotifyUrlsFile, AllowUnset: true},
 		{EnvName: "GIT_ACCESS_TOKEN", EnvValue: &cfg.GitAccessToken, FileValue: &cfg.GitAccessTokenFile, AllowUnset: true},
+		{EnvName: "GIT_AUTH_DOMAINS", EnvValue: &cfg.GitAuthDomainsYAML, FileValue: &cfg.GitAuthDomainsFile, AllowUnset: true},
 		{EnvName: "SSH_PRIVATE_KEY", EnvValue: &cfg.SSHPrivateKey, FileValue: &cfg.SSHPrivateKeyFile, AllowUnset: true},
 		{EnvName: "SSH_PRIVATE_KEY_PASSPHRASE", EnvValue: &cfg.SSHPrivateKeyPassphrase, FileValue: &cfg.SSHPrivateKeyPassphraseFile, AllowUnset: true},
 		{EnvName: "WEBHOOK_SECRET", EnvValue: &cfg.WebhookSecret, FileValue: &cfg.WebhookSecretFile, AllowUnset: true},
@@ -81,6 +86,11 @@ func GetConfig() (*Config, error) {
 	err = cfg.parsePollConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse poll config: %w", err)
+	}
+
+	err = cfg.parseGitAuthDomains()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse GIT_AUTH_DOMAINS: %w", err)
 	}
 
 	for _, pollConfig := range cfg.PollConfig {
@@ -120,6 +130,21 @@ func GetConfig() (*Config, error) {
 	)
 
 	return &cfg, nil
+}
+
+// parseGitAuthDomains parses domain-scoped Git credentials from GIT_AUTH_DOMAINS (or *_FILE content).
+func (cfg *Config) parseGitAuthDomains() error {
+	if strings.TrimSpace(cfg.GitAuthDomainsYAML) == "" {
+		cfg.GitAuthDomains = []git.ScopedAuthConfig{}
+
+		return nil
+	}
+
+	if err := yaml.Unmarshal([]byte(cfg.GitAuthDomainsYAML), &cfg.GitAuthDomains); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // parsePollConfig parses the PollConfig from either the PollConfigYAML string or the PollConfigFile.

--- a/internal/config/app/app_config_test.go
+++ b/internal/config/app/app_config_test.go
@@ -71,6 +71,42 @@ func TestGetConfig(t *testing.T) {
 			},
 			expectedErr: config.ErrBothSecretsSet,
 		},
+		{
+			name: "valid config with scoped git auth domains",
+			envVars: map[string]string{
+				"LOG_LEVEL":        "info",
+				"HTTP_PORT":        "8080",
+				"WEBHOOK_SECRET":   "secret",
+				"GIT_AUTH_DOMAINS": "- domains:\n  - github.com\n  git_access_token: gh-token\n- domains:\n  - '*.example.com'\n  ssh_private_key: test-key\n  ssh_private_key_passphrase: pass",
+			},
+			dockerSecrets: nil,
+			expectedErr:   nil,
+		},
+		{
+			name: "valid config with scoped git auth domains from file",
+			envVars: map[string]string{
+				"LOG_LEVEL":      "info",
+				"HTTP_PORT":      "8080",
+				"WEBHOOK_SECRET": "secret",
+			},
+			dockerSecrets: map[string]string{
+				"GIT_AUTH_DOMAINS": "- domains:\n  - gitlab.com\n  git_access_token: gl-token",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "config with duplicate scoped git auth domains",
+			envVars: map[string]string{
+				"LOG_LEVEL":        "info",
+				"HTTP_PORT":        "8080",
+				"WEBHOOK_SECRET":   "secret",
+				"GIT_AUTH_DOMAINS": "- domains:\n  - github.com\n  git_access_token: gh-token",
+			},
+			dockerSecrets: map[string]string{
+				"GIT_AUTH_DOMAINS": "- domains:\n  - gitlab.com\n  git_access_token: gl-token",
+			},
+			expectedErr: config.ErrBothSecretsSet,
+		},
 	}
 
 	for _, tt := range tests {
@@ -122,12 +158,12 @@ func TestGetConfig(t *testing.T) {
 
 			if tt.dockerSecrets != nil {
 				// Compare the config values with the expected values
-				if cfg.WebhookSecret != tt.dockerSecrets["WEBHOOK_SECRET"] {
-					t.Errorf("expected WebhookSecret to be '%s', got '%s'", tt.dockerSecrets["WEBHOOK_SECRET"], cfg.WebhookSecret)
+				if expectedWebhookSecret, ok := tt.dockerSecrets["WEBHOOK_SECRET"]; ok && cfg.WebhookSecret != expectedWebhookSecret {
+					t.Errorf("expected WebhookSecret to be '%s', got '%s'", expectedWebhookSecret, cfg.WebhookSecret)
 				}
 
-				if cfg.GitAccessToken != tt.dockerSecrets["GIT_ACCESS_TOKEN"] {
-					t.Errorf("expected GitAccessToken to be '%s', got '%s'", tt.dockerSecrets["GIT_ACCESS_TOKEN"], cfg.GitAccessToken)
+				if expectedGitAccessToken, ok := tt.dockerSecrets["GIT_ACCESS_TOKEN"]; ok && cfg.GitAccessToken != expectedGitAccessToken {
+					t.Errorf("expected GitAccessToken to be '%s', got '%s'", expectedGitAccessToken, cfg.GitAccessToken)
 				}
 
 				httpPort, err := strconv.ParseUint(tt.envVars["HTTP_PORT"], 10, 16)
@@ -137,6 +173,32 @@ func TestGetConfig(t *testing.T) {
 
 				if cfg.HttpPort != uint16(httpPort) {
 					t.Errorf("expected HttpPort to be '%d', got '%d'", httpPort, cfg.HttpPort)
+				}
+			}
+
+			if _, ok := tt.envVars["GIT_AUTH_DOMAINS"]; ok {
+				if len(cfg.GitAuthDomains) != 2 {
+					t.Fatalf("expected 2 scoped git auth entries, got %d", len(cfg.GitAuthDomains))
+				}
+
+				if cfg.GitAuthDomains[0].GitAccessToken != "gh-token" {
+					t.Fatalf("expected first scoped token to be 'gh-token', got '%s'", cfg.GitAuthDomains[0].GitAccessToken)
+				}
+
+				if len(cfg.GitAuthDomains[1].Domains) != 1 || cfg.GitAuthDomains[1].Domains[0] != "*.example.com" {
+					t.Fatalf("expected wildcard domain '*.example.com', got '%v'", cfg.GitAuthDomains[1].Domains)
+				}
+			}
+
+			if tt.dockerSecrets != nil {
+				if _, ok := tt.dockerSecrets["GIT_AUTH_DOMAINS"]; ok {
+					if len(cfg.GitAuthDomains) != 1 {
+						t.Fatalf("expected 1 scoped git auth entry from file, got %d", len(cfg.GitAuthDomains))
+					}
+
+					if cfg.GitAuthDomains[0].GitAccessToken != "gl-token" {
+						t.Fatalf("expected scoped token from file to be 'gl-token', got '%s'", cfg.GitAuthDomains[0].GitAccessToken)
+					}
 				}
 			}
 		})

--- a/internal/git/auth.go
+++ b/internal/git/auth.go
@@ -2,7 +2,9 @@ package git
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -11,8 +13,194 @@ import (
 	"github.com/kimdre/doco-cd/internal/git/ssh"
 )
 
+// ScopedAuthConfig maps credentials to one or more Git host/domain patterns.
+// Patterns support exact hosts (e.g. github.com) and wildcard subdomains (e.g. *.example.com).
+type ScopedAuthConfig struct {
+	Domains                 []string `yaml:"domains"`
+	GitAccessToken          string   `yaml:"git_access_token"`
+	SSHPrivateKey           string   `yaml:"ssh_private_key"`
+	SSHPrivateKeyPassphrase string   `yaml:"ssh_private_key_passphrase"`
+}
+
+type authResolver struct {
+	scoped              []ScopedAuthConfig
+	globalPrivateKey    string
+	globalKeyPassphrase string
+	globalToken         string
+}
+
+var (
+	authResolverMu     sync.RWMutex
+	configuredResolver = authResolver{}
+)
+
+// ConfigureAuthResolver configures domain-scoped and global Git credentials.
+// This should be called when application config is loaded or updated.
+func ConfigureAuthResolver(scoped []ScopedAuthConfig, globalPrivateKey, globalKeyPassphrase, globalToken string) {
+	authResolverMu.Lock()
+	defer authResolverMu.Unlock()
+
+	configuredResolver = authResolver{
+		scoped:              append([]ScopedAuthConfig(nil), scoped...),
+		globalPrivateKey:    globalPrivateKey,
+		globalKeyPassphrase: globalKeyPassphrase,
+		globalToken:         globalToken,
+	}
+}
+
+// ResolveScopedCredentials resolves credentials for a repository URL using exact domain matches,
+// then the most specific wildcard suffix, and finally global fallback credentials.
+func ResolveScopedCredentials(url, privateKey, keyPassphrase, token string) (string, string, string) {
+	authResolverMu.RLock()
+
+	resolver := configuredResolver
+
+	authResolverMu.RUnlock()
+
+	host := parseGitHost(url)
+	if host == "" {
+		return privateKey, keyPassphrase, token
+	}
+
+	resolvedGlobalPrivateKey := strings.TrimSpace(resolver.globalPrivateKey)
+	resolvedGlobalPassphrase := resolver.globalKeyPassphrase
+	resolvedGlobalToken := strings.TrimSpace(resolver.globalToken)
+
+	if resolvedGlobalPrivateKey != "" && strings.TrimSpace(privateKey) == "" {
+		privateKey = resolvedGlobalPrivateKey
+		keyPassphrase = resolvedGlobalPassphrase
+	}
+
+	if resolvedGlobalToken != "" && strings.TrimSpace(token) == "" {
+		token = resolvedGlobalToken
+	}
+
+	if len(resolver.scoped) == 0 {
+		return privateKey, keyPassphrase, token
+	}
+
+	// Exact domain matches always win.
+	for _, entry := range resolver.scoped {
+		for _, domain := range entry.Domains {
+			if normalizeHost(domain) == host {
+				return pickCredentials(entry, resolver, privateKey, keyPassphrase, token)
+			}
+		}
+	}
+
+	// Then choose the wildcard with the longest suffix (most specific).
+	bestIdx := -1
+	bestSuffixLen := -1
+
+	for i, entry := range resolver.scoped {
+		for _, domain := range entry.Domains {
+			suffix, ok := wildcardSuffix(domain)
+			if !ok {
+				continue
+			}
+
+			if wildcardMatches(host, suffix) && len(suffix) > bestSuffixLen {
+				bestIdx = i
+				bestSuffixLen = len(suffix)
+			}
+		}
+	}
+
+	if bestIdx >= 0 {
+		return pickCredentials(resolver.scoped[bestIdx], resolver, privateKey, keyPassphrase, token)
+	}
+
+	return privateKey, keyPassphrase, token
+}
+
+func pickCredentials(entry ScopedAuthConfig, resolver authResolver, privateKey, keyPassphrase, token string) (string, string, string) {
+	resolvedPrivateKey := strings.TrimSpace(entry.SSHPrivateKey)
+	resolvedPassphrase := entry.SSHPrivateKeyPassphrase
+	resolvedToken := strings.TrimSpace(entry.GitAccessToken)
+
+	if resolvedPrivateKey == "" {
+		resolvedPrivateKey = strings.TrimSpace(resolver.globalPrivateKey)
+		resolvedPassphrase = resolver.globalKeyPassphrase
+	}
+
+	if resolvedToken == "" {
+		resolvedToken = strings.TrimSpace(resolver.globalToken)
+	}
+
+	if resolvedPrivateKey == "" {
+		resolvedPrivateKey = privateKey
+		resolvedPassphrase = keyPassphrase
+	}
+
+	if resolvedToken == "" {
+		resolvedToken = token
+	}
+
+	return resolvedPrivateKey, resolvedPassphrase, resolvedToken
+}
+
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+
+	return strings.TrimSuffix(host, ".")
+}
+
+func parseGitHost(rawURL string) string {
+	u := strings.TrimSpace(rawURL)
+	if u == "" {
+		return ""
+	}
+
+	if strings.Contains(u, "@") && strings.Contains(u, ":") && !strings.Contains(u, "://") {
+		parts := strings.SplitN(u, "@", 2)
+		if len(parts) != 2 {
+			return ""
+		}
+
+		hostPath := strings.SplitN(parts[1], ":", 2)
+		if len(hostPath) != 2 {
+			return ""
+		}
+
+		return normalizeHost(hostPath[0])
+	}
+
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return ""
+	}
+
+	if parsed.Host == "" {
+		return ""
+	}
+
+	return normalizeHost(parsed.Hostname())
+}
+
+func wildcardSuffix(domain string) (string, bool) {
+	d := normalizeHost(domain)
+
+	after, ok := strings.CutPrefix(d, "*.")
+	if !ok || after == "" {
+		return "", false
+	}
+
+	return after, true
+}
+
+func wildcardMatches(host, suffix string) bool {
+	// Wildcards for subdomains must not match the apex domain.
+	if host == suffix {
+		return false
+	}
+
+	return strings.HasSuffix(host, "."+suffix)
+}
+
 // GetAuthMethod determines the appropriate authentication method based on the URL and provided credentials.
 func GetAuthMethod(url, privateKey, keyPassphrase, token string) (transport.AuthMethod, error) {
+	privateKey, keyPassphrase, token = ResolveScopedCredentials(url, privateKey, keyPassphrase, token)
+
 	if IsSSH(url) {
 		return SSHAuth(privateKey, keyPassphrase)
 	} else if token != "" {

--- a/internal/git/auth_test.go
+++ b/internal/git/auth_test.go
@@ -1,0 +1,113 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/kimdre/doco-cd/internal/git"
+)
+
+func TestResolveScopedCredentials_ExactBeatsWildcard(t *testing.T) {
+	t.Parallel()
+
+	git.ConfigureAuthResolver([]git.ScopedAuthConfig{
+		{
+			Domains:        []string{"*.github.com"},
+			GitAccessToken: "wildcard-token",
+		},
+		{
+			Domains:        []string{"api.github.com"},
+			GitAccessToken: "exact-token",
+		},
+	}, "", "", "")
+	t.Cleanup(func() {
+		git.ConfigureAuthResolver(nil, "", "", "")
+	})
+
+	_, _, token := git.ResolveScopedCredentials("https://api.github.com/org/repo.git", "", "", "")
+	if token != "exact-token" {
+		t.Fatalf("expected exact token to win, got '%s'", token)
+	}
+}
+
+func TestResolveScopedCredentials_LongestWildcardSuffixWins(t *testing.T) {
+	t.Parallel()
+
+	git.ConfigureAuthResolver([]git.ScopedAuthConfig{
+		{
+			Domains:        []string{"*.example.com"},
+			GitAccessToken: "broad-token",
+		},
+		{
+			Domains:        []string{"*.foo.example.com"},
+			GitAccessToken: "specific-token",
+		},
+	}, "", "", "")
+	t.Cleanup(func() {
+		git.ConfigureAuthResolver(nil, "", "", "")
+	})
+
+	_, _, token := git.ResolveScopedCredentials("https://git.foo.example.com/org/repo.git", "", "", "")
+	if token != "specific-token" {
+		t.Fatalf("expected most specific wildcard token, got '%s'", token)
+	}
+}
+
+func TestResolveScopedCredentials_WildcardDoesNotMatchApex(t *testing.T) {
+	t.Parallel()
+
+	git.ConfigureAuthResolver([]git.ScopedAuthConfig{
+		{
+			Domains:        []string{"*.example.com"},
+			GitAccessToken: "wildcard-token",
+		},
+	}, "", "", "")
+	t.Cleanup(func() {
+		git.ConfigureAuthResolver(nil, "", "", "")
+	})
+
+	_, _, token := git.ResolveScopedCredentials("https://example.com/org/repo.git", "", "", "")
+	if token != "" {
+		t.Fatalf("expected no wildcard match for apex domain, got '%s'", token)
+	}
+}
+
+func TestResolveScopedCredentials_GlobalFallback(t *testing.T) {
+	t.Parallel()
+
+	git.ConfigureAuthResolver(nil, "", "", "global-token")
+	t.Cleanup(func() {
+		git.ConfigureAuthResolver(nil, "", "", "")
+	})
+
+	_, _, token := git.ResolveScopedCredentials("https://gitlab.com/group/repo.git", "", "", "")
+	if token != "global-token" {
+		t.Fatalf("expected global fallback token, got '%s'", token)
+	}
+}
+
+func TestGetAuthMethod_UsesScopedHTTPToken(t *testing.T) {
+	t.Parallel()
+
+	git.ConfigureAuthResolver([]git.ScopedAuthConfig{
+		{
+			Domains:        []string{"gitlab.com"},
+			GitAccessToken: "scoped-token",
+		},
+	}, "", "", "")
+	t.Cleanup(func() {
+		git.ConfigureAuthResolver(nil, "", "", "")
+	})
+
+	auth, err := git.GetAuthMethod("https://gitlab.com/group/repo.git", "", "", "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if auth == nil {
+		t.Fatal("expected auth method, got nil")
+	}
+
+	if auth.Name() != "http-basic-auth" {
+		t.Fatalf("expected http-basic-auth, got '%s'", auth.Name())
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -608,6 +608,17 @@ func updateSubmodules(repo *git.Repository, auth transport.AuthMethod, depth int
 			Depth:             depth,
 		}
 
+		if subCfg := submodule.Config(); subCfg != nil && subCfg.URL != "" {
+			resolvedAuth, err := GetAuthMethod(subCfg.URL, "", "", "")
+			if err != nil {
+				return fmt.Errorf("failed to resolve auth method for submodule %s: %w", subCfg.Path, err)
+			}
+
+			if resolvedAuth != nil {
+				opts.Auth = resolvedAuth
+			}
+		}
+
 		err = retrier.Do(
 			func() error {
 				if err = submodule.Update(opts); err != nil {

--- a/wiki/docs/App-Settings.md
+++ b/wiki/docs/App-Settings.md
@@ -18,6 +18,8 @@ The application can be configured using the following environment variables:
 | `DEPLOY_CONFIG_BASE_DIR`          | string  | Relative Path to the directory containing the deployment configuration files **in all repositories**. **NOTE**: This does not affect/alter the `working_dir` path in the deploy config. It must still be relative to the repository root.                                                                                                              | `/`                                                    |
 | `GIT_ACCESS_TOKEN`                | string  | Access token for cloning repositories (required for private repositories) via **HTTP**, see [Access Token Setup](Setup-Access-Token.md)                                                                                                                                                                                                                | ` ` (Optional for public repositories but recommended) |
 | `GIT_ACCESS_TOKEN_FILE`           | string  | Path to the file containing the Git Access Token (Mutually exclusive with `GIT_ACCESS_TOKEN`).                                                                                                                                                                                                                                                         | ` `                                                    |
+| `GIT_AUTH_DOMAINS`                | list    | YAML list of domain-scoped Git credentials (HTTP token and/or SSH key). Supports exact domains and wildcard subdomains like `*.example.com` (see [Domain-scoped Git auth](#domain-scoped-git-authentication)). Mutually exclusive with `GIT_AUTH_DOMAINS_FILE`.                                                                                        | ` `                                                    |
+| `GIT_AUTH_DOMAINS_FILE`           | string  | Path to a file containing the YAML configuration for `GIT_AUTH_DOMAINS`. Mutually exclusive with `GIT_AUTH_DOMAINS`.                                                                                                                                                                                                                                   | ` `                                                    |
 | `GIT_CLONE_DEPTH`                 | number  | Limits the number of commits fetched during clone/fetch operations (shallow clone). `0` means full clone (no depth limit). Can be overridden per deployment via the [`git_depth`](Deploy-Settings.md) setting. When a requested ref is outside the shallow depth, doco-cd will automatically deepen incrementally before falling back to a full fetch. | `0`                                                    |
 | `GIT_CLONE_SUBMODULES`            | boolean | Whether Git submodules are cloned too                                                                                                                                                                                                                                                                                                                  | `true`                                                 |
 | `HTTP_PORT`                       | number  | Port on which the application will listen for incoming webhooks, API requests and [healthchecks](#healthcheck)                                                                                                                                                                                                                                         | `80`                                                   |
@@ -129,6 +131,49 @@ services:
       GIT_ACCESS_TOKEN: xxx
       WEBHOOK_SECRET: xxx
 ```
+
+## Domain-scoped Git authentication
+
+Use domain-scoped config when you fetch from multiple Git providers/domains and need separate credentials.
+
+=== "Using `GIT_AUTH_DOMAINS`"
+
+    ```yaml title="docker-compose.yml"
+    services:
+      app:
+        environment:
+          GIT_AUTH_DOMAINS: |
+            --8<-- "wiki/includes/git-auth-domains.example.yaml"
+    ```
+
+=== "Using `GIT_AUTH_DOMAINS_FILE`"
+
+    You can also store the YAML in a file and load it with `GIT_AUTH_DOMAINS_FILE`.
+
+    ```yaml title="git-auth-domains.yaml"
+    --8<-- "wiki/includes/git-auth-domains.example.yaml"
+    ```
+    
+    ```yaml title="docker-compose.yml"
+    services:
+      app:
+        environment:
+          GIT_AUTH_DOMAINS_FILE: /run/secrets/git_auth_domains
+        secrets:
+          - git_auth_domains
+    
+    secrets:
+      git_auth_domains:
+        file: ./git-auth-domains.yaml
+    ```
+
+Matching behavior:
+
+- Exact domain match wins over wildcard entries.
+- If multiple wildcard patterns match, the longest suffix wins (most specific).
+- Wildcards only match subdomains. Example: `*.example.com` matches `git.example.com`, but not `example.com`.
+- If no domain entry matches, doco-cd falls back to global `GIT_ACCESS_TOKEN` / `SSH_PRIVATE_KEY` values if set.
+- Submodule remotes are resolved independently, so each submodule can use credentials for its own domain.
 
 ## Usage with Docker Secrets
 

--- a/wiki/docs/App-Settings.md
+++ b/wiki/docs/App-Settings.md
@@ -136,6 +136,52 @@ services:
 
 Use domain-scoped config when you fetch from multiple Git providers/domains and need separate credentials.
 
+### Syntax and Format
+
+The domain-scoped authentication configuration is a YAML list where each entry defines credentials for one or more domains.
+
+#### Entry Structure
+
+Each entry in the list has the following structure:
+
+```yaml
+- domains:                          # (Required) List of domain names or patterns
+    - domain1.com
+    - domain2.com
+    - '*.example.com'
+  git_access_token: xxx             # (Optional) HTTP token for git access
+  ssh_private_key: |                # (Optional) SSH private key content
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    ...
+    -----END OPENSSH PRIVATE KEY-----
+  ssh_private_key_passphrase: xxx   # (Optional) Passphrase for encrypted SSH key
+```
+
+#### Available Options
+
+| Field                        | Type   | Required | Description                                                                                               |
+|------------------------------|--------|----------|-----------------------------------------------------------------------------------------------------------|
+| `domains`                    | list   | Yes      | List of domain names to apply these credentials to. Supports exact domains and wildcard patterns.         |
+| `git_access_token`           | string | No       | HTTP(S) access token for authenticating with the Git provider. Cannot be used with `ssh_private_key`.     |
+| `ssh_private_key`            | string | No       | SSH private key content (multi-line). Cannot be used with `git_access_token`.                             |
+| `ssh_private_key_passphrase` | string | No       | Passphrase for the SSH private key if it was generated with encryption. Only used with `ssh_private_key`. |
+
+#### Authentication Method Selection
+
+- **Use `git_access_token`** for HTTP(S) based Git access
+- **Use `ssh_private_key`** (and optionally `ssh_private_key_passphrase`) for SSH-based Git access
+- Do not mix both methods in the same entry
+
+### Matching Behavior
+
+- Exact domain match wins over wildcard entries.
+- If multiple wildcard patterns match, the longest suffix wins (most specific).
+- Wildcards only match subdomains. Example: `*.example.com` matches `git.example.com`, but not `example.com`.
+- If no domain entry matches, doco-cd falls back to global `GIT_ACCESS_TOKEN` / `SSH_PRIVATE_KEY` values if set.
+- Submodule remotes are resolved independently, so each submodule can use credentials for its own domain.
+
+### Examples
+
 === "Using `GIT_AUTH_DOMAINS`"
 
     ```yaml title="docker-compose.yml"
@@ -166,14 +212,6 @@ Use domain-scoped config when you fetch from multiple Git providers/domains and 
       git_auth_domains:
         file: ./git-auth-domains.yaml
     ```
-
-Matching behavior:
-
-- Exact domain match wins over wildcard entries.
-- If multiple wildcard patterns match, the longest suffix wins (most specific).
-- Wildcards only match subdomains. Example: `*.example.com` matches `git.example.com`, but not `example.com`.
-- If no domain entry matches, doco-cd falls back to global `GIT_ACCESS_TOKEN` / `SSH_PRIVATE_KEY` values if set.
-- Submodule remotes are resolved independently, so each submodule can use credentials for its own domain.
 
 ## Usage with Docker Secrets
 

--- a/wiki/docs/Getting-Started.md
+++ b/wiki/docs/Getting-Started.md
@@ -35,7 +35,7 @@ The Git access token is used to authenticate with your Git provider (GitHub, Git
     You can use doco-cd without a Git Access Token if the repositories you want to use for your deployments are publicly accessible. 
     However, it is still recommended to use one in that case to for example avoid rate limits. 
 
-If you set a Git access token, doco-cd will always use it to authenticate with your Git provider. See [Setup Access Token](Setup-Access-Token.md) to create this access token and set the `GIT_ACCESS_TOKEN` environment variable to the access token value.
+Set `GIT_ACCESS_TOKEN` for a global fallback token, or use `GIT_AUTH_DOMAINS` / `GIT_AUTH_DOMAINS_FILE` for per-domain credentials. See [Setup Access Token](Setup-Access-Token.md) for examples.
 
 ## Deployment triggers
 

--- a/wiki/docs/Setup-Access-Token.md
+++ b/wiki/docs/Setup-Access-Token.md
@@ -13,8 +13,12 @@ This page shows how to set up a Git Access Token for your deployments.
     
     !!! tip
         You can use doco-cd without a Git Access Token if the repositories you want to use for your deployments are publicly accessible. However, it is still recommended to use one in that case to for example avoid rate limits.
-    
-    If you set a Git Access Token, doco-cd will always use it to authenticate with your Git provider.
+
+!!! info "About Git Authentication"
+    If you set a global `GIT_ACCESS_TOKEN`, doco-cd uses it as fallback for Git domains without a scoped entry.
+    For per-domain credentials, use `GIT_AUTH_DOMAINS` / `GIT_AUTH_DOMAINS_FILE`.
+
+    See [Domain-scoped Git authentication](App-Settings.md#domain-scoped-git-authentication) for more information on how to set up domain-scoped Git authentication.
 
 ## Git Providers
 

--- a/wiki/docs/Setup-SSH-Key.md
+++ b/wiki/docs/Setup-SSH-Key.md
@@ -50,6 +50,11 @@ If the connection is successful, you should see a message indicating that you ha
 You need to configure doco-cd to use the private key (`id_ed25519` or the file path you specified) for SSH authentication.
 See the app config on the [App Settings](App-Settings.md) wiki page for more information on how to set the SSH private key in doco-cd.
 
+
+!!! tip "About Git Authentication"
+    For multiple domains/providers, configure SSH keys per domain with `GIT_AUTH_DOMAINS` (or `GIT_AUTH_DOMAINS_FILE`).
+    See [Domain-scoped Git authentication](App-Settings.md#domain-scoped-git-authentication) for more information.
+
 An example using Docker Compose:
 
 ```yaml title="docker-compose.yml"

--- a/wiki/includes/git-auth-domains.example.yaml
+++ b/wiki/includes/git-auth-domains.example.yaml
@@ -1,0 +1,14 @@
+# Example value for GIT_AUTH_DOMAINS
+- domains:
+    - github.com
+  git_access_token: ghp_xxx
+
+- domains:
+    - gitlab.com
+    - '*.corp.example.com'
+  ssh_private_key: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    ...
+    -----END OPENSSH PRIVATE KEY-----
+  ssh_private_key_passphrase: ""
+

--- a/wiki/includes/git-auth-domains.example.yaml
+++ b/wiki/includes/git-auth-domains.example.yaml
@@ -11,4 +11,3 @@
     ...
     -----END OPENSSH PRIVATE KEY-----
   ssh_private_key_passphrase: ""
-


### PR DESCRIPTION
Currently, when using a Git Access Token or SSH Key, doco-cd will use it for all Git operations regardless of the repository origin/domain.

This PR adds the option to specify domain-scoped Git auth credentials to allow Git operations (clone/fetch) for multiple SCMs/domains.

| Key                               | Type    | Description                                                                                                                                                                                                                                                                                                                                            |
|-----------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `GIT_AUTH_DOMAINS`                | list    | YAML list of domain-scoped Git credentials (HTTP token and/or SSH key). Supports exact domains and wildcard subdomains like `*.example.com` (see [Domain-scoped Git auth](#domain-scoped-git-authentication)). Mutually exclusive with `GIT_AUTH_DOMAINS_FILE`.                                                                                        |
| `GIT_AUTH_DOMAINS_FILE`           | string  | Path to a file containing the YAML configuration for `GIT_AUTH_DOMAINS`. Mutually exclusive with `GIT_AUTH_DOMAINS`.                                                                                                                                                                                                                                   |


## Domain-scoped Git authentication

Use domain-scoped config when you fetch from multiple Git providers/domains and need separate credentials.

### Using `GIT_AUTH_DOMAINS`

```yaml title="docker-compose.yml"
services:
  app:
    environment:
      GIT_AUTH_DOMAINS: |
        # Example value for GIT_AUTH_DOMAINS
        - domains:
            - github.com
          git_access_token: ghp_xxx

        - domains:
            - gitlab.com
            - '*.corp.example.com'
          ssh_private_key: |
            -----BEGIN OPENSSH PRIVATE KEY-----
            ...
            -----END OPENSSH PRIVATE KEY-----
          ssh_private_key_passphrase: ""
```

### Using `GIT_AUTH_DOMAINS_FILE`

You can also store the YAML in a file and load it with `GIT_AUTH_DOMAINS_FILE`.

```yaml title="git-auth-domains.yaml"
# Example value for GIT_AUTH_DOMAINS
- domains:
    - github.com
  git_access_token: ghp_xxx

- domains:
    - gitlab.com
    - '*.corp.example.com'
  ssh_private_key: |
    -----BEGIN OPENSSH PRIVATE KEY-----
    ...
    -----END OPENSSH PRIVATE KEY-----
  ssh_private_key_passphrase: ""
```

```yaml title="docker-compose.yml"
services:
  app:
    environment:
      GIT_AUTH_DOMAINS_FILE: /run/secrets/git_auth_domains
    secrets:
      - git_auth_domains

secrets:
  git_auth_domains:
    file: ./git-auth-domains.yaml
```

## Matching behavior

- Exact domain match wins over wildcard entries.
- If multiple wildcard patterns match, the longest suffix wins (most specific).
- Wildcards only match subdomains. Example: `*.example.com` matches `git.example.com`, but not `example.com`.
- If no domain entry matches, doco-cd falls back to global `GIT_ACCESS_TOKEN` / `SSH_PRIVATE_KEY` values if set.
- Submodule remotes are resolved independently, so each submodule can use credentials for its own domain.
