### PR TITLE
feat(auto-discovery): implement auto-discovery config label drift detection

### DIFF
--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"maps"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -21,16 +22,51 @@ import (
 )
 
 func shouldSkipDeployment(composeChanged bool,
+	autoDiscoveryLabelChanged bool,
 	changedServices []docker.Change,
 	ignoredInfo docker.IgnoredInfo,
 	imagesChanged bool,
 	mismatchServices []docker.ServiceMismatch,
 ) bool {
 	return !composeChanged &&
+		!autoDiscoveryLabelChanged &&
 		len(changedServices) == 0 &&
 		!ignoredInfo.IsNeedSignal() &&
 		!imagesChanged &&
 		len(mismatchServices) == 0
+}
+
+func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]docker.ServiceStatus, expected string) ([]string, string) {
+	expected = strings.TrimSpace(expected)
+
+	if len(deployedStatus) == 0 {
+		return nil, ""
+	}
+
+	affected := make([]string, 0, len(deployedStatus))
+
+	var firstObserved string
+
+	for serviceName, status := range deployedStatus {
+		actual, ok := status.Labels[docker.DocoCDLabels.Deployment.AutoDiscoveryConfig]
+
+		actual = strings.TrimSpace(actual)
+		if !ok || actual != expected {
+			affected = append(affected, string(serviceName))
+
+			if firstObserved == "" {
+				firstObserved = actual
+			}
+		}
+	}
+
+	if len(affected) == 0 {
+		return nil, expected
+	}
+
+	slices.Sort(affected)
+
+	return affected, firstObserved
 }
 
 func shouldSkipOCIDeployment(forceRecreate bool, deployedDigest, resolvedDigest string) bool {
@@ -94,11 +130,26 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 		return fmt.Errorf("failed to get latest state from deployed services: %w", err)
 	}
 
