### PR TITLE
fix(deploy): require deploy config file

### DIFF
--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -105,7 +105,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 	)
 
 	if customTarget != "" {
-		jobLog = jobLog.With(slog.String("custom_target", customTarget))
+		jobLog = jobLog.With(slog.String("target", customTarget))
 	}
 
 	if strings.Contains(repoName, "..") {

--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -47,7 +47,7 @@ func (r handleError) Error() string {
 	ret := r.msg
 
 	if r.err != nil {
-		ret += fmt.Sprintf(", err: %v", r.err)
+		ret = fmt.Sprintf("%s: %v", r.msg, r.err)
 	}
 
 	return ret

--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -210,7 +210,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 
 	switch jobTrigger {
 	case stages.JobTriggerWebhook:
-		deployConfigs, err = deploy.GetConfigs(internalRepoPath, appConfig.DeployConfigBaseDir, payload.Name, customTarget, payload.Ref, gitOpts)
+		deployConfigs, err = deploy.GetConfigs(internalRepoPath, appConfig.DeployConfigBaseDir, customTarget, payload.Ref, gitOpts)
 		if err != nil {
 			return handleError{
 				err:            err,
@@ -219,9 +219,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 			}
 		}
 	case stages.JobTriggerPoll:
-		shortName := filepath.Base(repoName)
-
-		deployConfigs, err = deploy.ResolveConfigs(pollConfig.Deployments, pollConfig.CustomTarget, ref, internalRepoPath, appConfig.DeployConfigBaseDir, shortName, gitOpts)
+		deployConfigs, err = deploy.ResolveConfigs(pollConfig.Deployments, pollConfig.CustomTarget, ref, internalRepoPath, appConfig.DeployConfigBaseDir, gitOpts)
 		if err != nil {
 			return handleError{
 				err:            err,

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -155,7 +155,7 @@ func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config,
 	)
 
 	if pollConfig.CustomTarget != "" {
-		jobLog = jobLog.With(slog.String("custom_target", pollConfig.CustomTarget))
+		jobLog = jobLog.With(slog.String("target", pollConfig.CustomTarget))
 	}
 
 	configVal := log.BuildLogValue(&pollConfig, "Deployments.Internal")

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -117,7 +117,7 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	jobLog = jobLog.With(slog.String(entity, logValue))
 
 	if customTarget != "" {
-		jobLog = jobLog.With(slog.String("custom_target", customTarget))
+		jobLog = jobLog.With(slog.String("target", customTarget))
 	}
 
 	jobLog.Info("received new "+entity+" job",

--- a/cmd/doco-cd/main_test.go
+++ b/cmd/doco-cd/main_test.go
@@ -156,7 +156,7 @@ func TestHandleEvent(t *testing.T) {
 			swarmMode:            false,
 		},
 		{
-			name: "Missing Compose Configuration",
+			name: "Missing Deployment Configuration",
 			payload: webhook.ParsedPayload{
 				Ref:       git.MainBranch,
 				CommitSHA: "efefb4111f3c363692a2526f9be9b24560e6511f",
@@ -166,7 +166,7 @@ func TestHandleEvent(t *testing.T) {
 				Private:   false,
 			},
 			expectedStatusCode:   http.StatusInternalServerError,
-			expectedResponseBody: `{"error":"deployment failed","content":"failed to deploy stack %[3]s: failed to load compose config: failed to load compose project: no configuration file provided: not found","job_id":"%[1]s"}`,
+			expectedResponseBody: `{"error":"failed to get deploy configuration","content":"configuration file not found in repository: .doco-cd.y(a)ml","job_id":"%[1]s"}`,
 			customTarget:         "",
 			swarmMode:            false,
 		},

--- a/dev.compose.yaml
+++ b/dev.compose.yaml
@@ -2,12 +2,12 @@ x-poll-config: &poll-config
   POLL_CONFIG: |
     - source: oci
       url: ghcr.io/kimdre/doco-cd_tests:test
-      interval: 0
+      interval: 10s
     - source: git
       url: https://github.com/kimdre/doco-cd_tests.git
       #url: git@github.com:kimdre/doco-cd_tests.git
-      reference: autodiscover
-      interval: 10
+      reference: main
+      interval: 0
       #target: "bitwarden-sm"
 
 services:
@@ -37,7 +37,7 @@ services:
     environment:
       TZ: Europe/Berlin
       HTTP_PORT: 80
-      LOG_LEVEL: debug
+      LOG_LEVEL: info
       OCI_VERIFY_MAX_WORKERS: 1
       OCI_TRUST_POLICY: |
         enabled: true

--- a/dev.compose.yaml
+++ b/dev.compose.yaml
@@ -2,12 +2,12 @@ x-poll-config: &poll-config
   POLL_CONFIG: |
     - source: oci
       url: ghcr.io/kimdre/doco-cd_tests:test
-      interval: 10s
+      interval: 0
     - source: git
       url: https://github.com/kimdre/doco-cd_tests.git
       #url: git@github.com:kimdre/doco-cd_tests.git
-      reference: main
-      interval: 0
+      reference: autodiscover
+      interval: 10
       #target: "bitwarden-sm"
 
 services:
@@ -37,7 +37,7 @@ services:
     environment:
       TZ: Europe/Berlin
       HTTP_PORT: 80
-      LOG_LEVEL: info
+      LOG_LEVEL: debug
       OCI_VERIFY_MAX_WORKERS: 1
       OCI_TRUST_POLICY: |
         enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@
 #    - url: https://github.com/kimdre/doco-cd.git  # This is the repository to poll
 #      reference: main  # Optional: specify the branch or tag to poll, defaults to 'main'
 #      interval: 180  # Optional: specify the interval in seconds to poll the repository, defaults to 180 seconds (3 minutes)
-#      target: ""  # Optional: use to target a specific deployment config file, e.g., "test" -> .doco-cd.test.yaml
+#      target: ""  # Optional: use to target a specific deployment config file, e.g., "test" -> .doco-cd.test.y(a)ml
+#      # Repository-based deployments require .doco-cd.y(a)ml (or .doco-cd.<target>.y(a)ml when target is set).
 
 services:
   app:

--- a/internal/config/deploy/deploy.go
+++ b/internal/config/deploy/deploy.go
@@ -275,9 +275,10 @@ func GetConfigFromYAML(f string, applyDefaults bool) ([]*Config, error) {
 	return configs, nil
 }
 
-// GetConfigs returns either the deployment configuration from the repository or the default configuration.
-// gitOpts is optional (may be nil) and is only required when AutoDiscovery with a remote RepositoryUrl is used.
-func GetConfigs(repoRoot, configBaseDir, name, customTarget, reference string, gitOpts *GitOptions) ([]*Config, error) {
+// GetConfigs returns deployment configurations discovered in the repository.
+// It fails when no matching deployment configuration file exists.
+// gitOpts is optional (can be nil) and is only required when AutoDiscovery with a remote RepositoryUrl is used.
+func GetConfigs(repoRoot, configBaseDir, customTarget, reference string, gitOpts *GitOptions) ([]*Config, error) {
 	configDir := filepath.Join(repoRoot, configBaseDir)
 
 	files, err := os.ReadDir(configDir)
@@ -436,7 +437,7 @@ func GetConfigs(repoRoot, configBaseDir, name, customTarget, reference string, g
 		return nil, fmt.Errorf("%w: .doco-cd.%s.y(a)ml", ErrConfigFileNotFound, customTarget)
 	}
 
-	return []*Config{New(name, reference)}, nil
+	return nil, fmt.Errorf("%w: .doco-cd.y(a)ml", ErrConfigFileNotFound)
 }
 
 // getConfigsFromFile returns the deployment configurations from the repository or nil if not found.
@@ -484,12 +485,13 @@ func ValidateUniqueProjectNames(configs []*Config) error {
 }
 
 // ResolveConfigs returns Deployment Config's for a poll run, preferring inline
-// deployments defined on the PollConfig when provided. Falls back to repository
-// configuration files or default values when no inline deployments are present.
+// deployments defined on the PollConfig when provided. Inline deployments bypass
+// repository config file discovery. When no inline deployments are present,
+// repository config files are required.
 // repoRoot is the absolute path to the repository root.
 // configBaseDir is the relative path from repo root where config files are located.
 // gitOpts is optional (may be nil) and is only required when AutoDiscovery with a remote RepositoryUrl is used.
-func ResolveConfigs(inlineDeployments []*Config, customTarget, reference, repoRoot, configBaseDir, name string, gitOpts *GitOptions) ([]*Config, error) {
+func ResolveConfigs(inlineDeployments []*Config, customTarget, reference, repoRoot, configBaseDir string, gitOpts *GitOptions) ([]*Config, error) {
 	// Prefer inline deployments when present
 	if len(inlineDeployments) > 0 {
 		// Apply reference to inline deployments if not already set
@@ -508,5 +510,5 @@ func ResolveConfigs(inlineDeployments []*Config, customTarget, reference, repoRo
 	}
 
 	// No inline deployments, use repository config discovery
-	return GetConfigs(repoRoot, configBaseDir, name, customTarget, reference, gitOpts)
+	return GetConfigs(repoRoot, configBaseDir, customTarget, reference, gitOpts)
 }

--- a/internal/config/deploy/deploy_test.go
+++ b/internal/config/deploy/deploy_test.go
@@ -62,7 +62,7 @@ compose_files:
 			t.Fatal(err)
 		}
 
-		configs, err := GetConfigs(dirName, ".", t.Name(), customTarget, reference, nil)
+		configs, err := GetConfigs(dirName, ".", customTarget, reference, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -106,7 +106,7 @@ compose_files:
 		t.Fatal(err)
 	}
 
-	configs, err := GetConfigs(repoRoot, ".", "oci-stack", "", "", nil)
+	configs, err := GetConfigs(repoRoot, ".", "", "", nil)
 	if err != nil {
 		t.Fatalf("expected no error for non-git repo, got %v", err)
 	}
@@ -120,40 +120,45 @@ compose_files:
 	}
 }
 
-func TestGetConfigs_DefaultValues(t *testing.T) {
+func TestGetConfigs_MissingDefaultConfigFile(t *testing.T) {
 	t.Parallel()
-
-	defaultConfig := New(t.Name(), DefaultReference)
 
 	dirName := t.TempDir()
 
 	createTestRepo(t, dirName)
 
-	configs, err := GetConfigs(dirName, ".", t.Name(), "", "", nil)
-	if err != nil {
-		t.Fatal(err)
+	_, err := GetConfigs(dirName, ".", "", "", nil)
+	if err == nil {
+		t.Fatal("expected error when no default deployment config file exists, got nil")
 	}
 
-	if len(configs) != 1 {
-		t.Fatalf("expected 1 config, got %d", len(configs))
+	if !errors.Is(err, ErrConfigFileNotFound) {
+		t.Fatalf("expected ErrConfigFileNotFound, got %v", err)
 	}
 
-	dc := configs[0]
+	if !strings.Contains(err.Error(), ".doco-cd.y(a)ml") {
+		t.Fatalf("expected missing default config hint in error, got %v", err)
+	}
+}
 
-	if dc.Name != t.Name() {
-		t.Errorf("expected name to be %v, got %s", t.Name(), dc.Name)
+func TestGetConfigs_MissingTargetConfigFile(t *testing.T) {
+	t.Parallel()
+
+	dirName := t.TempDir()
+
+	createTestRepo(t, dirName)
+
+	_, err := GetConfigs(dirName, ".", "nas", "", nil)
+	if err == nil {
+		t.Fatal("expected error when no target deployment config file exists, got nil")
 	}
 
-	if dc.Reference != defaultConfig.Reference {
-		t.Errorf("expected reference to be %s, got %s", defaultConfig.Reference, dc.Reference)
+	if !errors.Is(err, ErrConfigFileNotFound) {
+		t.Fatalf("expected ErrConfigFileNotFound, got %v", err)
 	}
 
-	if dc.WorkingDirectory != defaultConfig.WorkingDirectory {
-		t.Errorf("expected working directory to be %s, got %s", defaultConfig.WorkingDirectory, dc.WorkingDirectory)
-	}
-
-	if !reflect.DeepEqual(dc.ComposeFiles, defaultConfig.ComposeFiles) {
-		t.Errorf("expected compose files to be %v, got %v", defaultConfig.ComposeFiles, dc.ComposeFiles)
+	if !strings.Contains(err.Error(), ".doco-cd.nas.y(a)ml") {
+		t.Fatalf("expected missing target config hint in error, got %v", err)
 	}
 }
 
@@ -297,7 +302,7 @@ func TestResolveConfigs_InlineOverride(t *testing.T) {
 	customTarget := ""
 	reference := "refs/heads/main"
 
-	configs, err := ResolveConfigs(deployments, customTarget, reference, dirName, ".", "repo", nil)
+	configs, err := ResolveConfigs(deployments, customTarget, reference, dirName, ".", nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -373,7 +378,7 @@ func TestResolveConfigs_InlineAutoDiscover(t *testing.T) {
 	customTarget := ""
 	reference := "refs/heads/main"
 
-	configs, err := ResolveConfigs(deployments, customTarget, reference, repoRoot, ".", t.Name(), nil)
+	configs, err := ResolveConfigs(deployments, customTarget, reference, repoRoot, ".", nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -433,7 +438,7 @@ reference: %s
 	}
 
 	// Test with subdirectory as configBaseDir
-	configs, err := GetConfigs(repoRoot, configBaseDir, t.Name(), customTarget, reference, nil)
+	configs, err := GetConfigs(repoRoot, configBaseDir, customTarget, reference, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +481,7 @@ reference: %s
 	}
 
 	// Test with root directory as configBaseDir
-	configs, err := GetConfigs(repoRoot, configBaseDir, t.Name(), customTarget, reference, nil)
+	configs, err := GetConfigs(repoRoot, configBaseDir, customTarget, reference, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +530,7 @@ auto_discovery:
 	}
 
 	// Test with auto-discovery enabled
-	configs, err := GetConfigs(repoRoot, ".", t.Name(), "", "main", nil)
+	configs, err := GetConfigs(repoRoot, ".", "", "main", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -604,7 +609,7 @@ auto_discovery:
 	}
 
 	// Test with auto-discovery enabled on feature branch
-	configs, err := GetConfigs(repoRoot, ".", t.Name(), "", "refs/heads/feature-branch", nil)
+	configs, err := GetConfigs(repoRoot, ".", "", "refs/heads/feature-branch", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -667,7 +672,7 @@ repository_url: https://github.com/kimdre/doco-cd_tests.git
 			}
 
 			// Test with auto-discovery enabled and repository URL set (should ignore repository URL for discovery)
-			configs, err := GetConfigs(subDir, ".", t.Name(), "", "main", nil)
+			configs, err := GetConfigs(subDir, ".", "", "main", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -724,7 +729,7 @@ reference: %s
 		t.Fatal(err)
 	}
 
-	configs, err := ResolveConfigs(nil, "", reference, repoRoot, configBaseDir, t.Name(), nil)
+	configs, err := ResolveConfigs(nil, "", reference, repoRoot, configBaseDir, nil)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -735,6 +740,46 @@ reference: %s
 
 	if configs[0].Name != t.Name() {
 		t.Errorf("expected name to be %v, got %s", t.Name(), configs[0].Name)
+	}
+}
+
+func TestResolveConfigs_MissingRepositoryConfigFile(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	createTestRepo(t, repoRoot)
+
+	_, err := ResolveConfigs(nil, "", "refs/heads/main", repoRoot, ".", nil)
+	if err == nil {
+		t.Fatal("expected error when repository deploy config file is missing, got nil")
+	}
+
+	if !errors.Is(err, ErrConfigFileNotFound) {
+		t.Fatalf("expected ErrConfigFileNotFound, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), ".doco-cd.y(a)ml") {
+		t.Fatalf("expected missing default config hint in error, got %v", err)
+	}
+}
+
+func TestResolveConfigs_MissingRepositoryTargetConfigFile(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	createTestRepo(t, repoRoot)
+
+	_, err := ResolveConfigs(nil, "nas", "refs/heads/main", repoRoot, ".", nil)
+	if err == nil {
+		t.Fatal("expected error when repository target deploy config file is missing, got nil")
+	}
+
+	if !errors.Is(err, ErrConfigFileNotFound) {
+		t.Fatalf("expected ErrConfigFileNotFound, got %v", err)
+	}
+
+	if !strings.Contains(err.Error(), ".doco-cd.nas.y(a)ml") {
+		t.Fatalf("expected missing target config hint in error, got %v", err)
 	}
 }
 
@@ -1111,7 +1156,7 @@ auto_discovery:
 		t.Fatal(err)
 	}
 
-	configs, err := GetConfigs(repoRoot, ".", t.Name(), "", "main", nil)
+	configs, err := GetConfigs(repoRoot, ".", "", "main", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -238,7 +238,7 @@ compose_files:
 		t.Fatal(err)
 	}
 
-	deployConfigs, err := deploy.GetConfigs(tmpDir, c.DeployConfigBaseDir, stackName, customTarget, p.Ref, nil)
+	deployConfigs, err := deploy.GetConfigs(tmpDir, c.DeployConfigBaseDir, customTarget, p.Ref, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1495,7 +1495,7 @@ func TestProjectFilesHaveChanges(t *testing.T) {
 				t.Fatalf("Failed to checkout old commit: %v", err)
 			}
 
-			deployConfigs, err := deploy.GetConfigs(tmpDir, ".", t.Name(), "", "", nil)
+			deployConfigs, err := deploy.GetConfigs(tmpDir, ".", "", "", nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/docker/swarm_test.go
+++ b/internal/docker/swarm_test.go
@@ -75,7 +75,7 @@ func TestDeploySwarmStack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deployConfigs, err := deploy.GetConfigs(tmpDir, c.DeployConfigBaseDir, stackName, customTarget, p.Ref, nil)
+	deployConfigs, err := deploy.GetConfigs(tmpDir, c.DeployConfigBaseDir, customTarget, p.Ref, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -99,7 +99,7 @@ func TestDeploy(t *testing.T) {
 
 	stackName := test.ConvertTestName(t.Name())
 
-	dcs, err := deployConfig.GetConfigs(repoPath, c.DeployConfigBaseDir, stackName, "", p.Ref, nil)
+	dcs, err := deployConfig.GetConfigs(repoPath, c.DeployConfigBaseDir, "", p.Ref, nil)
 
 	// commit have 5 apps
 	// https://github.com/kimdre/doco-cd_tests/blob/7be81e788a40724cee7542eec00a2af0c4340eba/.doco-cd.yml

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -29,6 +29,8 @@ The deployment configuration file must be placed in the root/base directory of y
 - `.doco-cd.yaml`
 - `.doco-cd.yml`
 
+When using a custom target (for example `nas`), the file name must match `.doco-cd.<target>.y(a)ml`.
+
 If you use polling, you can also specify inline deployment configurations in the poll configuration file.
 See [Poll Settings](Poll-Settings.md) and this [example](Poll-Settings.md#inline-deploy-configs) for more information.
 


### PR DESCRIPTION
This PR refactors how deployment configurations are discovered and handled, making repository-based configuration files mandatory (rather than falling back to defaults) and improving error handling and logging consistency.