### PR TITLE
refactor(poll): update interval handling to use Go durations

### DIFF
--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -94,7 +94,7 @@ func (h *handlerData) PollHandler(ctx context.Context, pollJob *poll.Job) {
 				repoLock.Unlock()
 			}
 
-			pollJob.NextRun = time.Now().Unix() + int64(pollJob.Config.Interval)
+			pollJob.NextRun = time.Now().Add(pollJob.Config.Interval).Unix()
 		} else {
 			logger.Debug("skipping poll, waiting for next run")
 		}
@@ -111,7 +111,7 @@ func (h *handlerData) PollHandler(ctx context.Context, pollJob *poll.Job) {
 		case <-ctx.Done():
 			logger.Debug("ctx is done in poll handler")
 			return
-		case <-time.After(time.Duration(pollJob.Config.Interval) * time.Second):
+		case <-time.After(pollJob.Config.Interval):
 			continue
 		}
 	}
@@ -177,7 +177,7 @@ func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config,
 		pollConfig, webhook.ParsedPayload{},
 	)
 
-	nextRun := time.Now().Add(time.Duration(pollConfig.Interval) * time.Second).Format(time.RFC3339)
+	nextRun := time.Now().Add(pollConfig.Interval).Format(time.RFC3339)
 	elapsedTime := time.Since(startTime)
 
 	if deployErr != nil {

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -158,10 +158,15 @@ func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config,
 		jobLog = jobLog.With(slog.String("custom_target", pollConfig.CustomTarget))
 	}
 
+	configVal := log.BuildLogValue(&pollConfig, "Deployments.Internal")
+	if pollConfig.Source == config.SourceTypeOCI {
+		configVal = log.BuildLogValue(&pollConfig, "Reference", "Deployments.Internal")
+	}
+
 	jobLog.Info("polling "+entity,
 		slog.Group("trigger",
 			slog.String("event", string(stages.JobTriggerPoll)),
-			slog.Attr{Key: "config", Value: log.BuildLogValue(&pollConfig, "Deployments.Internal")}))
+			slog.Attr{Key: "config", Value: configVal}))
 
 	// For OCI sources, use the tag from the artifact reference as the deployment reference
 	// (e.g., "latest" from "ghcr.io/org/repo:latest") rather than pollConfig.Reference.

