### PR TITLE
feat(api): add API endpoints for managing scheduled jobs

### DIFF
--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
 	restAPI "github.com/kimdre/doco-cd/internal/restapi"
+	"github.com/kimdre/doco-cd/internal/scheduler"
 	"github.com/kimdre/doco-cd/internal/utils/id"
 )
 
@@ -42,6 +43,8 @@ func registerApiEndpoints(c *app.Config, h *handlerData, log *logger.Logger, mux
 		enabledEndpoints = append(enabledEndpoints, apiPath)
 
 		endpoints := []endpoint{
+			{apiPath + "/jobs/scheduled", h.GetScheduledJobsHandler},
+			{apiPath + "/job/{jobName}/run", h.TriggerScheduledJobHandler},
 			{apiPath + "/projects", h.GetProjectsApiHandler},
 			{apiPath + "/project/{projectName}", h.ProjectApiHandler},
 			{apiPath + "/project/{projectName}/{action}", h.ProjectActionApiHandler},
@@ -76,6 +79,113 @@ func registerApiEndpoints(c *app.Config, h *handlerData, log *logger.Logger, mux
 	}
 
 	return enabledEndpoints
+}
+
+// GetScheduledJobsHandler handles API requests to list scheduler-managed jobs.
+func (h *handlerData) GetScheduledJobsHandler(w http.ResponseWriter, r *http.Request) {
+	jobID := id.GenID()
+	jobLog := h.log.With(slog.String("job_id", jobID), slog.String("ip", r.RemoteAddr))
+
+	jobLog.Debug("received api request")
+
+	if !requireMethod(w, jobLog, r, http.MethodGet) {
+		return
+	}
+
+	if !restAPI.ValidateApiKey(r, h.appConfig.ApiSecret) {
+		jobLog.Error(restAPI.ErrInvalidApiKey.Error())
+		JSONError(w, restAPI.ErrInvalidApiKey.Error(), "", jobID, http.StatusUnauthorized)
+
+		return
+	}
+
+	stackName := getQueryParam(r, w, jobLog, jobID, "stack", "string", "").(string)
+
+	jobs, err := scheduler.ListJobs(r.Context(), h.dockerCli, stackName)
+	if err != nil {
+		errMsg := "failed to list scheduled jobs"
+		jobLog.With(logger.ErrAttr(err)).Error(errMsg)
+		JSONError(w, errMsg, err.Error(), jobID, http.StatusInternalServerError)
+
+		return
+	}
+
+	JSONResponse(w, jobs, jobID, http.StatusOK)
+}
+
+// TriggerScheduledJobHandler handles API requests to run one configured scheduled job immediately.
+func (h *handlerData) TriggerScheduledJobHandler(w http.ResponseWriter, r *http.Request) {
+	jobID := id.GenID()
+	jobLog := h.log.With(slog.String("job_id", jobID), slog.String("ip", r.RemoteAddr))
+
+	jobLog.Debug("received api request")
+
+	if !requireMethod(w, jobLog, r, http.MethodPost) {
+		return
+	}
+
+	if !restAPI.ValidateApiKey(r, h.appConfig.ApiSecret) {
+		jobLog.Error(restAPI.ErrInvalidApiKey.Error())
+		JSONError(w, restAPI.ErrInvalidApiKey.Error(), "", jobID, http.StatusUnauthorized)
+
+		return
+	}
+
+	jobName := r.PathValue("jobName")
+	if jobName == "" {
+		err := errors.New("missing job name")
+		jobLog.Error(err.Error())
+		JSONError(w, err, "", jobID, http.StatusBadRequest)
+
+		return
+	}
+
+	stackName := getQueryParam(r, w, jobLog, jobID, "stack", "string", "").(string)
+	wait := getQueryParam(r, w, jobLog, jobID, "wait", "bool", true).(bool)
+
+	triggerFn := func(ctx context.Context) error {
+		runID, err := scheduler.TriggerNow(ctx, h.dockerCli, h.log.Logger, jobName, stackName)
+
+		runLog := jobLog
+		if runID != "" {
+			runLog = runLog.With(slog.String("scheduled_run_id", runID))
+		}
+
+		if err == nil {
+			runLog.Info("scheduled job run triggered", slog.String("job", jobName), slog.String("stack", stackName))
+			return nil
+		}
+
+		runLog.With(logger.ErrAttr(err)).Error("failed to trigger scheduled job run", slog.String("job", jobName), slog.String("stack", stackName))
+
+		return err
+	}
+
+	if !wait {
+		go func(ctx context.Context) {
+			_ = triggerFn(ctx)
+		}(context.WithoutCancel(r.Context()))
+
+		JSONResponse(w, "scheduled job run accepted", jobID, http.StatusAccepted)
+
+		return
+	}
+
+	err := triggerFn(r.Context())
+	if err != nil {
+		switch {
+		case errors.Is(err, scheduler.ErrScheduledJobNotFound):
+			JSONError(w, err.Error(), "", jobID, http.StatusNotFound)
+		case errors.Is(err, scheduler.ErrScheduledJobDisabled), errors.Is(err, scheduler.ErrScheduledJobAmbiguous):
+			JSONError(w, err.Error(), "", jobID, http.StatusConflict)
+		default:
+			JSONError(w, "failed to trigger scheduled job run", err.Error(), jobID, http.StatusInternalServerError)
+		}
+
+		return
+	}
+
+	JSONResponse(w, "scheduled job run completed", jobID, http.StatusOK)
 }
 
 // HealthCheckHandler handles health check requests.

--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -43,7 +43,7 @@ func registerApiEndpoints(c *app.Config, h *handlerData, log *logger.Logger, mux
 		enabledEndpoints = append(enabledEndpoints, apiPath)
 
 		endpoints := []endpoint{
-			{apiPath + "/jobs/scheduled", h.GetScheduledJobsHandler},
+			{apiPath + "/jobs", h.GetScheduledJobsHandler},
 			{apiPath + "/job/{jobName}/run", h.TriggerScheduledJobHandler},
 			{apiPath + "/projects", h.GetProjectsApiHandler},
 			{apiPath + "/project/{projectName}", h.ProjectApiHandler},

--- a/cmd/doco-cd/handler_api_test.go
+++ b/cmd/doco-cd/handler_api_test.go
@@ -406,7 +406,7 @@ func TestHandlerData_GetScheduledJobsHandlerValidation(t *testing.T) {
 		},
 	}
 
-	endpoint := path.Join(apiPath, "/jobs/scheduled")
+	endpoint := path.Join(apiPath, "/jobs")
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/doco-cd/handler_api_test.go
+++ b/cmd/doco-cd/handler_api_test.go
@@ -311,3 +311,124 @@ func TestHandlerData_TriggerPollHandler(t *testing.T) {
 		})
 	}
 }
