### PR TITLE
refactor(scheduler): rename execution mode from `one_shot` to `one_off` for consistency

### DIFF
--- a/internal/docker/compose_start_services_test.go
+++ b/internal/docker/compose_start_services_test.go
@@ -43,7 +43,7 @@ func TestGetStartServicesForDeploy(t *testing.T) {
 				Labels: map[string]string{
 					docoCDJobLabelNames.JobEnabled:       "true",
 					docoCDJobLabelNames.JobSchedule:      "@hourly",
-					docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneShot),
+					docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
 				},
 			},
 		},

--- a/internal/docker/container_run.go
+++ b/internal/docker/container_run.go
@@ -50,7 +50,7 @@ func getContainerRunAction(inspectResult containerTypes.InspectResponse) contain
 	return containerRunActionRestart
 }
 
-func RunContainerOneShotFromExisting(ctx context.Context, apiClient client.APIClient, containerID string) error {
+func RunContainerOneOffFromExisting(ctx context.Context, apiClient client.APIClient, containerID string) error {
 	inspectResult, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
 	if err != nil {
 		return fmt.Errorf("inspect container %s: %w", containerID, err)
@@ -84,26 +84,26 @@ func RunContainerOneShotFromExisting(ctx context.Context, apiClient client.APICl
 		Name:             tmpName,
 	})
 	if err != nil {
-		return fmt.Errorf("create one-shot container from %s: %w", containerID, err)
+		return fmt.Errorf("create one-off container from %s: %w", containerID, err)
 	}
 
 	if _, err = apiClient.ContainerStart(ctx, createResult.ID, client.ContainerStartOptions{}); err != nil {
-		return fmt.Errorf("start one-shot container %s: %w", createResult.ID, err)
+		return fmt.Errorf("start one-off container %s: %w", createResult.ID, err)
 	}
 
 	waitResult := apiClient.ContainerWait(ctx, createResult.ID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNotRunning})
 	select {
 	case waitErr := <-waitResult.Error:
 		if waitErr != nil {
-			return fmt.Errorf("wait for one-shot container %s: %w", createResult.ID, waitErr)
+			return fmt.Errorf("wait for one-off container %s: %w", createResult.ID, waitErr)
 		}
 	case waitStatus := <-waitResult.Result:
 		if waitStatus.Error != nil && waitStatus.Error.Message != "" {
-			return fmt.Errorf("one-shot container %s failed: %s", createResult.ID, waitStatus.Error.Message)
+			return fmt.Errorf("one-off container %s failed: %s", createResult.ID, waitStatus.Error.Message)
 		}
 
 		if waitStatus.StatusCode != 0 {
-			return fmt.Errorf("one-shot container %s exited with status %d", createResult.ID, waitStatus.StatusCode)
+			return fmt.Errorf("one-off container %s exited with status %d", createResult.ID, waitStatus.StatusCode)
 		}
 	}
 

--- a/internal/docker/job_schedule.go
+++ b/internal/docker/job_schedule.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
@@ -12,7 +13,12 @@ type JobExecutionMode string
 
 const (
 	JobExecutionModeRestart JobExecutionMode = "restart"
-	JobExecutionModeOneShot JobExecutionMode = "one_shot"
+	JobExecutionModeOneOff  JobExecutionMode = "one_off"
+
+	// JobExecutionModeOneShotDeprecated is the deprecated alias for JobExecutionModeOneOff.
+	// Deprecated: still accepted for backward compatibility but will log a warning
+	// TODO: Remove in a future release.
+	JobExecutionModeOneShotDeprecated JobExecutionMode = "one_shot"
 )
 
 type JobNotifyOn string
@@ -55,7 +61,14 @@ func ParseJobScheduleExpression(spec string) (cron.Schedule, error) {
 	return schedule, nil
 }
 
-func ParseJobScheduleLabels(labels map[string]string) (JobScheduleConfig, bool, error) {
+func ParseJobScheduleLabels(labels map[string]string, log ...*slog.Logger) (JobScheduleConfig, bool, error) {
+	var logger *slog.Logger
+	if len(log) > 0 && log[0] != nil {
+		logger = log[0]
+	} else {
+		logger = slog.Default()
+	}
+
 	cfg := JobScheduleConfig{
 		ExecutionMode: JobExecutionModeRestart,
 		NotifyOn:      JobNotifyAll,
@@ -101,8 +114,14 @@ func ParseJobScheduleLabels(labels map[string]string) (JobScheduleConfig, bool, 
 	if modeRaw, ok := labels[docoCDJobLabelNames.JobExecutionMode]; ok {
 		mode := JobExecutionMode(strings.TrimSpace(modeRaw))
 		switch mode {
-		case JobExecutionModeRestart, JobExecutionModeOneShot:
+		case JobExecutionModeRestart, JobExecutionModeOneOff:
 			cfg.ExecutionMode = mode
+		case JobExecutionModeOneShotDeprecated:
+			logger.Warn(
+				fmt.Sprintf("label %s: value %q is deprecated, use %q instead", docoCDJobLabelNames.JobExecutionMode, JobExecutionModeOneShotDeprecated, JobExecutionModeOneOff),
+				slog.String("label", docoCDJobLabelNames.JobExecutionMode),
+			)
+			cfg.ExecutionMode = JobExecutionModeOneOff
 		default:
 			return cfg, false, fmt.Errorf("invalid %s label value %q", docoCDJobLabelNames.JobExecutionMode, modeRaw)
 		}

--- a/internal/docker/job_schedule_test.go
+++ b/internal/docker/job_schedule_test.go
@@ -35,7 +35,7 @@ func TestParseJobScheduleLabels(t *testing.T) {
 		docoCDJobLabelNames.JobEnabled:       "true",
 		docoCDJobLabelNames.JobSchedule:      "*/10 * * * *",
 		docoCDJobLabelNames.JobSkipRunning:   "true",
-		docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneShot),
+		docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
 		docoCDJobLabelNames.JobNotifyOn:      string(JobNotifyFailure),
 		docoCDJobLabelNames.JobSwarmReplicas: "3",
 	}
@@ -49,7 +49,7 @@ func TestParseJobScheduleLabels(t *testing.T) {
 		t.Fatalf("expected enabled=true")
 	}
 
-	if cfg.ExecutionMode != JobExecutionModeOneShot {
+	if cfg.ExecutionMode != JobExecutionModeOneOff {
 		t.Fatalf("unexpected execution mode: %s", cfg.ExecutionMode)
 	}
 
@@ -63,6 +63,27 @@ func TestParseJobScheduleLabels(t *testing.T) {
 
 	if cfg.SwarmReplicas != 3 {
 		t.Fatalf("unexpected swarm replicas: %d", cfg.SwarmReplicas)
+	}
+}
+
+func TestParseJobScheduleLabels_OneShotDeprecatedAlias(t *testing.T) {
+	t.Parallel()
+
+	cfg, enabled, err := ParseJobScheduleLabels(map[string]string{
+		docoCDJobLabelNames.JobEnabled:       "true",
+		docoCDJobLabelNames.JobSchedule:      "0 * * * *",
+		docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneShotDeprecated),
+	})
+	if err != nil {
+		t.Fatalf("ParseJobScheduleLabels() failed with deprecated one_shot alias: %v", err)
+	}
+
+	if !enabled {
+		t.Fatalf("expected enabled=true")
+	}
+
+	if cfg.ExecutionMode != JobExecutionModeOneOff {
+		t.Fatalf("expected execution mode to be normalized to %q, got %q", JobExecutionModeOneOff, cfg.ExecutionMode)
 	}
 }
 

--- a/internal/docker/job_schedule_validation_test.go
+++ b/internal/docker/job_schedule_validation_test.go
@@ -50,16 +50,16 @@ func TestValidateScheduledJobPolicies(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:      "standalone allows one_shot with restart unset",
+			name:      "standalone allows one_off with restart unset",
 			swarmMode: false,
 			project: &types.Project{
 				Services: types.Services{
-					"ok-one-shot": {
-						Name: "ok-one-shot",
+					"ok-one-off": {
+						Name: "ok-one-off",
 						Labels: map[string]string{
 							docoCDJobLabelNames.JobEnabled:       "true",
 							docoCDJobLabelNames.JobSchedule:      "*/10 * * * *",
-							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneShot),
+							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
 						},
 					},
 				},
@@ -81,7 +81,7 @@ func TestValidateScheduledJobPolicies(t *testing.T) {
 						Labels: map[string]string{
 							docoCDJobLabelNames.JobEnabled:       "true",
 							docoCDJobLabelNames.JobSchedule:      "0 * * * *",
-							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneShot),
+							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
 						},
 					},
 				},
@@ -104,7 +104,7 @@ func TestValidateScheduledJobPolicies(t *testing.T) {
 						Labels: map[string]string{
 							docoCDJobLabelNames.JobEnabled:       "true",
 							docoCDJobLabelNames.JobSchedule:      "@every 1h",
-							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneShot),
+							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
 						},
 					},
 				},

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -78,9 +78,9 @@ var docoCDJobLabelNames = struct {
 	JobEnabled       string // Enable scheduling for a service/container
 	JobSchedule      string // Schedule of the job in 5-field cron format or @every duration
 	JobSkipRunning   string // Skip a schedule trigger when a previous run is still in progress
-	JobExecutionMode string // Defines if a run restarts/reruns the job or starts an ephemeral one-shot execution
+	JobExecutionMode string // Defines if a run restarts/reruns the job or starts an ephemeral one-off execution
 	JobNotifyOn      string // Controls notification behavior: none, success, failure, all
-	JobSwarmReplicas string // Number of replicas for one-shot replicated-job runs in swarm mode
+	JobSwarmReplicas string // Number of replicas for one-off replicated-job runs in swarm mode
 	JobLastRun       string // Timestamp of the last run in RFC3339 format
 	JobNextRun       string // Timestamp of the next scheduled run in RFC3339 format
 }{

--- a/internal/docker/swarm_job.go
+++ b/internal/docker/swarm_job.go
@@ -192,13 +192,13 @@ func RunImageRemoveJob(ctx context.Context, dockerCLI command.Cli, images []stri
 	return RunSwarmJob(ctx, dockerCLI, swarm.DeployModeGlobalJob, args, "image-remove")
 }
 
-type SwarmOneShotFromServiceOptions struct {
+type SwarmOneOffFromServiceOptions struct {
 	Replicas         uint64
 	SendRegistryAuth bool
 }
 
-// RunSwarmOneShotFromService creates a temporary job service from an existing service spec and waits for completion.
-func RunSwarmOneShotFromService(ctx context.Context, dockerCLI command.Cli, serviceName string, opts SwarmOneShotFromServiceOptions) error {
+// RunSwarmOneOffFromService creates a temporary job service from an existing service spec and waits for completion.
+func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, serviceName string, opts SwarmOneOffFromServiceOptions) error {
 	apiClient := dockerCLI.Client()
 
 	if opts.Replicas == 0 {
@@ -211,26 +211,26 @@ func RunSwarmOneShotFromService(ctx context.Context, dockerCLI command.Cli, serv
 	}
 
 	sourceService := inspectResult.Service
-	oneShotSpec := sourceService.Spec
-	oneShotSpec.Name = fmt.Sprintf("%s-doco-job-%d", sourceService.Spec.Name, time.Now().UTC().UnixNano())
+	oneOffSpec := sourceService.Spec
+	oneOffSpec.Name = fmt.Sprintf("%s-doco-job-%d", sourceService.Spec.Name, time.Now().UTC().UnixNano())
 
-	if oneShotSpec.TaskTemplate.ContainerSpec == nil {
+	if oneOffSpec.TaskTemplate.ContainerSpec == nil {
 		return fmt.Errorf("service %s has no task container spec", serviceName)
 	}
 
-	if oneShotSpec.Labels == nil {
-		oneShotSpec.Labels = map[string]string{}
+	if oneOffSpec.Labels == nil {
+		oneOffSpec.Labels = map[string]string{}
 	}
 
-	oneShotSpec.Labels[DocoCDLabels.Metadata.Manager] = app.Name
-	oneShotSpec.Labels[DocoCDLabels.Deployment.Trigger] = "job.schedule"
+	oneOffSpec.Labels[DocoCDLabels.Metadata.Manager] = app.Name
+	oneOffSpec.Labels[DocoCDLabels.Deployment.Trigger] = "job.schedule"
 
 	if sourceService.Spec.Mode.Global != nil || sourceService.Spec.Mode.GlobalJob != nil {
-		oneShotSpec.Mode = swarmTypes.ServiceMode{
+		oneOffSpec.Mode = swarmTypes.ServiceMode{
 			GlobalJob: &swarmTypes.GlobalJob{},
 		}
 	} else {
-		oneShotSpec.Mode = swarmTypes.ServiceMode{
+		oneOffSpec.Mode = swarmTypes.ServiceMode{
 			ReplicatedJob: &swarmTypes.ReplicatedJob{
 				TotalCompletions: &opts.Replicas,
 				MaxConcurrent:    &opts.Replicas,
@@ -238,18 +238,18 @@ func RunSwarmOneShotFromService(ctx context.Context, dockerCLI command.Cli, serv
 		}
 	}
 
-	oneShotSpec.UpdateConfig = nil
-	oneShotSpec.RollbackConfig = nil
-	oneShotSpec.TaskTemplate.RestartPolicy = &swarmTypes.RestartPolicy{
+	oneOffSpec.UpdateConfig = nil
+	oneOffSpec.RollbackConfig = nil
+	oneOffSpec.TaskTemplate.RestartPolicy = &swarmTypes.RestartPolicy{
 		Condition: swarmTypes.RestartPolicyConditionNone,
 	}
 
 	createOpts := client.ServiceCreateOptions{
-		Spec: oneShotSpec,
+		Spec: oneOffSpec,
 	}
 
 	if opts.SendRegistryAuth {
-		encodedAuth, authErr := command.RetrieveAuthTokenFromImage(dockerCLI.ConfigFile(), oneShotSpec.TaskTemplate.ContainerSpec.Image)
+		encodedAuth, authErr := command.RetrieveAuthTokenFromImage(dockerCLI.ConfigFile(), oneOffSpec.TaskTemplate.ContainerSpec.Image)
 		if authErr != nil {
 			return fmt.Errorf("retrieve auth token from image: %w", authErr)
 		}
@@ -259,7 +259,7 @@ func RunSwarmOneShotFromService(ctx context.Context, dockerCLI command.Cli, serv
 
 	createResult, err := apiClient.ServiceCreate(ctx, createOpts)
 	if err != nil {
-		return fmt.Errorf("create one-shot service from %s: %w", serviceName, err)
+		return fmt.Errorf("create one-off service from %s: %w", serviceName, err)
 	}
 
 	defer func() {
@@ -267,7 +267,7 @@ func RunSwarmOneShotFromService(ctx context.Context, dockerCLI command.Cli, serv
 	}()
 
 	if err = swarm.WaitOnServices(ctx, dockerCLI, []string{createResult.ID}); err != nil {
-		return fmt.Errorf("wait one-shot service %s: %w", createResult.ID, err)
+		return fmt.Errorf("wait one-off service %s: %w", createResult.ID, err)
 	}
 
 	return nil

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -145,7 +145,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		info.LastRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobLastRun])
 		info.LabelNextRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobNextRun])
 
-		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels)
+		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels, s.log)
 		if parseErr != nil {
 			info.Valid = false
 			info.ScheduleError = parseErr.Error()
@@ -340,7 +340,7 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 	for _, job := range jobs {
 		discoveredByKey[job.key] = job
 
-		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels)
+		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels, s.log)
 		if parseErr != nil {
 			s.log.Warn("ignoring job with invalid schedule labels",
 				slog.String("job", job.name),
@@ -650,15 +650,15 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 	switch job.mode {
 	case scheduledJobModeContainer:
 		switch cfg.ExecutionMode {
-		case docker.JobExecutionModeOneShot:
-			return docker.RunContainerOneShotFromExisting(ctx, s.dockerCli.Client(), job.id)
+		case docker.JobExecutionModeOneOff:
+			return docker.RunContainerOneOffFromExisting(ctx, s.dockerCli.Client(), job.id)
 		default:
 			return docker.RestartContainer(ctx, s.dockerCli.Client(), job.id)
 		}
 	case scheduledjobModeSwarm:
 		switch cfg.ExecutionMode {
-		case docker.JobExecutionModeOneShot:
-			return docker.RunSwarmOneShotFromService(ctx, s.dockerCli, job.id, docker.SwarmOneShotFromServiceOptions{
+		case docker.JobExecutionModeOneOff:
+			return docker.RunSwarmOneOffFromService(ctx, s.dockerCli, job.id, docker.SwarmOneOffFromServiceOptions{
 				Replicas:         cfg.SwarmReplicas,
 				SendRegistryAuth: true,
 			})

--- a/wiki/docs/Advanced/Scheduled-Jobs.md
+++ b/wiki/docs/Advanced/Scheduled-Jobs.md
@@ -90,9 +90,9 @@ The execution mode determines how scheduled jobs are run and managed by doco-cd 
 By default, scheduled jobs will be executed in `restart` mode, which means the service will be created on deployment 
 and then re-/started at the scheduled time without being removed after completion.
 
-### `one_shot`
+### `one_off`
 
-Alternatively, you can configure scheduled jobs to run in `one_shot` mode, which means a new ephemeral container will 
+Alternatively, you can configure scheduled jobs to run in `one_off` mode, which means a new ephemeral container will 
 be created for each scheduled run and removed after completion.
 
 !!! note
@@ -100,23 +100,23 @@ be created for each scheduled run and removed after completion.
     so make sure to configure appropriate logging (e.g., log to a persistent file or logging service like [Loki](https://grafana.com/docs/loki/latest/)) 
     if you need to keep track of job runs and [notifications](Notifications.md) if needed.
 
-??? info "`one_shot` behavior in Docker Swarm"
+??? info "`one_off` behavior in Docker Swarm"
 
-    In Docker Swarm, `one_shot` does **not** modify the source service mode permanently.
+    In Docker Swarm, `one_off` does **not** modify the source service mode permanently.
     Instead, doco-cd creates a temporary job service for each scheduled run, waits for completion,
     and removes that temporary service afterwards.
     
     This means the original service may still show `replicated`/`global` when inspected,
-    while each one-shot execution runs as a temporary `replicated-job`/`global-job` service.
+    while each one-off execution runs as a temporary `replicated-job`/`global-job` service.
 
-    See also [Swarm `deploy.mode` configuration](#swarm-deploymode) for how the original service's deploy mode affects the temporary job service's deploy mode in one-shot executions.
+    See also [Swarm `deploy.mode` configuration](#swarm-deploymode) for how the original service's deploy mode affects the temporary job service's deploy mode in one-off executions.
 
     **Behavior summary**
     
     | `cd.doco.job.execution_mode` | What doco-cd acts on | Service mode after run |
     |------------------------------|----------------------|------------------------|
     | `restart`                    | Existing service     | Unchanged              |
-    | `one_shot`                   | Temporary clone      | Source unchanged       |
+    | `one_off`                    | Temporary clone      | Source unchanged       |
 
 ## Configuration
 
@@ -139,20 +139,20 @@ be created for each scheduled run and removed after completion.
 
 Use the following service labels to configure scheduled jobs:
 
-| Label                        | Type    | Description                                                                                                | Default   |
-|------------------------------|---------|------------------------------------------------------------------------------------------------------------|-----------|
-| `cd.doco.job.enabled`        | boolean | Enable scheduling for this service/container                                                               | `false`   |
-| `cd.doco.job.schedule`       | string  | [Schedule format](#schedule-formats) to use                                                                |           |
-| `cd.doco.job.execution_mode` | string  | [`restart`](#restart) (default behavior) or [`one_shot`](#one_shot) (ephemeral execution)                  | `restart` |
-| `cd.doco.job.skip_running`   | boolean | Do not run the job if a previous scheduled run is still active/running                                     | `false`   |
-| `cd.doco.job.notify_on`      | string  | [Notification](Notifications.md) behavior for scheduled runs: `none`, `success`, `failure`, `all`          | `all`     |
-| `cd.doco.job.swarm.replicas` | integer | Number of completions/concurrency for swarm one-shot jobs in `replicated` [deploy mode](#swarm-deploymode) | `1`       |
+| Label                        | Type    | Description                                                                                               | Default   |
+|------------------------------|---------|-----------------------------------------------------------------------------------------------------------|-----------|
+| `cd.doco.job.enabled`        | boolean | Enable scheduling for this service/container                                                              | `false`   |
+| `cd.doco.job.schedule`       | string  | [Schedule format](#schedule-formats) to use                                                               |           |
+| `cd.doco.job.execution_mode` | string  | [`restart`](#restart) (default behavior) or [`one_off`](#one_off) (ephemeral execution)                   | `restart` |
+| `cd.doco.job.skip_running`   | boolean | Do not run the job if a previous scheduled run is still active/running                                    | `false`   |
+| `cd.doco.job.notify_on`      | string  | [Notification](Notifications.md) behavior for scheduled runs: `none`, `success`, `failure`, `all`         | `all`     |
+| `cd.doco.job.swarm.replicas` | integer | Number of completions/concurrency for swarm one-off jobs in `replicated` [deploy mode](#swarm-deploymode) | `1`       |
 
 ### Swarm `deploy.mode`
 
 When using Docker Swarm, you can configure the deploy mode for scheduled jobs using the `deploy.mode` field in your docker compose file.
 
-The following mapping applies to scheduled runs in `one_shot` mode:
+The following mapping applies to scheduled runs in `one_off` mode:
 
 - If the service uses `#!yaml deploy.mode: global`, the job run is created as `global-job`
 - If the service uses `#!yaml deploy.mode: replicated` or does not specify a deploy mode, the job run is created as `replicated-job` with the number of completions/concurrency determined by the `cd.doco.job.swarm.replicas` label.
@@ -161,7 +161,7 @@ The following mapping applies to scheduled runs in `one_shot` mode:
 
 === "Prune swarm nodes"
 
-    Prune Docker system every hour on all swarm nodes using a global one-shot job service
+    Prune Docker system every hour on all swarm nodes using a global one-off job service
 
     ```yaml title="docker-compose.yml"
     services:
@@ -177,8 +177,12 @@ The following mapping applies to scheduled runs in `one_shot` mode:
         labels:
           cd.doco.job.enabled: "true"
           cd.doco.job.schedule: "@hourly"
-          cd.doco.job.execution_mode: "one_shot"
+          cd.doco.job.execution_mode: "one_off"
     ```
+
+!!! warning "Deprecated: `one_shot`"
+    The value `one_shot` is deprecated and will be removed in a future release.
+    Use `one_off` instead. The old value is still accepted for backward compatibility but will log a warning.
 
 === "Backup"
 

--- a/wiki/docs/Advanced/Scheduled-Jobs.md
+++ b/wiki/docs/Advanced/Scheduled-Jobs.md
@@ -118,6 +118,10 @@ be created for each scheduled run and removed after completion.
     | `restart`                    | Existing service     | Unchanged              |
     | `one_off`                    | Temporary clone      | Source unchanged       |
 
+??? warning "Deprecated: `one_shot` has been renamed to `one_off`"
+    `one_shot` has been renamed to `one_off` and will be removed in a future release.
+    Use `one_off` instead. The old value is still accepted for backward compatibility but will log a warning.
+
 ## Configuration
 
 ??? example "How to set service labels in a docker compose file"
@@ -179,10 +183,6 @@ The following mapping applies to scheduled runs in `one_off` mode:
           cd.doco.job.schedule: "@hourly"
           cd.doco.job.execution_mode: "one_off"
     ```
-
-!!! warning "Deprecated: `one_shot`"
-    The value `one_shot` is deprecated and will be removed in a future release.
-    Use `one_off` instead. The old value is still accepted for backward compatibility but will log a warning.
 
 === "Backup"
 


### PR DESCRIPTION
> [!WARNING] 
> Deprecated: `one_shot` has been renamed to `one_off`

`one_shot` has been renamed to `one_off` and will be removed in a future release.
Use `one_off` instead. The old value is still accepted for backward compatibility but will log a warning.