### PR TITLE
fix(scheduler): prevent race condition in one-off container wait

### DIFF
--- a/internal/docker/container_run.go
+++ b/internal/docker/container_run.go
@@ -87,11 +87,16 @@ func RunContainerOneShotFromExisting(ctx context.Context, apiClient client.APICl
 		return fmt.Errorf("create one-shot container from %s: %w", containerID, err)
 	}
 
+	// Subscribe to wait BEFORE starting so we don't race with a fast-exiting
+	// (auto-removed) container: if ContainerStart is called first the container
+	// may finish and be removed before ContainerWait registers, causing a
+	// "No such container" error.
+	waitResult := apiClient.ContainerWait(ctx, createResult.ID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNotRunning})
+
 	if _, err = apiClient.ContainerStart(ctx, createResult.ID, client.ContainerStartOptions{}); err != nil {
 		return fmt.Errorf("start one-shot container %s: %w", createResult.ID, err)
 	}
 
-	waitResult := apiClient.ContainerWait(ctx, createResult.ID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNotRunning})
 	select {
 	case waitErr := <-waitResult.Error:
 		if waitErr != nil {


### PR DESCRIPTION
This PR fixes a race condition: `ContainerWait` is called after `ContainerStart`. With `AutoRemove`: `true`, a fast-exiting container can finish and be removed before `ContainerWait` is even called — the daemon then returns "No such container".