+
+func TestHandlerData_TriggerScheduledJobHandlerValidation(t *testing.T) {
+	t.Parallel()
+
+	appConfig, err := app.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := handlerData{
+		appConfig: appConfig,
+		log:       logger.New(logger.LevelCritical),
+	}
+
+	tests := []struct {
+		name           string
+		method         string
+		setAPIKey      bool
+		expectedStatus int
+	}{
+		{
+			name:           "invalid method",
+			method:         http.MethodGet,
+			setAPIKey:      true,
+			expectedStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:           "missing api key",
+			method:         http.MethodPost,
+			setAPIKey:      false,
+			expectedStatus: http.StatusUnauthorized,
+		},
+	}
+
+	endpoint := path.Join(apiPath, "/job/{jobName}/run")
+	requestPath := path.Join(apiPath, "/job/example-job/run")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(tc.method, requestPath, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.setAPIKey {
+				req.Header.Set(restAPI.KeyHeader, appConfig.ApiSecret)
+			}
+
+			rr := httptest.NewRecorder()
+			mux := http.NewServeMux()
+			mux.HandleFunc(endpoint, h.TriggerScheduledJobHandler)
+			mux.ServeHTTP(rr, req)
+
+			if rr.Code != tc.expectedStatus {
+				t.Fatalf("handler returned wrong status code: got %v want %v", rr.Code, tc.expectedStatus)
+			}
+		})
+	}
+}
+
+func TestHandlerData_GetScheduledJobsHandlerValidation(t *testing.T) {
+	t.Parallel()
+
+	appConfig, err := app.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := handlerData{
+		appConfig: appConfig,
+		log:       logger.New(logger.LevelCritical),
+	}
+
+	tests := []struct {
+		name           string
+		method         string
+		setAPIKey      bool
+		expectedStatus int
+	}{
+		{
+			name:           "invalid method",
+			method:         http.MethodPost,
+			setAPIKey:      true,
+			expectedStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:           "missing api key",
+			method:         http.MethodGet,
+			setAPIKey:      false,
+			expectedStatus: http.StatusUnauthorized,
+		},
+	}
+
+	endpoint := path.Join(apiPath, "/jobs/scheduled")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(tc.method, endpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.setAPIKey {
+				req.Header.Set(restAPI.KeyHeader, appConfig.ApiSecret)
+			}
+
+			rr := httptest.NewRecorder()
+			mux := http.NewServeMux()
+			mux.HandleFunc(endpoint, h.GetScheduledJobsHandler)
+			mux.ServeHTTP(rr, req)
+
+			if rr.Code != tc.expectedStatus {
+				t.Fatalf("handler returned wrong status code: got %v want %v", rr.Code, tc.expectedStatus)
+			}
+		})
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -836,11 +836,10 @@ func parseRFC3339Time(raw string) *time.Time {
 		return nil
 	}
 
-	u := t.UTC()
-
-	return &u
+	return new(t.UTC())
 }
 