+	expectedAutoDiscoveryLabel := docker.MarshalAutoDiscoveryConfig(s.DeployConfig.AutoDiscovery)
+	autoDiscoveryDriftServices, deployedAutoDiscoveryLabel := autoDiscoveryConfigLabelDriftServices(
+		deployedState.DeployedStatus,
+		expectedAutoDiscoveryLabel,
+	)
+
+	autoDiscoveryConfigChanged := len(autoDiscoveryDriftServices) > 0
+	if autoDiscoveryConfigChanged {
+		stageLog.Debug("auto-discovery config label changed, proceeding with deployment",
+			slog.Any("affected_services", autoDiscoveryDriftServices),
+			slog.String("deployed_auto_discovery_config", deployedAutoDiscoveryLabel),
+			slog.String("expected_auto_discovery_config", expectedAutoDiscoveryLabel),
+		)
+	}
+
 	if s.Repository.Source == config.SourceTypeOCI {
 		deployedDigest := deployedState.GetDeploymentCommitSHA()
 		resolvedDigest := s.Repository.Revision
 
-		if shouldSkipOCIDeployment(s.DeployConfig.ForceRecreate, deployedDigest, resolvedDigest) {
+		if shouldSkipOCIDeployment(s.DeployConfig.ForceRecreate, deployedDigest, resolvedDigest) && !autoDiscoveryConfigChanged {
 			stageLog.Debug("OCI artifact digest unchanged, skipping deployment",
 				slog.String("deployed_digest", strings.TrimSpace(deployedDigest)),
 				slog.String("resolved_digest", strings.TrimSpace(resolvedDigest)),
@@ -116,6 +167,13 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 				slog.String("deployed_digest", strings.TrimSpace(deployedDigest)),
 				slog.String("resolved_digest", strings.TrimSpace(resolvedDigest)),
 			)
+		}
+
+		if autoDiscoveryConfigChanged {
+			s.DeployState.changedServices = []docker.Change{{
+				Type:     "auto_discovery_config_label",
+				Services: autoDiscoveryDriftServices,
+			}}
 		}
 
 		return nil
@@ -201,13 +259,20 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 			return fmt.Errorf("failed to check for changed project files: %s", err)
 		}
 
+		if autoDiscoveryConfigChanged {
+			changedServices = append(changedServices, docker.Change{
+				Type:     "auto_discovery_config_label",
+				Services: autoDiscoveryDriftServices,
+			})
+		}
+
 		mismatchServices := docker.CheckServiceMismatch(swarm.GetModeEnabled(), deployedState.DeployedStatus, s.Docker.Project.Services)
 
 		if s.DeployConfig.ForceRecreate {
 			stageLog.Debug("force recreate enabled, proceeding with deployment",
 				slog.String("directory", s.DeployConfig.WorkingDirectory),
 			)
-		} else if shouldSkipDeployment(composeChanged, changedServices, ignoredInfo, imagesChanged, mismatchServices) {
+		} else if shouldSkipDeployment(composeChanged, autoDiscoveryConfigChanged, changedServices, ignoredInfo, imagesChanged, mismatchServices) {
 			stageLog.Debug("no changes detected, skipping deployment",
 				slog.String("directory", s.DeployConfig.WorkingDirectory),
 			)
@@ -223,6 +288,7 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 			slog.Bool("force_recreate", s.DeployConfig.ForceRecreate),
 			slog.Group("has_changes",
 				slog.Bool("compose_config", composeChanged),
+				slog.Bool("auto_discovery_label", autoDiscoveryConfigChanged),
 				slog.Any("files", changedServices),
 				slog.Any("ignored_info", ignoredInfo),
 				slog.Bool("images", imagesChanged),

--- a/internal/stages/stage_2_pre-deploy_test.go
+++ b/internal/stages/stage_2_pre-deploy_test.go
@@ -1,42 +1,119 @@
 package stages
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/kimdre/doco-cd/internal/docker"
 )
 
-func TestShouldSkipDeployment(t *testing.T) {
+func TestAutoDiscoveryConfigLabelDriftServices(t *testing.T) {
+	expected := "{enabled: true, depth: 0, delete: false, remove_volumes: true, remove_images: true}"
+
 	tests := []struct {
-		name             string
-		composeChanged   bool
-		changedServices  []docker.Change
-		ignoredInfo      docker.IgnoredInfo
-		imagesChanged    bool
-		mismatchServices []docker.ServiceMismatch
-		want             bool
+		name           string
+		status         map[docker.Service]docker.ServiceStatus
+		wantServices   []string
+		wantFirstLabel string
 	}{
 		{
-			name:             "no changes",
-			composeChanged:   false,
-			changedServices:  nil,
-			ignoredInfo:      docker.IgnoredInfo{},
-			imagesChanged:    false,
-			mismatchServices: nil,
-			want:             true,
+			name: "matching labels",
+			status: map[docker.Service]docker.ServiceStatus{
+				"web": {
+					Labels: docker.Labels{
+						docker.DocoCDLabels.Deployment.AutoDiscoveryConfig: expected,
+					},
+				},
+			},
+			wantServices:   nil,
+			wantFirstLabel: expected,
 		},
 		{
-			name:             "compose file changed",
-			composeChanged:   true,
-			changedServices:  nil,
-			ignoredInfo:      docker.IgnoredInfo{},
-			imagesChanged:    false,
-			mismatchServices: nil,
-			want:             false,
+			name: "mismatched labels",
+			status: map[docker.Service]docker.ServiceStatus{
+				"web": {
+					Labels: docker.Labels{
+						docker.DocoCDLabels.Deployment.AutoDiscoveryConfig: "{enabled: true, depth: 0, delete: true, remove_volumes: true, remove_images: true}",
+					},
+				},
+			},
+			wantServices:   []string{"web"},
+			wantFirstLabel: "{enabled: true, depth: 0, delete: true, remove_volumes: true, remove_images: true}",
 		},
 		{
-			name:           "services changed",
-			composeChanged: false,
+			name: "missing label",
+			status: map[docker.Service]docker.ServiceStatus{
+				"web": {
+					Labels: docker.Labels{},
+				},
+			},
+			wantServices:   []string{"web"},
+			wantFirstLabel: "",
+		},
+		{
+			name: "multiple services sorted",
+			status: map[docker.Service]docker.ServiceStatus{
+				"z-api": {
+					Labels: docker.Labels{},
+				},
+				"a-web": {
+					Labels: docker.Labels{},
+				},
+			},
+			wantServices:   []string{"a-web", "z-api"},
+			wantFirstLabel: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotServices, gotFirst := autoDiscoveryConfigLabelDriftServices(tt.status, expected)
+			if !slices.Equal(gotServices, tt.wantServices) {
+				t.Fatalf("autoDiscoveryConfigLabelDriftServices() services = %v, want %v", gotServices, tt.wantServices)
+			}
+
+			if gotFirst != tt.wantFirstLabel {
+				t.Fatalf("autoDiscoveryConfigLabelDriftServices() first label = %q, want %q", gotFirst, tt.wantFirstLabel)
+			}
+		})
+	}
+}
+
+func TestShouldSkipDeployment(t *testing.T) {
+	tests := []struct {
+		name                      string
+		composeChanged            bool
+		autoDiscoveryLabelChanged bool
+		changedServices           []docker.Change
+		ignoredInfo               docker.IgnoredInfo
+		imagesChanged             bool
+		mismatchServices          []docker.ServiceMismatch
+		want                      bool
+	}{
+		{
+			name:                      "no changes",
+			composeChanged:            false,
+			autoDiscoveryLabelChanged: false,
+			changedServices:           nil,
+			ignoredInfo:               docker.IgnoredInfo{},
+			imagesChanged:             false,
+			mismatchServices:          nil,
+			want:                      true,
+		},
+		{
+			name:                      "compose file changed",
+			composeChanged:            true,
+			autoDiscoveryLabelChanged: false,
+			changedServices:           nil,
+			ignoredInfo:               docker.IgnoredInfo{},
+			imagesChanged:             false,
+			mismatchServices:          nil,
+			want:                      false,
+		},
+		{
+			name:                      "services changed",
+			composeChanged:            false,
+			autoDiscoveryLabelChanged: false,
 			changedServices: []docker.Change{{
 				Type:     "configs",
 				Services: []string{"web"},
@@ -47,18 +124,20 @@ func TestShouldSkipDeployment(t *testing.T) {
 			want:             false,
 		},
 		{
-			name:             "ignored changes",
-			composeChanged:   false,
-			changedServices:  nil,
-			ignoredInfo:      docker.IgnoredInfo{Ignored: []string{"web"}},
-			imagesChanged:    false,
-			mismatchServices: nil,
-			want:             true,
+			name:                      "ignored changes",
+			composeChanged:            false,
+			autoDiscoveryLabelChanged: false,
+			changedServices:           nil,
+			ignoredInfo:               docker.IgnoredInfo{Ignored: []string{"web"}},
+			imagesChanged:             false,
+			mismatchServices:          nil,
+			want:                      true,
 		},
 		{
-			name:            "ignored changes but need send signal",
-			composeChanged:  false,
-			changedServices: nil,
+			name:                      "ignored changes but need send signal",
+			composeChanged:            false,
+			autoDiscoveryLabelChanged: false,
+			changedServices:           nil,
 			ignoredInfo: docker.IgnoredInfo{NeedSendSignal: []docker.SignalService{
 				{ServiceName: "web", Signal: "SIGHUP"},
 			}},
@@ -67,20 +146,22 @@ func TestShouldSkipDeployment(t *testing.T) {
 			want:             false,
 		},
 		{
-			name:             "images changed",
-			composeChanged:   false,
-			changedServices:  nil,
-			ignoredInfo:      docker.IgnoredInfo{},
-			imagesChanged:    true,
-			mismatchServices: nil,
-			want:             false,
+			name:                      "images changed",
+			composeChanged:            false,
+			autoDiscoveryLabelChanged: false,
+			changedServices:           nil,
+			ignoredInfo:               docker.IgnoredInfo{},
+			imagesChanged:             true,
+			mismatchServices:          nil,
+			want:                      false,
 		},
 		{
-			name:            "missing services",
-			composeChanged:  false,
-			changedServices: nil,
-			ignoredInfo:     docker.IgnoredInfo{},
-			imagesChanged:   false,
+			name:                      "missing services",
+			composeChanged:            false,
+			autoDiscoveryLabelChanged: false,
+			changedServices:           nil,
+			ignoredInfo:               docker.IgnoredInfo{},
+			imagesChanged:             false,
 			mismatchServices: []docker.ServiceMismatch{
 				{
 					ServiceName: "web",
@@ -93,10 +174,20 @@ func TestShouldSkipDeployment(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name:                      "auto discovery label changed",
+			composeChanged:            false,
+			autoDiscoveryLabelChanged: true,
+			changedServices:           nil,
+			ignoredInfo:               docker.IgnoredInfo{},
+			imagesChanged:             false,
+			mismatchServices:          nil,
+			want:                      false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldSkipDeployment(tt.composeChanged, tt.changedServices, tt.ignoredInfo, tt.imagesChanged, tt.mismatchServices)
+			got := shouldSkipDeployment(tt.composeChanged, tt.autoDiscoveryLabelChanged, tt.changedServices, tt.ignoredInfo, tt.imagesChanged, tt.mismatchServices)
 			if got != tt.want {
 				t.Errorf("shouldSkipDeployment() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
This PR fixes an issue that caused doco-cd to ignore autodicovery config changes.