### PR TITLE
feat(auto-discovery): enhance configuration with volume and image removal options

### DIFF
--- a/internal/config/deploy/auto_discovery.go
+++ b/internal/config/deploy/auto_discovery.go
@@ -18,9 +18,11 @@ import (
 
 // AutoDiscoveryConfig holds auto-discovery settings for a deployment.
 type AutoDiscoveryConfig struct {
-	Enabled   bool `yaml:"enabled" json:"enabled" default:"false"` // Enabled enables autodiscovery of services to deploy in the working directory
-	ScanDepth int  `yaml:"depth" json:"depth" default:"0"`         // ScanDepth is the maximum depth of subdirectories to scan for docker-compose files
-	Delete    bool `yaml:"delete" json:"delete" default:"true"`    // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
+	Enabled       bool `yaml:"enabled" json:"enabled" default:"false"`              // Enabled enables autodiscovery of services to deploy in the working directory
+	ScanDepth     int  `yaml:"depth" json:"depth" default:"0"`                      // ScanDepth is the maximum depth of subdirectories to scan for docker-compose files
+	Delete        bool `yaml:"delete" json:"delete" default:"true"`                 // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
+	RemoveVolumes bool `yaml:"remove_volumes" json:"remove_volumes" default:"true"` // RemoveVolumes removes the volumes of an auto-discovered deployment when it is deleted
+	RemoveImages  bool `yaml:"remove_images" json:"remove_images" default:"true"`   // RemoveImages removes the images of an auto-discovered deployment when it is deleted
 }
 
 func (c *AutoDiscoveryConfig) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/config/deploy/auto_discovery.go
+++ b/internal/config/deploy/auto_discovery.go
@@ -18,11 +18,11 @@ import (
 
 // AutoDiscoveryConfig holds auto-discovery settings for a deployment.
 type AutoDiscoveryConfig struct {
-	Enabled       bool `yaml:"enabled" json:"enabled" default:"false"`              // Enabled enables autodiscovery of services to deploy in the working directory
-	ScanDepth     int  `yaml:"depth" json:"depth" default:"0"`                      // ScanDepth is the maximum depth of subdirectories to scan for docker-compose files
-	Delete        bool `yaml:"delete" json:"delete" default:"true"`                 // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
-	RemoveVolumes bool `yaml:"remove_volumes" json:"remove_volumes" default:"true"` // RemoveVolumes removes the volumes of an auto-discovered deployment when it is deleted
-	RemoveImages  bool `yaml:"remove_images" json:"remove_images" default:"true"`   // RemoveImages removes the images of an auto-discovered deployment when it is deleted
+	Enabled       bool `yaml:"enabled" json:"enabled" default:"false"`               // Enabled enables autodiscovery of services to deploy in the working directory
+	ScanDepth     int  `yaml:"depth" json:"depth" default:"0"`                       // ScanDepth is the maximum depth of subdirectories to scan for docker-compose files
+	Delete        bool `yaml:"delete" json:"delete" default:"true"`                  // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
+	RemoveVolumes bool `yaml:"remove_volumes" json:"remove_volumes" default:"false"` // RemoveVolumes removes the volumes of an auto-discovered deployment when it is deleted
+	RemoveImages  bool `yaml:"remove_images" json:"remove_images" default:"true"`    // RemoveImages removes the images of an auto-discovered deployment when it is deleted
 }
 
 func (c *AutoDiscoveryConfig) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -129,7 +129,7 @@ func addComposeServiceLabels(project *types.Project, deployConfig *deploy.Config
 			DocoCDLabels.Deployment.TargetRef:           ExtractOciArtifactTag(deployConfig.Reference),
 			DocoCDLabels.Deployment.ConfigHash:          deployConfig.Internal.Hash,
 			DocoCDLabels.Deployment.AutoDiscovery:       strconv.FormatBool(deployConfig.AutoDiscovery.Enabled),
-			DocoCDLabels.Deployment.AutoDiscoveryDelete: strconv.FormatBool(deployConfig.AutoDiscovery.Delete),
+			DocoCDLabels.Deployment.AutoDiscoveryConfig: MarshalAutoDiscoveryConfig(deployConfig.AutoDiscovery),
 			DocoCDLabels.Source.Type:                    SourceTypeLabelValue(string(payload.Source), string(deployConfig.Source)),
 			DocoCDLabels.Source.Name:                    payload.FullName,
 			DocoCDLabels.Source.URL:                     payload.WebURL,

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -19,7 +19,7 @@ type docoCdLabelNamesDeployment struct {
 	CommitSHA            string // SHA of the commit that is currently deployed
 	ConfigHash           string // SHA256 hash of the deploy-config used during deployment
 	AutoDiscovery        string // Whether the deployment was auto-discovered
-	AutoDiscoveryDelete  string // Whether auto-discovered deployment is allowed to be deleted
+	AutoDiscoveryConfig  string // JSON-serialized AutoDiscoveryConfig settings
 	RecreateIgnore       string // Whether the deployment file changes should ignore recreate
 	RecreateIgnoreSignal string // Signal service when deployment file changes and ignore recreate
 }
@@ -54,7 +54,7 @@ var DocoCDLabels = docoCdLabelNames{
 		Trigger:              "cd.doco.deployment.trigger",
 		ConfigHash:           "cd.doco.deployment.config.sha",
 		AutoDiscovery:        "cd.doco.deployment.auto_discovery",
-		AutoDiscoveryDelete:  "cd.doco.deployment.auto_discovery.delete",
+		AutoDiscoveryConfig:  "cd.doco.deployment.auto_discovery.config",
 		RecreateIgnore:       "cd.doco.deployment.recreate.ignore",
 		RecreateIgnoreSignal: "cd.doco.deployment.recreate.ignore.signal",
 	},
@@ -69,13 +69,15 @@ var DocoCDLabels = docoCdLabelNames{
 DeprecatedAutoDiscoverLabel and DeprecatedAutoDiscoverDeleteLabel are the old label names
 kept for backwards-compatible reads. New deployments only write the new labels.
 
-Deprecated: Use DocoCDLabels.Deployment.AutoDiscovery and DocoCDLabels.Deployment.AutoDiscoveryDelete instead.
+Deprecated: Use DocoCDLabels.Deployment.AutoDiscovery and DocoCDLabels.Deployment.AutoDiscoveryConfig instead.
 
 TODO: Remove in a future release.
 */
 const (
 	DeprecatedAutoDiscoverLabel       = "cd.doco.deployment.auto_discover"
 	DeprecatedAutoDiscoverDeleteLabel = "cd.doco.deployment.auto_discover.delete"
+	// DeprecatedAutoDiscoveryDeleteLabel is the pre-consolidation scalar label for the delete setting.
+	DeprecatedAutoDiscoveryDeleteLabel = "cd.doco.deployment.auto_discovery.delete" //nolint:staticcheck
 )
 
 var docoCDJobLabelNames = struct {

--- a/internal/docker/swarm.go
+++ b/internal/docker/swarm.go
@@ -98,7 +98,7 @@ func addSwarmServiceLabels(stack *composetypes.Config, deployConfig *deploy.Conf
 		DocoCDLabels.Deployment.TargetRef:           ExtractOciArtifactTag(deployConfig.Reference),
 		DocoCDLabels.Deployment.ConfigHash:          deployConfig.Internal.Hash,
 		DocoCDLabels.Deployment.AutoDiscovery:       strconv.FormatBool(deployConfig.AutoDiscovery.Enabled),
-		DocoCDLabels.Deployment.AutoDiscoveryDelete: strconv.FormatBool(deployConfig.AutoDiscovery.Delete),
+		DocoCDLabels.Deployment.AutoDiscoveryConfig: MarshalAutoDiscoveryConfig(deployConfig.AutoDiscovery),
 		DocoCDLabels.Source.Type:                    SourceTypeLabelValue(string(payload.Source), string(deployConfig.Source)),
 		DocoCDLabels.Source.Name:                    payload.FullName,
 		DocoCDLabels.Source.URL:                     payload.WebURL,

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -18,6 +17,7 @@ import (
 
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 	swarmInternal "github.com/kimdre/doco-cd/internal/docker/swarm"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/moby/moby/client"
 )
@@ -247,18 +247,35 @@ func RemoveLabeledVolumes(ctx context.Context, dockerClient client.APIClient, st
 	return nil
 }
 
-// MarshalAutoDiscoveryConfig serializes an AutoDiscoveryConfig to a JSON string for use as a container label.
+// MarshalAutoDiscoveryConfig serializes an AutoDiscoveryConfig to a single-line YAML flow-style string for use as a container label.
 func MarshalAutoDiscoveryConfig(cfg deployConfig.AutoDiscoveryConfig) string {
-	b, err := json.Marshal(cfg)
+	// First marshal to get standard YAML
+	b, err := yaml.Marshal(cfg)
 	if err != nil {
-		// Should never happen for a plain struct; fall back to an empty object.
 		return "{}"
 	}
 
-	return string(b)
+	// Parse it back into a node to apply flow style
+	var node yaml.Node
+	if err := yaml.Unmarshal(b, &node); err != nil {
+		return "{}"
+	}
+
+	// Set flow style (produces {key: value, key: value} format)
+	if node.Content != nil && len(node.Content) > 0 {
+		node.Content[0].Style = yaml.FlowStyle
+	}
+
+	// Marshal with flow style applied
+	result, err := yaml.Marshal(&node)
+	if err != nil {
+		return "{}"
+	}
+
+	return strings.TrimSpace(string(result))
 }
 
-// ParseAutoDiscoveryConfig deserializes an AutoDiscoveryConfig from a JSON container label value.
+// ParseAutoDiscoveryConfig deserializes an AutoDiscoveryConfig from a YAML container label value.
 // If the label is empty or invalid it returns a default config with Delete=true, RemoveVolumes=true, RemoveImages=true.
 func ParseAutoDiscoveryConfig(labelValue string) deployConfig.AutoDiscoveryConfig {
 	defaults := deployConfig.AutoDiscoveryConfig{
@@ -272,7 +289,7 @@ func ParseAutoDiscoveryConfig(labelValue string) deployConfig.AutoDiscoveryConfi
 	}
 
 	var cfg deployConfig.AutoDiscoveryConfig
-	if err := json.Unmarshal([]byte(labelValue), &cfg); err != nil {
+	if err := yaml.Unmarshal([]byte(labelValue), &cfg); err != nil {
 		return defaults
 	}
 

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -15,9 +15,10 @@ import (
 
 	"github.com/moby/moby/api/types/volume"
 
+	"go.yaml.in/yaml/v3"
+
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 	swarmInternal "github.com/kimdre/doco-cd/internal/docker/swarm"
-	"go.yaml.in/yaml/v3"
 
 	"github.com/moby/moby/client"
 )
@@ -262,7 +263,7 @@ func MarshalAutoDiscoveryConfig(cfg deployConfig.AutoDiscoveryConfig) string {
 	}
 
 	// Set flow style (produces {key: value, key: value} format)
-	if node.Content != nil && len(node.Content) > 0 {
+	if len(node.Content) > 0 {
 		node.Content[0].Style = yaml.FlowStyle
 	}
 

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/moby/moby/api/types/volume"
 
+	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 	swarmInternal "github.com/kimdre/doco-cd/internal/docker/swarm"
 
 	"github.com/moby/moby/client"
@@ -243,4 +245,36 @@ func RemoveLabeledVolumes(ctx context.Context, dockerClient client.APIClient, st
 	}
 
 	return nil
+}
+
+// MarshalAutoDiscoveryConfig serializes an AutoDiscoveryConfig to a JSON string for use as a container label.
+func MarshalAutoDiscoveryConfig(cfg deployConfig.AutoDiscoveryConfig) string {
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		// Should never happen for a plain struct; fall back to an empty object.
+		return "{}"
+	}
+
+	return string(b)
+}
+
+// ParseAutoDiscoveryConfig deserializes an AutoDiscoveryConfig from a JSON container label value.
+// If the label is empty or invalid it returns a default config with Delete=true, RemoveVolumes=true, RemoveImages=true.
+func ParseAutoDiscoveryConfig(labelValue string) deployConfig.AutoDiscoveryConfig {
+	defaults := deployConfig.AutoDiscoveryConfig{
+		Delete:        true,
+		RemoveVolumes: true,
+		RemoveImages:  true,
+	}
+
+	if labelValue == "" {
+		return defaults
+	}
+
+	var cfg deployConfig.AutoDiscoveryConfig
+	if err := json.Unmarshal([]byte(labelValue), &cfg); err != nil {
+		return defaults
+	}
+
+	return cfg
 }

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -277,11 +277,11 @@ func MarshalAutoDiscoveryConfig(cfg deployConfig.AutoDiscoveryConfig) string {
 }
 
 // ParseAutoDiscoveryConfig deserializes an AutoDiscoveryConfig from a YAML container label value.
-// If the label is empty or invalid it returns a default config with Delete=true, RemoveVolumes=true, RemoveImages=true.
+// If the label is empty or invalid it returns a default config with Delete=true, RemoveVolumes=false, RemoveImages=true.
 func ParseAutoDiscoveryConfig(labelValue string) deployConfig.AutoDiscoveryConfig {
 	defaults := deployConfig.AutoDiscoveryConfig{
 		Delete:        true,
-		RemoveVolumes: true,
+		RemoveVolumes: false,
 		RemoveImages:  true,
 	}
 

--- a/internal/reconciliation/clean.go
+++ b/internal/reconciliation/clean.go
@@ -97,22 +97,25 @@ func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.L
 			stackLog.Debug("checking auto-discovered stack for obsolescence")
 
 			if _, found := autoDiscoveredNames[stackName]; !found {
-				autoDiscoverDelete := labels[docker.DocoCDLabels.Deployment.AutoDiscoveryDelete]
-				if autoDiscoverDelete == "" {
-					// Fall back to deprecated label
-					autoDiscoverDelete = labels[docker.DeprecatedAutoDiscoverDeleteLabel] //nolint:staticcheck // fallback for pre-rename containers
+				// Parse the auto-discovery config from the new JSON label.
+				// Fall back to the old scalar labels for containers deployed before this change.
+				autoDiscoverCfg := docker.ParseAutoDiscoveryConfig(labels[docker.DocoCDLabels.Deployment.AutoDiscoveryConfig])
+
+				// If the new label was absent, try the legacy scalar delete label.
+				if labels[docker.DocoCDLabels.Deployment.AutoDiscoveryConfig] == "" {
+					legacyDelete := labels[docker.DeprecatedAutoDiscoveryDeleteLabel] //nolint:staticcheck // fallback for pre-consolidation containers
+					if legacyDelete == "" {
+						legacyDelete = labels[docker.DeprecatedAutoDiscoverDeleteLabel] //nolint:staticcheck // fallback for pre-rename containers
+					}
+
+					if legacyDelete != "" {
+						if parsed, err := strconv.ParseBool(legacyDelete); err == nil {
+							autoDiscoverCfg.Delete = parsed
+						}
+					}
 				}
 
-				if autoDiscoverDelete == "" {
-					autoDiscoverDelete = "true" // Default to true if label is missing
-				}
-
-				deleteEnabled, err := strconv.ParseBool(autoDiscoverDelete)
-				if err != nil {
-					return err
-				}
-
-				if !deleteEnabled {
+				if !autoDiscoverCfg.Delete {
 					stackLog.Debug("skipping removal of obsolete auto-discovered stack as per configuration")
 
 					processedStacks = append(processedStacks, stackName)
@@ -124,8 +127,8 @@ func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.L
 
 				removeConfig := &deployConfig.Config{Name: stackName}
 				removeConfig.Destroy.Enabled = true
-				removeConfig.Destroy.RemoveVolumes = true
-				removeConfig.Destroy.RemoveImages = true
+				removeConfig.Destroy.RemoveVolumes = autoDiscoverCfg.RemoveVolumes
+				removeConfig.Destroy.RemoveImages = autoDiscoverCfg.RemoveImages
 				removeConfig.Destroy.RemoveRepoDir = false // Do not remove repo dir for auto-discovered stacks
 
 				err = docker.DestroyStack(jobLog, &ctx, &dockerCli, removeConfig)

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -138,21 +138,29 @@ The docker compose deployment can be configured inside the [deployment configura
 
 ### Auto-Discovery
 
-If `auto_discovery` is enabled, doco-cd will try to find projects/stacks to deploy by searching for docker compose files (see the `compose_files` setting) in subdirectories in the working directory (`working_dir`). 
-Doco-cd will internally generate new deploy configs based on the directory name and inherits all other settings from the base deploy config inside the `.doco-cd.yml` file or the inline deployment config inside the poll config.
-When an app is no longer available in the `working_dir` (e.g. deleted or moved to another directory outside the working dir), doco-cd will automatically remove the deployed project/stack from the docker host.
+If `auto_discovery` is enabled, doco-cd will try to find projects/stacks to deploy by searching for docker compose files 
+(see the `compose_files` setting) in subdirectories in the working directory (`working_dir`). 
+
+Doco-cd will internally generate new deploy configs based on the directory name and inherits all other settings from the 
+base deploy config inside the `.doco-cd.yml` file or the inline deployment config inside the poll config.
+
+When an app is no longer available in the `working_dir` (e.g. deleted or moved to another directory outside the working dir), 
+doco-cd will automatically remove the deployed project/stack from the docker host.
 
 #### Auto-Discovery settings
 
-`auto_discovery` accepts either a boolean or a nested object in the deployment configuration file. Use `auto_discovery: true` to enable it with defaults, or use the object form below to customize `depth` and `delete`.
+`auto_discovery` accepts either a boolean or a nested object in the deployment configuration file. 
+Use `auto_discovery: true` to enable it with defaults, or use the object form below to customize the settings.
 
-| Key       | Type    | Description                                                                                          | Default value |
-|-----------|---------|------------------------------------------------------------------------------------------------------|---------------|
-| `enabled` | boolean | Enables auto-discovery of services to deploy in the working directory                                | `false`       |
-| `depth`   | number  | Maximum depth of subdirectories to scan for docker-compose files, set to `0` for no limit            | `0`           |
-| `delete`  | boolean | Auto-remove obsolete auto-discovered deployments that are no longer present in the working directory | `true`        |
+| Key              | Type    | Description                                                                                          | Default value |
+|------------------|---------|------------------------------------------------------------------------------------------------------|---------------|
+| `enabled`        | boolean | Enables auto-discovery of services to deploy in the working directory                                | `false`       |
+| `depth`          | number  | Maximum depth of subdirectories to scan for docker-compose files, set to `0` for no limit            | `0`           |
+| `delete`         | boolean | Auto-remove obsolete auto-discovered deployments that are no longer present in the working directory | `true`        |
+| `remove_volumes` | boolean | Remove volumes of auto-discovered deployments when they are deleted                                  | `false`       |
+| `remove_images`  | boolean | Remove images of auto-discovered deployments when they are deleted                                   | `true`        |
 
-!!! example
+??? example "Auto-discovery Setup Example"
     <div class="grid cards" markdown>
 
     - With a file structure like this
@@ -189,6 +197,28 @@ When an app is no longer available in the `working_dir` (e.g. deleted or moved t
     </div>
 
     Doco-cd would deploy 2 stacks to the docker host: `wordpress` and `nginx`
+
+#### Controlling resource cleanup on stack deletion
+
+When auto-discovered stacks are deleted (e.g., because the compose file was removed from the repository), 
+you can control whether volumes and images are removed using the `remove_volumes` and `remove_images` settings 
+in the `auto_discovery` configuration:
+
+```yaml title=".doco-cd.yml"
+working_dir: apps/
+auto_discovery:
+  enabled: true
+  delete: true
+  remove_volumes: false # (1)!
+  remove_images: true # (2)!
+```
+
+1. Keep volumes when stacks are auto-deleted
+2. Remove images when stacks are auto-deleted
+
+??? note "Default behavior"
+    By default, `remove_volumes` is set to `false`, meaning volumes are **preserved** when auto-discovered stacks are deleted.
+    This is a safer default to prevent accidental data loss (e.g., databases). Set `remove_volumes: true` if you want volumes to be removed when stacks are auto-deleted.
 
 #### Nested config overrides
 


### PR DESCRIPTION
Added auto-discovery settings to toggle volume and image removal on stack cleanup.


| Key              | Type    | Description                                                                                          | Default value |
|------------------|---------|------------------------------------------------------------------------------------------------------|---------------|
| `remove_volumes` | boolean | Remove volumes of auto-discovered deployments when they are deleted                                  | `false`       |
| `remove_images`  | boolean | Remove images of auto-discovered deployments when they are deleted                                   | `true`        |
 
The autodiscovery config is stored in stack containers in the label `cd.doco.deployment.auto_discovery.config`.

For example `"{enabled: true, depth: 2, delete: true, remove_volumes: true, remove_images: true}"`