+// schedulerNow returns the current time in local timezone for consistent scheduling behavior regardless of host timezone settings.
 func schedulerNow() time.Time {
 	return time.Now().In(time.Local)
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,6 +36,9 @@ var (
 	ErrScheduledJobNotFound  = errors.New("scheduled job not found")
 	ErrScheduledJobDisabled  = errors.New("scheduled job is disabled")
 	ErrScheduledJobAmbiguous = errors.New("multiple scheduled jobs matched, narrow your selection")
+
+	runtimeStatesMu sync.RWMutex
+	runtimeStates   = map[string]scheduledJobState{}
 )
 
 type scheduledJobMode string
@@ -55,6 +59,7 @@ type scheduledJob struct {
 type scheduledJobState struct {
 	fingerprint string
 	schedule    cron.Schedule
+	lastRun     time.Time
 	nextRun     time.Time
 	cfg         docker.JobScheduleConfig
 }
@@ -80,7 +85,7 @@ type JobInfo struct {
 	ExecutionMode  docker.JobExecutionMode `json:"execution_mode,omitempty"`
 	SkipRunning    bool                    `json:"skip_running"`
 	NotifyOn       docker.JobNotifyOn      `json:"notify_on,omitempty"`
-	SwarmReplicas  uint64                  `json:"swarm_replicas,omitempty"`
+	Replicas       uint64                  `json:"replicas,omitempty"`
 	LastRunAt      *time.Time              `json:"last_run_at,omitempty"`
 	NextRunAt      *time.Time              `json:"next_run_at,omitempty"`
 	LabelNextRunAt *time.Time              `json:"label_next_run_at,omitempty"`
@@ -121,6 +126,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 	now := time.Now().UTC()
 	stackName = strings.TrimSpace(stackName)
 	result := make([]JobInfo, 0, len(jobs))
+	states := getRuntimeStatesSnapshot()
 
 	for _, job := range jobs {
 		stack := getJobStackName(job)
@@ -158,7 +164,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		info.ExecutionMode = cfg.ExecutionMode
 		info.SkipRunning = cfg.SkipRunning
 		info.NotifyOn = cfg.NotifyOn
-		info.SwarmReplicas = cfg.SwarmReplicas
+		info.Replicas = cfg.SwarmReplicas
 
 		schedule, scheduleErr := docker.ParseJobScheduleExpression(cfg.Schedule)
 		if scheduleErr != nil {
@@ -169,8 +175,16 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 			continue
 		}
 
-		next := schedule.Next(now)
-		info.NextRunAt = &next
+		nextRun := schedule.Next(now)
+		if state, ok := states[job.key]; ok && !state.nextRun.IsZero() {
+			if !state.lastRun.IsZero() {
+				info.LastRunAt = new(state.lastRun)
+			}
+
+			nextRun = state.nextRun
+		}
+
+		info.NextRunAt = &nextRun
 
 		result = append(result, info)
 	}
@@ -224,6 +238,8 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 	defer lock.UnlockScheduledDeploy()
 
 	err = s.executeScheduledRun(ctx, job, cfg)
+	setRuntimeLastRun(job.key, time.Now().UTC())
+
 	if err != nil {
 		runLog.Error("scheduled run failed", logger.ErrAttr(err))
 		s.sendRunNotification(job, cfg, runID, false, "Scheduled job failed", fmt.Sprintf("scheduled job '%s' failed to run: %v", job.name, err))
@@ -374,6 +390,7 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 
 		if !now.Before(state.nextRun) {
 			scheduledAt := state.nextRun
+			state.lastRun = scheduledAt
 			state.nextRun = nextScheduledRun(state.schedule, scheduledAt, now)
 			s.states[job.key] = state
 
@@ -408,6 +425,8 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 	if nearestNextRun.IsZero() {
 		nearestNextRun, _ = getNearestNextRun(s.states)
 	}
+
+	setRuntimeStatesSnapshot(s.states)
 
 	return nearestNextRun, !nearestNextRun.IsZero()
 }
@@ -820,4 +839,37 @@ func parseRFC3339Time(raw string) *time.Time {
 	u := t.UTC()
 
 	return &u
+}
+
+func setRuntimeStatesSnapshot(states map[string]scheduledJobState) {
+	runtimeStatesMu.Lock()
+	defer runtimeStatesMu.Unlock()
+
+	next := make(map[string]scheduledJobState, len(states))
+	maps.Copy(next, states)
+
+	runtimeStates = next
+}
+
+func getRuntimeStatesSnapshot() map[string]scheduledJobState {
+	runtimeStatesMu.RLock()
+	defer runtimeStatesMu.RUnlock()
+
+	ret := make(map[string]scheduledJobState, len(runtimeStates))
+	maps.Copy(ret, runtimeStates)
+
+	return ret
+}
+
+func setRuntimeLastRun(key string, lastRun time.Time) {
+	if key == "" {
+		return
+	}
+
+	runtimeStatesMu.Lock()
+	defer runtimeStatesMu.Unlock()
+
+	state := runtimeStates[key]
+	state.lastRun = lastRun
+	runtimeStates[key] = state
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -72,21 +72,21 @@ type scheduler struct {
 
 // JobInfo describes one scheduler-managed target and its runtime scheduling status.
 type JobInfo struct {
-	Name            string                  `json:"name"`
-	Stack           string                  `json:"stack,omitempty"`
-	Mode            string                  `json:"mode"`
-	Enabled         bool                    `json:"enabled"`
-	Schedule        string                  `json:"schedule,omitempty"`
-	ExecutionMode   docker.JobExecutionMode `json:"execution_mode,omitempty"`
-	SkipRunning     bool                    `json:"skip_running"`
-	NotifyOn        docker.JobNotifyOn      `json:"notify_on,omitempty"`
-	SwarmReplicas   uint64                  `json:"swarm_replicas,omitempty"`
-	LastRunAt       *time.Time              `json:"last_run_at,omitempty"`
-	NextRunAt       *time.Time              `json:"next_run_at,omitempty"`
-	LabelNextRunAt  *time.Time              `json:"label_next_run_at,omitempty"`
-	Repository      string                  `json:"repository,omitempty"`
-	ScheduleError   string                  `json:"schedule_error,omitempty"`
-	ConfigurationOk bool                    `json:"configuration_ok"`
+	Name           string                  `json:"name"`
+	Enabled        bool                    `json:"enabled"`
+	Stack          string                  `json:"stack,omitempty"`
+	Mode           string                  `json:"mode"`
+	Schedule       string                  `json:"schedule,omitempty"`
+	ExecutionMode  docker.JobExecutionMode `json:"execution_mode,omitempty"`
+	SkipRunning    bool                    `json:"skip_running"`
+	NotifyOn       docker.JobNotifyOn      `json:"notify_on,omitempty"`
+	SwarmReplicas  uint64                  `json:"swarm_replicas,omitempty"`
+	LastRunAt      *time.Time              `json:"last_run_at,omitempty"`
+	NextRunAt      *time.Time              `json:"next_run_at,omitempty"`
+	LabelNextRunAt *time.Time              `json:"label_next_run_at,omitempty"`
+	Repository     string                  `json:"repository,omitempty"`
+	ScheduleError  string                  `json:"schedule_error,omitempty"`
+	Valid          bool                    `json:"valid"`
 }
 
 func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *sync.WaitGroup) {
@@ -129,11 +129,11 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		}
 
 		info := JobInfo{
-			Name:            job.name,
-			Stack:           stack,
-			Mode:            string(job.mode),
-			Repository:      job.labels[docker.DocoCDLabels.Repository.Name],
-			ConfigurationOk: true,
+			Name:       job.name,
+			Stack:      stack,
+			Mode:       string(job.mode),
+			Repository: job.labels[docker.DocoCDLabels.Repository.Name],
+			Valid:      true,
 		}
 
 		info.LastRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobLastRun])
@@ -141,7 +141,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 
 		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels)
 		if parseErr != nil {
-			info.ConfigurationOk = false
+			info.Valid = false
 			info.ScheduleError = parseErr.Error()
 			result = append(result, info)
 
@@ -162,7 +162,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 
 		schedule, scheduleErr := docker.ParseJobScheduleExpression(cfg.Schedule)
 		if scheduleErr != nil {
-			info.ConfigurationOk = false
+			info.Valid = false
 			info.ScheduleError = scheduleErr.Error()
 			result = append(result, info)
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -123,7 +123,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		return nil, fmt.Errorf("failed to discover scheduled jobs: %w", err)
 	}
 
-	now := time.Now().UTC()
+	now := schedulerNow()
 	stackName = strings.TrimSpace(stackName)
 	result := make([]JobInfo, 0, len(jobs))
 	states := getRuntimeStatesSnapshot()
@@ -238,7 +238,7 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 	defer lock.UnlockScheduledDeploy()
 
 	err = s.executeScheduledRun(ctx, job, cfg)
-	setRuntimeLastRun(job.key, time.Now().UTC())
+	setRuntimeLastRun(job.key, schedulerNow())
 
 	if err != nil {
 		runLog.Error("scheduled run failed", logger.ErrAttr(err))
@@ -303,10 +303,10 @@ func (s *scheduler) run(ctx context.Context) {
 
 	s.log.Info("starting scheduler")
 
-	nextRun, hasNextRun := s.refreshJobs(ctx, time.Now().UTC())
+	nextRun, hasNextRun := s.refreshJobs(ctx, schedulerNow())
 
 	for {
-		setTimerToNextRun(timer, time.Now().UTC(), nextRun, hasNextRun)
+		setTimerToNextRun(timer, schedulerNow(), nextRun, hasNextRun)
 
 		select {
 		case <-ctx.Done():
@@ -318,9 +318,9 @@ func (s *scheduler) run(ctx context.Context) {
 				continue
 			}
 
-			nextRun, hasNextRun = s.refreshJobs(ctx, time.Now().UTC())
+			nextRun, hasNextRun = s.refreshJobs(ctx, schedulerNow())
 		case t := <-timer.C:
-			nextRun, hasNextRun = s.refreshJobs(ctx, t.UTC())
+			nextRun, hasNextRun = s.refreshJobs(ctx, t)
 		}
 	}
 }
@@ -839,6 +839,10 @@ func parseRFC3339Time(raw string) *time.Time {
 	u := t.UTC()
 
 	return &u
+}
+
+func schedulerNow() time.Time {
+	return time.Now().In(time.Local)
 }
 
 func setRuntimeStatesSnapshot(states map[string]scheduledJobState) {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -31,6 +31,12 @@ const (
 	schedulerRefreshRetryDelay   = time.Second
 )
 
+var (
+	ErrScheduledJobNotFound  = errors.New("scheduled job not found")
+	ErrScheduledJobDisabled  = errors.New("scheduled job is disabled")
+	ErrScheduledJobAmbiguous = errors.New("multiple scheduled jobs matched, narrow your selection")
+)
+
 type scheduledJobMode string
 
 const (
@@ -64,6 +70,25 @@ type scheduler struct {
 	running   map[string]bool
 }
 
+// JobInfo describes one scheduler-managed target and its runtime scheduling status.
+type JobInfo struct {
+	Name            string                  `json:"name"`
+	Stack           string                  `json:"stack,omitempty"`
+	Mode            string                  `json:"mode"`
+	Enabled         bool                    `json:"enabled"`
+	Schedule        string                  `json:"schedule,omitempty"`
+	ExecutionMode   docker.JobExecutionMode `json:"execution_mode,omitempty"`
+	SkipRunning     bool                    `json:"skip_running"`
+	NotifyOn        docker.JobNotifyOn      `json:"notify_on,omitempty"`
+	SwarmReplicas   uint64                  `json:"swarm_replicas,omitempty"`
+	LastRunAt       *time.Time              `json:"last_run_at,omitempty"`
+	NextRunAt       *time.Time              `json:"next_run_at,omitempty"`
+	LabelNextRunAt  *time.Time              `json:"label_next_run_at,omitempty"`
+	Repository      string                  `json:"repository,omitempty"`
+	ScheduleError   string                  `json:"schedule_error,omitempty"`
+	ConfigurationOk bool                    `json:"configuration_ok"`
+}
+
 func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *sync.WaitGroup) {
 	if dockerCli == nil || log == nil || wg == nil {
 		return
@@ -78,6 +103,179 @@ func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *syn
 	}
 
 	s.run(ctx)
+}
+
+// ListJobs returns all discovered scheduler jobs, optionally filtered by stack name.
+func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]JobInfo, error) {
+	if dockerCli == nil {
+		return nil, errors.New("docker cli is required")
+	}
+
+	s := &scheduler{dockerCli: dockerCli}
+
+	jobs, err := s.discoverJobs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover scheduled jobs: %w", err)
+	}
+
+	now := time.Now().UTC()
+	stackName = strings.TrimSpace(stackName)
+	result := make([]JobInfo, 0, len(jobs))
+
+	for _, job := range jobs {
+		stack := getJobStackName(job)
+		if stackName != "" && stack != stackName {
+			continue
+		}
+
+		info := JobInfo{
+			Name:            job.name,
+			Stack:           stack,
+			Mode:            string(job.mode),
+			Repository:      job.labels[docker.DocoCDLabels.Repository.Name],
+			ConfigurationOk: true,
+		}
+
+		info.LastRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobLastRun])
+		info.LabelNextRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobNextRun])
+
+		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels)
+		if parseErr != nil {
+			info.ConfigurationOk = false
+			info.ScheduleError = parseErr.Error()
+			result = append(result, info)
+
+			continue
+		}
+
+		info.Enabled = enabled
+		if !enabled {
+			result = append(result, info)
+			continue
+		}
+
+		info.Schedule = cfg.Schedule
+		info.ExecutionMode = cfg.ExecutionMode
+		info.SkipRunning = cfg.SkipRunning
+		info.NotifyOn = cfg.NotifyOn
+		info.SwarmReplicas = cfg.SwarmReplicas
+
+		schedule, scheduleErr := docker.ParseJobScheduleExpression(cfg.Schedule)
+		if scheduleErr != nil {
+			info.ConfigurationOk = false
+			info.ScheduleError = scheduleErr.Error()
+			result = append(result, info)
+
+			continue
+		}
+
+		next := schedule.Next(now)
+		info.NextRunAt = &next
+
+		result = append(result, info)
+	}
+
+	return result, nil
+}
+
+// TriggerNow executes one configured scheduled job immediately.
+// Job selection matches by container/service name and optional stack name.
+func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jobName, stackName string) (string, error) {
+	if dockerCli == nil {
+		return "", errors.New("docker cli is required")
+	}
+
+	if strings.TrimSpace(jobName) == "" {
+		return "", errors.New("job name is required")
+	}
+
+	if log == nil {
+		log = slog.Default()
+	}
+
+	s := &scheduler{
+		dockerCli: dockerCli,
+		log:       log.With(slog.String("component", "scheduler")),
+	}
+
+	jobs, err := s.discoverJobs(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to discover scheduled jobs: %w", err)
+	}
+
+	job, cfg, err := findRunnableJob(jobs, strings.TrimSpace(jobName), strings.TrimSpace(stackName))
+	if err != nil {
+		return "", err
+	}
+
+	runID := id.GenID()
+	runLog := s.log.With(
+		slog.String("job_id", runID),
+		slog.String("job", job.name),
+		slog.String("stack", getJobStackName(job)),
+		slog.String("mode", string(job.mode)),
+		slog.String("execution_mode", string(cfg.ExecutionMode)),
+	)
+
+	runLog.Info("triggering scheduled run via API")
+
+	lock.LockScheduledDeploy()
+
+	defer lock.UnlockScheduledDeploy()
+
+	err = s.executeScheduledRun(ctx, job, cfg)
+	if err != nil {
+		runLog.Error("scheduled run failed", logger.ErrAttr(err))
+		s.sendRunNotification(job, cfg, runID, false, "Scheduled job failed", fmt.Sprintf("scheduled job '%s' failed to run: %v", job.name, err))
+
+		return runID, err
+	}
+
+	runLog.Info("scheduled run completed")
+	s.sendRunNotification(job, cfg, runID, true, "Scheduled job completed", fmt.Sprintf("scheduled job '%s' completed successfully", job.name))
+
+	return runID, nil
+}
+
+func findRunnableJob(jobs []scheduledJob, jobName, stackName string) (scheduledJob, docker.JobScheduleConfig, error) {
+	var (
+		matchedJob scheduledJob
+		matchedCfg docker.JobScheduleConfig
+		matches    int
+	)
+
+	for _, job := range jobs {
+		if job.name != jobName {
+			continue
+		}
+
+		if stackName != "" && getJobStackName(job) != stackName {
+			continue
+		}
+
+		cfg, enabled, err := docker.ParseJobScheduleLabels(job.labels)
+		if err != nil {
+			return scheduledJob{}, docker.JobScheduleConfig{}, fmt.Errorf("job %q has invalid schedule labels: %w", jobName, err)
+		}
+
+		if !enabled {
+			return scheduledJob{}, docker.JobScheduleConfig{}, ErrScheduledJobDisabled
+		}
+
+		matchedJob = job
+		matchedCfg = cfg
+		matches++
+	}
+
+	if matches == 0 {
+		return scheduledJob{}, docker.JobScheduleConfig{}, ErrScheduledJobNotFound
+	}
+
+	if matches > 1 {
+		return scheduledJob{}, docker.JobScheduleConfig{}, ErrScheduledJobAmbiguous
+	}
+
+	return matchedJob, matchedCfg, nil
 }
 
 func (s *scheduler) run(ctx context.Context) {
@@ -606,4 +804,20 @@ func firstContainerName(names []string) string {
 	}
 
 	return names[0]
+}
+
+func parseRFC3339Time(raw string) *time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return nil
+	}
+
+	u := t.UTC()
+
+	return &u
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -204,6 +204,7 @@ func TestParseJobScheduleExpression_NextRunUsesLocalTimezone_Berlin(t *testing.T
 
 	originalLocal := time.Local
 	time.Local = berlin
+
 	t.Cleanup(func() {
 		time.Local = originalLocal
 	})

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -116,6 +117,80 @@ func TestGetJobStackName(t *testing.T) {
 			got := getJobStackName(scheduledJob{labels: tt.labels})
 			if got != tt.want {
 				t.Fatalf("getJobStackName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindRunnableJob(t *testing.T) {
+	t.Parallel()
+
+	validLabels := map[string]string{
+		docker.DocoCDJobLabels.JobEnabled:  "true",
+		docker.DocoCDJobLabels.JobSchedule: "@every 1m",
+	}
+
+	tests := []struct {
+		name      string
+		jobs      []scheduledJob
+		jobName   string
+		stackName string
+		wantErr   error
+	}{
+		{
+			name: "single matching job",
+			jobs: []scheduledJob{
+				{name: "stack-backup-1", labels: validLabels},
+			},
+			jobName: "stack-backup-1",
+		},
+		{
+			name: "stack filter avoids ambiguity",
+			jobs: []scheduledJob{
+				{name: "backup", labels: map[string]string{docker.DocoCDJobLabels.JobEnabled: "true", docker.DocoCDJobLabels.JobSchedule: "@every 1m", api.ProjectLabel: "stack-a"}},
+				{name: "backup", labels: map[string]string{docker.DocoCDJobLabels.JobEnabled: "true", docker.DocoCDJobLabels.JobSchedule: "@every 1m", api.ProjectLabel: "stack-b"}},
+			},
+			jobName:   "backup",
+			stackName: "stack-a",
+		},
+		{
+			name: "job not found",
+			jobs: []scheduledJob{
+				{name: "other", labels: validLabels},
+			},
+			jobName: "backup",
+			wantErr: ErrScheduledJobNotFound,
+		},
+		{
+			name: "job disabled",
+			jobs: []scheduledJob{
+				{name: "backup", labels: map[string]string{docker.DocoCDJobLabels.JobEnabled: "false", docker.DocoCDJobLabels.JobSchedule: "@every 1m"}},
+			},
+			jobName: "backup",
+			wantErr: ErrScheduledJobDisabled,
+		},
+		{
+			name: "ambiguous job name",
+			jobs: []scheduledJob{
+				{name: "backup", labels: validLabels},
+				{name: "backup", labels: validLabels},
+			},
+			jobName: "backup",
+			wantErr: ErrScheduledJobAmbiguous,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := findRunnableJob(tt.jobs, tt.jobName, tt.stackName)
+			if tt.wantErr == nil && err != nil {
+				t.Fatalf("findRunnableJob() unexpected error = %v", err)
+			}
+
+			if tt.wantErr != nil && !errors.Is(err, tt.wantErr) {
+				t.Fatalf("findRunnableJob() error = %v, want %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -195,3 +195,29 @@ func TestFindRunnableJob(t *testing.T) {
 		})
 	}
 }
+
+func TestParseJobScheduleExpression_NextRunUsesLocalTimezone_Berlin(t *testing.T) {
+	berlin, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatalf("time.LoadLocation() failed: %v", err)
+	}
+
+	originalLocal := time.Local
+	time.Local = berlin
+	t.Cleanup(func() {
+		time.Local = originalLocal
+	})
+
+	schedule, err := docker.ParseJobScheduleExpression("0 */6 * * *")
+	if err != nil {
+		t.Fatalf("ParseJobScheduleExpression() failed: %v", err)
+	}
+
+	now := time.Date(2026, time.May, 11, 0, 30, 0, 0, time.Local)
+	got := schedule.Next(now)
+	want := time.Date(2026, time.May, 11, 6, 0, 0, 0, time.Local)
+
+	if !got.Equal(want) {
+		t.Fatalf("schedule.Next() = %s, want %s", got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}

--- a/wiki/docs/Endpoints/REST-API.md
+++ b/wiki/docs/Endpoints/REST-API.md
@@ -97,17 +97,17 @@ curl --request POST \
 
 | Endpoint                    | Method | Description                                     | Query Parameters                                                                                                                                                           |
 |-----------------------------|--------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `/v1/api/jobs/scheduled`    | GET    | List all discovered scheduled jobs.             | - `stack` (string, optional): Return scheduled jobs only for one stack/project.                                                                                            |
+| `/v1/api/jobs`              | GET    | List all discovered scheduled jobs.             | - `stack` (string, optional): Return scheduled jobs only for one stack/project.                                                                                            |
 | `/v1/api/job/{jobName}/run` | POST   | Trigger a configured scheduled job immediately. | - `stack` (string, optional): Limit matching to a specific stack/project.<br/>- `wait` (boolean, default: `true`): Wait for the triggered run to finish before responding. |
 
-!!! question "What is the `jobName` for a scheduled job?"
+??? question "What is the `jobName` for a scheduled job?"
     `jobName` is the runtime name of the scheduled target:
 
     - Docker (standalone): the container name (for example `my-stack-backup-1`)
     - Docker Swarm: the service name (for example `my-stack_backup`)
 
-!!! question "How do I find the `jobName` for a scheduled job?"
-    You can get the `jobName` from the scheduler logs (`"job":"..."`) or from `GET /v1/api/jobs/scheduled`.
+??? question "How do I find the `jobName` for a scheduled job?"
+    You can get the `jobName` from the scheduler logs (`"job":"..."`) or from `GET /v1/api/jobs`.
 
 - If multiple jobs share the same `jobName`, provide `stack` to disambiguate for the run endpoint.
 - If the matched job is disabled, the run endpoint returns a conflict response.
@@ -141,7 +141,7 @@ curl --request POST \
 
     ```sh
     curl --request GET \
-      --url 'https://cd.example.com/v1/api/jobs/scheduled?stack=my-stack' \
+      --url 'https://cd.example.com/v1/api/jobs?stack=my-stack' \
       --header 'x-api-key: your-api-key'
     ```
 

--- a/wiki/docs/Endpoints/REST-API.md
+++ b/wiki/docs/Endpoints/REST-API.md
@@ -93,6 +93,58 @@ curl --request POST \
 ]'
 ```
 
+### Scheduled Jobs
+
+| Endpoint                    | Method | Description                                     | Query Parameters                                                                                                                                                           |
+|-----------------------------|--------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `/v1/api/jobs/scheduled`    | GET    | List all discovered scheduled jobs.             | - `stack` (string, optional): Return scheduled jobs only for one stack/project.                                                                                            |
+| `/v1/api/job/{jobName}/run` | POST   | Trigger a configured scheduled job immediately. | - `stack` (string, optional): Limit matching to a specific stack/project.<br/>- `wait` (boolean, default: `true`): Wait for the triggered run to finish before responding. |
+
+!!! question "What is the `jobName` for a scheduled job?"
+    `jobName` is the runtime name of the scheduled target:
+
+    - Docker (standalone): the container name (for example `my-stack-backup-1`)
+    - Docker Swarm: the service name (for example `my-stack_backup`)
+
+!!! question "How do I find the `jobName` for a scheduled job?"
+    You can get the `jobName` from the scheduler logs (`"job":"..."`) or from `GET /v1/api/jobs/scheduled`.
+
+- If multiple jobs share the same `jobName`, provide `stack` to disambiguate for the run endpoint.
+- If the matched job is disabled, the run endpoint returns a conflict response.
+
+**Common run endpoint outcomes**
+
+- `200 OK`: run triggered and completed (`wait=true`).
+- `202 Accepted`: run accepted and running in background (`wait=false`).
+- `404 Not Found`: no scheduled job matched `jobName` (and optional `stack`).
+- `409 Conflict`: matched job is disabled or the selection is ambiguous.
+
+#### Example Request
+
+=== "Trigger a job by container name"
+
+    ```sh
+    curl --request POST \
+      --url 'https://cd.example.com/v1/api/job/my-stack-backup-1/run?wait=true' \
+      --header 'x-api-key: your-api-key'
+    ```
+
+=== "Trigger a job by service name in a specific stack"
+
+    ```sh
+    curl --request POST \
+      --url 'https://cd.example.com/v1/api/job/backup/run?stack=my-stack&wait=true' \
+      --header 'x-api-key: your-api-key'
+    ```
+
+=== "List all scheduled jobs for a specific stack"
+
+    ```sh
+    curl --request GET \
+      --url 'https://cd.example.com/v1/api/jobs/scheduled?stack=my-stack' \
+      --header 'x-api-key: your-api-key'
+    ```
+
 ### Compose Projects
 
 !!! note


### PR DESCRIPTION
This PR fixes a bug that caused jobs to always be scheduled with UTC timezone instead of the local/set timezone.

It also adds two new API endpoints to list and trigger scheduled jobs.

| Endpoint                    | Method | Description                                     | Query Parameters                                                                                                                                                           |
|-----------------------------|--------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `/v1/api/jobs`              | GET    | List all discovered scheduled jobs.             | - `stack` (string, optional): Return scheduled jobs only for one stack/project.                                                                                            |
| `/v1/api/job/{jobName}/run` | POST   | Trigger a configured scheduled job immediately. | - `stack` (string, optional): Limit matching to a specific stack/project.<br/>- `wait` (boolean, default: `true`): Wait for the triggered run to finish before responding. |

**What is the `jobName` for a scheduled job?**
`jobName` is the runtime name of the scheduled target:

- Docker (standalone): the container name (for example `my-stack-backup-1`)
- Docker Swarm: the service name (for example `my-stack_backup`)

**How do I find the `jobName` for a scheduled job?**
You can get the `jobName` from the scheduler logs (`"job":"..."`) or from `GET /v1/api/jobs`.

- If multiple jobs share the same `jobName`, provide `stack` to disambiguate for the run endpoint.
- If the matched job is disabled, the run endpoint returns a conflict response.

**Common run endpoint outcomes**

- `200 OK`: run triggered and completed (`wait=true`).
- `202 Accepted`: run accepted and running in background (`wait=false`).
- `404 Not Found`: no scheduled job matched `jobName` (and optional `stack`).
- `409 Conflict`: matched job is disabled or the selection is ambiguous.

#### Example Request

##### Trigger a job by container name

```sh
curl --request POST \
  --url 'https://cd.example.com/v1/api/job/my-stack-backup-1/run?wait=true' \
  --header 'x-api-key: your-api-key'
```

##### Trigger a job by service name in a specific stack

```sh
curl --request POST \
  --url 'https://cd.example.com/v1/api/job/backup/run?stack=my-stack&wait=true' \
  --header 'x-api-key: your-api-key'
```

##### List all scheduled jobs for a specific stack

```sh
curl --request GET \
  --url 'https://cd.example.com/v1/api/jobs?stack=my-stack' \
  --header 'x-api-key: your-api-key'
```