--- a/cmd/doco-cd/handler_poll_test.go
+++ b/cmd/doco-cd/handler_poll_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/poll"
@@ -33,7 +34,7 @@ func TestRunPoll(t *testing.T) {
 	pollConfig := poll.Config{
 		SourceUrl:    "https://github.com/kimdre/doco-cd_tests.git",
 		Reference:    "main",
-		Interval:     10,
+		Interval:     10 * time.Second,
 		CustomTarget: "",
 	}
 

--- a/dev.compose.yaml
+++ b/dev.compose.yaml
@@ -2,12 +2,12 @@ x-poll-config: &poll-config
   POLL_CONFIG: |
     - source: oci
       url: ghcr.io/kimdre/doco-cd_tests:test
-      interval: 10
+      interval: 10s
     - source: git
       url: https://github.com/kimdre/doco-cd_tests.git
       #url: git@github.com:kimdre/doco-cd_tests.git
       reference: main
-      interval: 10
+      interval: 0
       #target: "bitwarden-sm"
 
 services:
@@ -37,7 +37,7 @@ services:
     environment:
       TZ: Europe/Berlin
       HTTP_PORT: 80
-      LOG_LEVEL: debug
+      LOG_LEVEL: info
       OCI_VERIFY_MAX_WORKERS: 1
       OCI_TRUST_POLICY: |
         enabled: true

--- a/internal/config/poll/poll_config.go
+++ b/internal/config/poll/poll_config.go
@@ -5,6 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/creasty/defaults"
 	"gopkg.in/validator.v2"
@@ -19,10 +23,20 @@ type Config struct {
 	Source       config.SourceType `yaml:"source" json:"source" default:"git"`                   // Source selects the poll source backend (git or oci)
 	SourceUrl    string            `yaml:"url" json:"url"`                                       // SourceUrl is the repository/artifact URL; validated as GitUrl or OciUrl depending on Source
 	Reference    string            `yaml:"reference" json:"reference" default:"refs/heads/main"` // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
-	Interval     int               `yaml:"interval" default:"180"`                               // Interval is the interval in seconds to poll for changes
+	Interval     time.Duration     `yaml:"interval" default:"180s"`                              // Interval is the interval at which to poll for changes
 	CustomTarget string            `yaml:"target" json:"target" default:""`                      // CustomTarget is the name of an optional custom deployment config file, e.g. ".doco-cd.custom-name.yaml"
 	RunOnce      bool              `yaml:"run_once" default:"false"`                             // RunOnce when true, performs a single run and exits
 	Deployments  []*deploy.Config  `yaml:"deployments" json:"deployments" default:"[]"`          // Deployments allows defining deployment configs inline in the poll configuration
+}
+
+type rawConfig struct {
+	Source       config.SourceType `yaml:"source" json:"source" default:"git"`
+	SourceUrl    string            `yaml:"url" json:"url"`
+	Reference    string            `yaml:"reference" json:"reference" default:"refs/heads/main"`
+	Interval     any               `yaml:"interval" json:"interval" default:"180s"`
+	CustomTarget string            `yaml:"target" json:"target" default:""`
+	RunOnce      bool              `yaml:"run_once" json:"run_once" default:"false"`
+	Deployments  []*deploy.Config  `yaml:"deployments" json:"deployments" default:"[]"`
 }
 
 type Job struct {
@@ -31,7 +45,7 @@ type Job struct {
 	NextRun int64  // NextRun is the next time this instance should run
 }
 
-const MinPollInterval = 10 // Minimum allowed poll interval in seconds
+const MinPollInterval = 10 * time.Second // Minimum allowed poll interval
 
 var (
 	ErrInvalidConfig  = errors.New("invalid poll configuration")
@@ -83,7 +97,7 @@ func (c *Config) Validate() error {
 	}
 
 	if c.Interval < MinPollInterval && c.Interval != 0 {
-		return fmt.Errorf("%w: must be at least %d seconds", ErrIntervalTooLow, MinPollInterval)
+		return fmt.Errorf("%w: must be at least %s", ErrIntervalTooLow, MinPollInterval)
 	}
 
 	// If inline deployments are defined, validate them
@@ -117,7 +131,7 @@ func (c *Config) Validate() error {
 
 // String returns a string representation of the Config.
 func (c *Config) String() string {
-	return fmt.Sprintf("Config{Source: %s, SourceUrl: %s, Reference: %s, Interval: %d}", c.Source, c.SourceUrl, c.Reference, c.Interval)
+	return fmt.Sprintf("Config{Source: %s, SourceUrl: %s, Reference: %s, Interval: %s}", c.Source, c.SourceUrl, c.Reference, c.Interval)
 }
 
 func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
@@ -126,11 +140,32 @@ func (c *Config) UnmarshalYAML(unmarshal func(any) error) error {
 		return err
 	}
 
-	type Plain Config
+	raw := rawConfig{
+		Source:       c.Source,
+		SourceUrl:    c.SourceUrl,
+		Reference:    c.Reference,
+		Interval:     c.Interval,
+		CustomTarget: c.CustomTarget,
+		RunOnce:      c.RunOnce,
+		Deployments:  c.Deployments,
+	}
 
-	if err := unmarshal((*Plain)(c)); err != nil {
+	if err := unmarshal(&raw); err != nil {
 		return err
 	}
+
+	parsedInterval, err := parsePollInterval(raw.Interval)
+	if err != nil {
+		return err
+	}
+
+	c.Source = raw.Source
+	c.SourceUrl = raw.SourceUrl
+	c.Reference = raw.Reference
+	c.Interval = parsedInterval
+	c.CustomTarget = raw.CustomTarget
+	c.RunOnce = raw.RunOnce
+	c.Deployments = raw.Deployments
 
 	return nil
 }
@@ -141,11 +176,111 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	type Plain Config
+	raw := rawConfig{
+		Source:       c.Source,
+		SourceUrl:    c.SourceUrl,
+		Reference:    c.Reference,
+		Interval:     c.Interval,
+		CustomTarget: c.CustomTarget,
+		RunOnce:      c.RunOnce,
+		Deployments:  c.Deployments,
+	}
 
-	if err := json.Unmarshal(data, (*Plain)(c)); err != nil {
+	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
+	parsedInterval, err := parsePollInterval(raw.Interval)
+	if err != nil {
+		return err
+	}
+
+	c.Source = raw.Source
+	c.SourceUrl = raw.SourceUrl
+	c.Reference = raw.Reference
+	c.Interval = parsedInterval
+	c.CustomTarget = raw.CustomTarget
+	c.RunOnce = raw.RunOnce
+	c.Deployments = raw.Deployments
+
 	return nil
+}
+
+func parsePollInterval(v any) (time.Duration, error) {
+	if v == nil {
+		return 0, nil
+	}
+
+	switch value := v.(type) {
+	case string:
+		return parsePollIntervalString(value)
+	case int:
+		return secondsToDuration(int64(value))
+	case int64:
+		return secondsToDuration(value)
+	case uint:
+		if uint64(value) > math.MaxInt64 {
+			return 0, fmt.Errorf("invalid interval value %d: out of range", value)
+		}
+
+		return secondsToDuration(int64(value))
+	case uint64:
+		if value > math.MaxInt64 {
+			return 0, fmt.Errorf("invalid interval value %d: out of range", value)
+		}
+
+		return secondsToDuration(int64(value))
+	case float64:
+		if math.Trunc(value) != value {
+			return 0, fmt.Errorf("invalid interval value %v: must be a whole number of seconds", value)
+		}
+
+		if value > math.MaxInt64 || value < math.MinInt64 {
+			return 0, fmt.Errorf("invalid interval value %v: out of range", value)
+		}
+
+		return secondsToDuration(int64(value))
+	case json.Number:
+		seconds, err := value.Int64()
+		if err != nil {
+			return 0, fmt.Errorf("invalid interval value %q: %w", value.String(), err)
+		}
+
+		return secondsToDuration(seconds)
+	default:
+		return 0, fmt.Errorf("invalid interval type %T: expected number or string", v)
+	}
+}
+
+func secondsToDuration(seconds int64) (time.Duration, error) {
+	maxSeconds := math.MaxInt64 / int64(time.Second)
+	minSeconds := math.MinInt64 / int64(time.Second)
+
+	if seconds > maxSeconds || seconds < minSeconds {
+		return 0, fmt.Errorf("invalid interval value %d: out of range", seconds)
+	}
+
+	return time.Duration(seconds) * time.Second, nil
+}
+
+func parsePollIntervalString(raw string) (time.Duration, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return 0, errors.New("invalid interval value: must not be empty")
+	}
+
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return secondsToDuration(seconds)
+	}
+
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid interval value %q: must be seconds or a Go duration", raw)
+	}
+
+	if duration%time.Second != 0 {
+		return 0, fmt.Errorf("invalid interval duration %q: must resolve to full seconds", raw)
+	}
+
+	return duration, nil
 }

--- a/internal/config/poll/poll_config.go
+++ b/internal/config/poll/poll_config.go
@@ -217,6 +217,8 @@ func parsePollInterval(v any) (time.Duration, error) {
 	}
 
 	switch value := v.(type) {
+	case time.Duration:
+		return value, nil
 	case string:
 		return parsePollIntervalString(value)
 	case int:

--- a/internal/config/poll/poll_config.go
+++ b/internal/config/poll/poll_config.go
@@ -14,25 +14,26 @@ import (
 	"gopkg.in/validator.v2"
 
 	"github.com/kimdre/doco-cd/internal/config"
+	gitInternal "github.com/kimdre/doco-cd/internal/git"
 
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/logger"
 )
 
 type Config struct {
-	Source       config.SourceType `yaml:"source" json:"source" default:"git"`                   // Source selects the poll source backend (git or oci)
-	SourceUrl    string            `yaml:"url" json:"url"`                                       // SourceUrl is the repository/artifact URL; validated as GitUrl or OciUrl depending on Source
-	Reference    string            `yaml:"reference" json:"reference" default:"refs/heads/main"` // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
-	Interval     time.Duration     `yaml:"interval" default:"180s"`                              // Interval is the interval at which to poll for changes
-	CustomTarget string            `yaml:"target" json:"target" default:""`                      // CustomTarget is the name of an optional custom deployment config file, e.g. ".doco-cd.custom-name.yaml"
-	RunOnce      bool              `yaml:"run_once" default:"false"`                             // RunOnce when true, performs a single run and exits
-	Deployments  []*deploy.Config  `yaml:"deployments" json:"deployments" default:"[]"`          // Deployments allows defining deployment configs inline in the poll configuration
+	Source       config.SourceType `yaml:"source" json:"source" default:"git"`          // Source selects the poll source backend (git or oci)
+	SourceUrl    string            `yaml:"url" json:"url"`                              // SourceUrl is the repository/artifact URL; validated as GitUrl or OciUrl depending on Source
+	Reference    string            `yaml:"reference" json:"reference"`                  // Reference is the Git reference to the deployment, e.g., refs/heads/main, main, refs/tags/v1.0.0 or v1.0.0
+	Interval     time.Duration     `yaml:"interval" default:"180s"`                     // Interval is the interval at which to poll for changes
+	CustomTarget string            `yaml:"target" json:"target" default:""`             // CustomTarget is the name of an optional custom deployment config file, e.g. ".doco-cd.custom-name.yaml"
+	RunOnce      bool              `yaml:"run_once" default:"false"`                    // RunOnce when true, performs a single run and exits
+	Deployments  []*deploy.Config  `yaml:"deployments" json:"deployments" default:"[]"` // Deployments allows defining deployment configs inline in the poll configuration
 }
 
 type rawConfig struct {
 	Source       config.SourceType `yaml:"source" json:"source" default:"git"`
 	SourceUrl    string            `yaml:"url" json:"url"`
-	Reference    string            `yaml:"reference" json:"reference" default:"refs/heads/main"`
+	Reference    string            `yaml:"reference" json:"reference"`
 	Interval     any               `yaml:"interval" json:"interval" default:"180s"`
 	CustomTarget string            `yaml:"target" json:"target" default:""`
 	RunOnce      bool              `yaml:"run_once" json:"run_once" default:"false"`
@@ -64,6 +65,10 @@ func (c *Config) Validate() error {
 
 	if err := config.ValidateSourceType(c.Source); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+	}
+
+	if c.Reference == "" && c.Source != config.SourceTypeOCI {
+		c.Reference = gitInternal.MainBranch
 	}
 
 	switch c.Source {

--- a/internal/config/poll/poll_config_test.go
+++ b/internal/config/poll/poll_config_test.go
@@ -19,6 +19,7 @@ func TestConfig_Validate(t *testing.T) {
 		name     string
 		config   Config
 		expected error
+		wantRef  string
 	}{
 		{
 			name: "Valid git config",
@@ -29,6 +30,7 @@ func TestConfig_Validate(t *testing.T) {
 				Interval:  10 * time.Second,
 			},
 			expected: nil,
+			wantRef:  "main",
 		},
 		{
 			name: "Valid git config - SSH scp-style URL",
@@ -39,6 +41,7 @@ func TestConfig_Validate(t *testing.T) {
 				Interval:  10 * time.Second,
 			},
 			expected: nil,
+			wantRef:  "main",
 		},
 		{
 			name: "Valid OCI config",
@@ -48,6 +51,7 @@ func TestConfig_Validate(t *testing.T) {
 				Interval:  10 * time.Second,
 			},
 			expected: nil,
+			wantRef:  "main",
 		},
 		{
 			name: "Valid OCI config - tagged reference",
@@ -57,6 +61,7 @@ func TestConfig_Validate(t *testing.T) {
 				Interval:  10 * time.Second,
 			},
 			expected: nil,
+			wantRef:  "v1.0.0",
 		},
 		{
 			name: "Invalid config - empty SourceUrl for git",
@@ -69,14 +74,15 @@ func TestConfig_Validate(t *testing.T) {
 			expected: deploy.ErrKeyNotFound,
 		},
 		{
-			name: "Invalid config - empty Reference",
+			name: "Valid git config - empty Reference defaults to main",
 			config: Config{
 				Source:    config.SourceTypeGit,
 				SourceUrl: "https://example.com/repo.git",
 				Reference: "",
 				Interval:  10 * time.Second,
 			},
-			expected: deploy.ErrKeyNotFound,
+			expected: nil,
+			wantRef:  "refs/heads/main",
 		},
 		{
 			name: "Invalid config - empty SourceUrl for OCI",
@@ -96,6 +102,7 @@ func TestConfig_Validate(t *testing.T) {
 				Interval:  10 * time.Second,
 			},
 			expected: ErrInvalidConfig,
+			wantRef:  "main",
 		},
 		{
 			name: "Invalid config - negative Interval",
@@ -106,6 +113,7 @@ func TestConfig_Validate(t *testing.T) {
 				Interval:  -5 * time.Second,
 			},
 			expected: ErrIntervalTooLow,
+			wantRef:  "main",
 		},
 		{
 			name: "Invalid config - 5s Interval",
@@ -116,6 +124,7 @@ func TestConfig_Validate(t *testing.T) {
 				Interval:  5 * time.Second,
 			},
 			expected: ErrIntervalTooLow,
+			wantRef:  "main",
 		},
 		{
 			name: "Valid config - zero Interval (disabled)",
@@ -126,6 +135,7 @@ func TestConfig_Validate(t *testing.T) {
 				Interval:  0,
 			},
 			expected: nil,
+			wantRef:  "main",
 		},
 	}
 	for _, tc := range testCases {
@@ -135,6 +145,11 @@ func TestConfig_Validate(t *testing.T) {
 			err := tc.config.Validate()
 			if !errors.Is(err, tc.expected) {
 				t.Errorf("expected %v, got %v", tc.expected, err)
+				return
+			}
+
+			if tc.wantRef != "" && tc.config.Reference != tc.wantRef {
+				t.Errorf("expected reference %q, got %q", tc.wantRef, tc.config.Reference)
 			}
 		})
 	}

--- a/internal/config/poll/poll_config_test.go
+++ b/internal/config/poll/poll_config_test.go
@@ -1,8 +1,12 @@
 package poll
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
+	"time"
+
+	"go.yaml.in/yaml/v3"
 
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
@@ -22,7 +26,7 @@ func TestConfig_Validate(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "https://example.com/repo.git",
 				Reference: "main",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
 			expected: nil,
 		},
@@ -32,7 +36,7 @@ func TestConfig_Validate(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "git@github.com:owner/repo.git",
 				Reference: "main",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
 			expected: nil,
 		},
@@ -41,7 +45,7 @@ func TestConfig_Validate(t *testing.T) {
 			config: Config{
 				Source:    config.SourceTypeOCI,
 				SourceUrl: "ghcr.io/example/app-config:main",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
 			expected: nil,
 		},
@@ -50,7 +54,7 @@ func TestConfig_Validate(t *testing.T) {
 			config: Config{
 				Source:    config.SourceTypeOCI,
 				SourceUrl: "ghcr.io/example/app-config:v1.0.0",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
 			expected: nil,
 		},
@@ -60,7 +64,7 @@ func TestConfig_Validate(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "",
 				Reference: "main",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
 			expected: deploy.ErrKeyNotFound,
 		},
@@ -70,7 +74,7 @@ func TestConfig_Validate(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "https://example.com/repo.git",
 				Reference: "",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
 			expected: deploy.ErrKeyNotFound,
 		},
@@ -79,7 +83,7 @@ func TestConfig_Validate(t *testing.T) {
 			config: Config{
 				Source:    config.SourceTypeOCI,
 				SourceUrl: "",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
 			expected: deploy.ErrKeyNotFound,
 		},
@@ -89,7 +93,7 @@ func TestConfig_Validate(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "ftp://example.com/repo.git",
 				Reference: "main",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
 			expected: ErrInvalidConfig,
 		},
@@ -99,7 +103,7 @@ func TestConfig_Validate(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "https://example.com/repo.git",
 				Reference: "main",
-				Interval:  -5,
+				Interval:  -5 * time.Second,
 			},
 			expected: ErrIntervalTooLow,
 		},
@@ -109,7 +113,7 @@ func TestConfig_Validate(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "https://example.com/repo.git",
 				Reference: "main",
-				Interval:  5,
+				Interval:  5 * time.Second,
 			},
 			expected: ErrIntervalTooLow,
 		},
@@ -150,9 +154,9 @@ func TestConfig_String(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "https://example.com/repo.git",
 				Reference: "main",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
-			expected: "Config{Source: git, SourceUrl: https://example.com/repo.git, Reference: main, Interval: 10}",
+			expected: "Config{Source: git, SourceUrl: https://example.com/repo.git, Reference: main, Interval: 10s}",
 		},
 		{
 			name: "OCI config",
@@ -160,9 +164,9 @@ func TestConfig_String(t *testing.T) {
 				Source:    config.SourceTypeOCI,
 				SourceUrl: "ghcr.io/example/app-config:main",
 				Reference: "main",
-				Interval:  10,
+				Interval:  10 * time.Second,
 			},
-			expected: "Config{Source: oci, SourceUrl: ghcr.io/example/app-config:main, Reference: main, Interval: 10}",
+			expected: "Config{Source: oci, SourceUrl: ghcr.io/example/app-config:main, Reference: main, Interval: 10s}",
 		},
 		{
 			name: "Basic config",
@@ -170,9 +174,9 @@ func TestConfig_String(t *testing.T) {
 				Source:    config.SourceTypeGit,
 				SourceUrl: "https://example.com/repo.git",
 				Reference: "main",
-				Interval:  180,
+				Interval:  180 * time.Second,
 			},
-			expected: "Config{Source: git, SourceUrl: https://example.com/repo.git, Reference: main, Interval: 180}",
+			expected: "Config{Source: git, SourceUrl: https://example.com/repo.git, Reference: main, Interval: 3m0s}",
 		},
 	}
 	for _, tc := range testCases {
@@ -182,6 +186,115 @@ func TestConfig_String(t *testing.T) {
 			result := tc.config.String()
 			if result != tc.expected {
 				t.Errorf("expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestParsePollInterval(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    any
+		expected time.Duration
+		wantErr  bool
+	}{
+		{name: "int", input: 300, expected: 300 * time.Second},
+		{name: "float64 whole number", input: float64(90), expected: 90 * time.Second},
+		{name: "numeric string", input: "300", expected: 300 * time.Second},
+		{name: "duration string", input: "5m", expected: 5 * time.Minute},
+		{name: "composite duration string", input: "1m30s", expected: 90 * time.Second},
+		{name: "zero duration", input: "0s", expected: 0},
+		{name: "fractional seconds duration", input: "500ms", wantErr: true},
+		{name: "invalid duration", input: "abc", wantErr: true},
+		{name: "invalid type", input: true, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parsePollInterval(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.expected {
+				t.Fatalf("expected %s, got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestConfig_UnmarshalYAML_IntervalDuration(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`
+- source: git
+  url: https://example.com/repo.git
+  reference: main
+  interval: 5m
+`)
+
+	var cfg []Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("failed to unmarshal yaml: %v", err)
+	}
+
+	if len(cfg) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(cfg))
+	}
+
+	if cfg[0].Interval != 5*time.Minute {
+		t.Fatalf("expected interval to normalize to 5m0s, got %s", cfg[0].Interval)
+	}
+}
+
+func TestConfig_UnmarshalJSON_IntervalVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+	}{
+		{
+			name:     "duration string",
+			input:    `{"source":"git","url":"https://example.com/repo.git","reference":"main","interval":"1m30s"}`,
+			expected: 90 * time.Second,
+		},
+		{
+			name:     "numeric string treated as seconds",
+			input:    `{"source":"git","url":"https://example.com/repo.git","reference":"main","interval":"300"}`,
+			expected: 300 * time.Second,
+		},
+		{
+			name:     "integer seconds",
+			input:    `{"source":"git","url":"https://example.com/repo.git","reference":"main","interval":45}`,
+			expected: 45 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg Config
+			if err := json.Unmarshal([]byte(tc.input), &cfg); err != nil {
+				t.Fatalf("failed to unmarshal json: %v", err)
+			}
+
+			if cfg.Interval != tc.expected {
+				t.Fatalf("expected interval %s, got %s", tc.expected, cfg.Interval)
 			}
 		})
 	}
@@ -206,7 +319,7 @@ func TestOCIConfig_ReferenceAutoderived(t *testing.T) {
 			c := Config{
 				Source:    config.SourceTypeOCI,
 				SourceUrl: tc.artifact,
-				Interval:  10,
+				Interval:  10 * time.Second,
 			}
 
 			if err := c.Validate(); err != nil {

--- a/internal/logger/helpers.go
+++ b/internal/logger/helpers.go
@@ -4,7 +4,10 @@ import (
 	"log/slog"
 	"reflect"
 	"strings"
+	"time"
 )
+
+var durationType = reflect.TypeFor[time.Duration]()
 
 // BuildLogValue returns a slog.Value for any value, excluding fields by name or dot-path.
 // Examples:
@@ -34,6 +37,10 @@ func BuildSliceLogValue(slice any, ignore ...string) slog.Value {
 func buildPlain(rv reflect.Value, prefix string, ignoreSet map[string]struct{}) any {
 	if !rv.IsValid() {
 		return nil
+	}
+
+	if rv.Type() == durationType {
+		return rv.Interface().(time.Duration).String()
 	}
 
 	// Unwrap interfaces/pointers

--- a/internal/logger/helpers.go
+++ b/internal/logger/helpers.go
@@ -82,7 +82,12 @@ func buildPlain(rv reflect.Value, prefix string, ignoreSet map[string]struct{}) 
 				continue
 			}
 
-			out[key] = buildPlain(rv.Field(i), goPath, ignoreSet)
+			fieldValue := rv.Field(i)
+			if fieldValue.Kind() == reflect.String && fieldValue.Len() == 0 {
+				continue
+			}
+
+			out[key] = buildPlain(fieldValue, goPath, ignoreSet)
 		}
 
 		return out
@@ -104,13 +109,22 @@ func buildPlain(rv reflect.Value, prefix string, ignoreSet map[string]struct{}) 
 		for iter.Next() {
 			k := iter.Key()
 			if k.Kind() == reflect.String {
-				out[k.String()] = buildPlain(iter.Value(), prefix, ignoreSet)
+				value := iter.Value()
+				if value.Kind() == reflect.String && value.Len() == 0 {
+					continue
+				}
+
+				out[k.String()] = buildPlain(value, prefix, ignoreSet)
 			}
 		}
 
 		return out
 
 	default:
+		if rv.Kind() == reflect.String && rv.Len() == 0 {
+			return nil
+		}
+
 		if rv.CanInterface() {
 			return rv.Interface()
 		}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -13,6 +13,14 @@ type durationLogSample struct {
 	Interval time.Duration `json:"interval" yaml:"interval"`
 }
 
+type zeroValueLogSample struct {
+	EmptyString string            `json:"empty_string" yaml:"empty_string"`
+	ZeroInt     int               `json:"zero_int" yaml:"zero_int"`
+	FalseBool   bool              `json:"false_bool" yaml:"false_bool"`
+	EmptySlice  []string          `json:"empty_slice" yaml:"empty_slice"`
+	EmptyMap    map[string]string `json:"empty_map" yaml:"empty_map"`
+}
+
 func TestParseLevel(t *testing.T) {
 	t.Parallel()
 
@@ -92,6 +100,44 @@ func TestBuildLogValue_FormatsDuration(t *testing.T) {
 	value := BuildLogValue(durationLogSample{Interval: 10 * time.Second})
 	if got := value.Any().(map[string]any)["interval"]; got != "10s" {
 		t.Fatalf("expected interval to be formatted as 10s, got %v", got)
+	}
+}
+
+func TestBuildLogValue_SkipsEmptyStrings_ButKeepsOtherZeroValues(t *testing.T) {
+	t.Parallel()
+
+	value := BuildLogValue(zeroValueLogSample{
+		EmptyString: "",
+		ZeroInt:     0,
+		FalseBool:   false,
+		EmptySlice:  []string{},
+		EmptyMap:    map[string]string{},
+	})
+
+	entry := value.Any().(map[string]any)
+
+	if _, exists := entry["empty_string"]; exists {
+		t.Fatal("expected empty_string to be omitted")
+	}
+
+	if got := entry["zero_int"]; got != 0 {
+		t.Fatalf("expected zero_int to be preserved as 0, got %v", got)
+	}
+
+	if got := entry["false_bool"]; got != false {
+		t.Fatalf("expected false_bool to be preserved as false, got %v", got)
+	}
+
+	if got, ok := entry["empty_slice"]; !ok {
+		t.Fatal("expected empty_slice to be preserved")
+	} else if slice, ok := got.([]any); !ok || len(slice) != 0 {
+		t.Fatalf("expected empty_slice to be an empty slice, got %T %v", got, got)
+	}
+
+	if got, ok := entry["empty_map"]; !ok {
+		t.Fatal("expected empty_map to be preserved")
+	} else if m, ok := got.(map[string]any); !ok || len(m) != 0 {
+		t.Fatalf("expected empty_map to be an empty map, got %T %v", got, got)
 	}
 }
 

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -6,7 +6,12 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 )
+
+type durationLogSample struct {
+	Interval time.Duration `json:"interval" yaml:"interval"`
+}
 
 func TestParseLevel(t *testing.T) {
 	t.Parallel()
@@ -78,6 +83,15 @@ func TestErrAttr(t *testing.T) {
 
 	if !attr.Equal(slog.Any("error", err)) {
 		t.Errorf("ErrAttr() value = %v, want %v", attr.Value, err)
+	}
+}
+
+func TestBuildLogValue_FormatsDuration(t *testing.T) {
+	t.Parallel()
+
+	value := BuildLogValue(durationLogSample{Interval: 10 * time.Second})
+	if got := value.Any().(map[string]any)["interval"]; got != "10s" {
+		t.Fatalf("expected interval to be formatted as 10s, got %v", got)
 	}
 }
 

--- a/wiki/docs/Advanced/OCI/Polling.md
+++ b/wiki/docs/Advanced/OCI/Polling.md
@@ -29,14 +29,16 @@ Add an OCI [polling configuration](../../Poll-Settings.md) to `POLL_CONFIG`:
         - production
 ```
 
-## Parameters
+## Fields
 
-| Parameter     | Default | Description                                                                                                                                             |
-|---------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `source`      |         | (required) Must be `oci`.                                                                                                                               |
-| `url`         |         | (required) Full OCI artifact reference including the tag to pull (e.g., `ghcr.io/myorg/app:main`)                                                       |
-| `interval`    | `180`   | Poll interval in seconds (minimum: 10)                                                                                                                  |
-| `deployments` |         | (optional) Array of [inline deployment configurations](../../Poll-Settings.md#inline-deploy-configs). When provided, overrides configs in the artifact. |
+See also [Poll Settings](../../Poll-Settings.md) for general polling configuration fields.
+
+| Key           | Type                                                | Description                                                                                                                                             | Default |
+|---------------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `source`      | string                                              | (required) Must be `oci`.                                                                                                                               |         |
+| `url`         | string                                              | (required) Full OCI artifact reference including the tag to pull (e.g., `ghcr.io/myorg/app:main`)                                                       |         |
+| `interval`    | integer or string                                   | Poll interval (min 10s). Supports integer seconds (`300`), numeric strings (`"300"`), and Go duration strings (`"5m"`, `"1m30s"`).                      | `180s`  |
+| `deployments` | array of [Deploy Configs](../../Deploy-Settings.md) | (optional) Array of [inline deployment configurations](../../Poll-Settings.md#inline-deploy-configs). When provided, overrides configs in the artifact. |         |
 
 ## Example: Full Polling Configuration
 
@@ -64,7 +66,7 @@ Add an OCI [polling configuration](../../Poll-Settings.md) to `POLL_CONFIG`:
 
     - source: oci
       url: ghcr.io/myorg/config:staging
-      interval: 180
+      interval: 3m
       deployments:
         - name: web-staging
           compose_files:

--- a/wiki/docs/Poll-Settings.md
+++ b/wiki/docs/Poll-Settings.md
@@ -9,7 +9,7 @@ tags:
 !!! question "About Polling"
     Polling is a time-based trigger that checks the repositories for changes to deploy at regular intervals. This method does not require doco-cd to be reachable from the internet but is less efficient and slower than webhooks.
 
-## Polling Configuration File
+## Configuration
 
 Poll configurations can be set using the `POLL_CONFIG` environment variable or by providing a file with the `POLL_CONFIG_FILE` environment variable.
 
@@ -17,15 +17,15 @@ They must be in the format of a YAML list/array (also called YAML Sequence) and 
 
 !!! note "Settings without a default value are required."
 
-| Key           | Type                                          | Description                                                                                                                                                                                                                                | Default value                    |
-|---------------|-----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
-| `source`      | string                                        | Source backend for this poll job. Use `git` (default) for repositories or `oci` for [OCI artifacts](Advanced/OCI/Artifact-Usage.md).                                                                                                       | `git`                            |
-| `url`         | string                                        | Source URL. For `source: git`, this is the Git clone URL (e.g. `https://github.com/kimdre/doco-cd.git` or `git@github.com:kimdre/doco-cd.git`). For `source: oci`, this is the full artifact reference (e.g. `ghcr.io/myorg/config:main`). |                                  |
-| `reference`   | string                                        | Source revision used by deployment configs. For Git this is the branch/tag/ref (e.g. `main` or `refs/heads/main`). For OCI, the tag from `url` is used automatically when present.                                                         | `refs/heads/main`                |
-| `interval`    | integer                                       | The interval in seconds at which the source will be polled for changes (set to `0` to disable this poll job)                                                                                                                               | `180`                            |
-| `target`      | string                                        | Similar to the *custom target* [webhook endpoint](Endpoints/Webhook-Listener.md#with-custom-target), used to target a specific deployment config, e.g., "test" -> .doco-cd.test.yaml                                                       | ` ` (Ignored when not specified) |
-| `run_once`    | boolean                                       | Stop the poll job after the first run. Useful if you only want to do the first initial deployment via the poll job but do all future deployments via webhooks                                                                              | `false`                          |
-| `deployments` | array of [Deploy Configs](Deploy-Settings.md) | In-line configuration for [deployment settings](Deploy-Settings.md) specific to this poll configuration. Overrides the `.doco-cd.yml` file in the target repository (`url`) if exists.<br>See the [example below](#inline-deploy-configs). | `[]`                             |
+| Key           | Type                                          | Description                                                                                                                                                                                                                                               | Default value                    |
+|---------------|-----------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|
+| `source`      | string                                        | Source backend for this poll job. Use `git` (default) for repositories or `oci` for [OCI artifacts](Advanced/OCI/Artifact-Usage.md).                                                                                                                      | `git`                            |
+| `url`         | string                                        | Source URL. For `source: git`, this is the Git clone URL (e.g. `https://github.com/kimdre/doco-cd.git` or `git@github.com:kimdre/doco-cd.git`). For `source: oci`, this is the full artifact reference (e.g. `ghcr.io/myorg/config:main`).                |                                  |
+| `reference`   | string                                        | Source revision used by deployment configs. For Git this is the branch/tag/ref (e.g. `main` or `refs/heads/main`). For [OCI](Advanced/OCI/Polling.md), the tag from `url` is used automatically when present.                                             | `refs/heads/main`                |
+| `interval`    | integer or string                             | Poll interval (min 10s). Supports integer seconds (e.g. `300`), numeric strings treated as seconds (e.g. `"300"`), and [Go duration](https://pkg.go.dev/time#ParseDuration) strings (e.g. `"5m"`, `"1m30s"`). Set to `0` or `"0s"` to disable a poll job. | `180s`                           |
+| `target`      | string                                        | Similar to the *custom target* [webhook endpoint](Endpoints/Webhook-Listener.md#with-custom-target), used to target a specific deployment config, e.g., "test" -> .doco-cd.test.yaml                                                                      | ` ` (Ignored when not specified) |
+| `run_once`    | boolean                                       | Stop the poll job after the first run. Useful if you only want to do the first initial deployment via the poll job but do all future deployments via webhooks                                                                                             | `false`                          |
+| `deployments` | array of [Deploy Configs](Deploy-Settings.md) | In-line configuration for [deployment settings](Deploy-Settings.md) specific to this poll configuration. Overrides the `.doco-cd.yml` file in the target repository (`url`) if exists.<br>See the [example below](#inline-deploy-configs).                | `[]`                             |
 
 ## Example
 
@@ -41,7 +41,7 @@ x-poll-config: &poll-config
     - url: https://github.com/example/some-repo.git
     - url: https://github.com/example/public-repo.git
       reference: dev
-      interval: 300
+      interval: 300  # or as a Go duration: 5m
 
 services:
   app:
@@ -81,7 +81,7 @@ services:
         - url: https://github.com/example/some-repo.git
         - url: https://github.com/example/public-repo.git
           reference: dev
-          interval: 300
+          interval: 300  # or as a Go duration: 5m
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - data:/data
@@ -96,8 +96,10 @@ volumes:
 - url: https://github.com/example/some-repo.git
 - url: https://github.com/example/public-repo.git
   reference: dev
-  interval: 300
+  interval: 300 # (1)!
 ```
+
+1. Or as a Go duration: 5m
 
 ```yaml title="docker-compose.yaml" hl_lines="12 16"
 services:
@@ -151,7 +153,7 @@ configs:
       - url: https://example.com
         branch: main
       - url: https://other-example.com
-        interval: 120
+        interval: 120  # Or as a Go duration: 2m
       - url: https://yet-another-example.com
         branch: dev
 ```
@@ -163,8 +165,12 @@ configs:
 ```yaml title="poll-config.yaml"
 - source: oci
   url: ghcr.io/example/deploy-config:production
-  interval: 300
+  interval: 300 # (1)!
 ```
+
+1. Or as a Go duration: 5m
+
+See more at [Polling with OCI](Advanced/OCI/Polling.md) and [OCI Artifact Usage](Advanced/OCI/Artifact-Usage.md)
 
 ### Inline Deploy Configs
 


### PR DESCRIPTION
Poll intervals can now be definied as integer, numeric strings and [Go duration](https://pkg.go.dev/time#ParseDuration) strings.
Intervals are now always shown in the logs as Go durations.