### PR TITLE
feat(compose): add support for automatic recreation of specific named volumes

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -52,6 +53,7 @@ var (
 	ErrNoContainerToStart = errors.New("no container to start")
 	ErrIsInUse            = errors.New("is in use")
 	ComposeVersion        string // Version of the docker compose module, will be set at runtime
+	volumeMismatchRegex   = regexp.MustCompile(`Volume "([^"]+)" exists but doesn't match configuration in compose file`)
 )
 
 func init() {
@@ -165,6 +167,58 @@ func addComposeVolumeLabels(project *types.Project, deployConfig *deploy.Config,
 		}
 		project.Volumes[i] = v
 	}
+}
+
+// getRecreatableVolumeNames returns the set of volume names that are marked as recreatable in the compose file.
+func getRecreatableVolumeNames(project *types.Project) (set.Set[string], error) {
+	recreatableVolumes := set.New[string]()
+
+	for key, cfg := range project.Volumes {
+		raw, exists := cfg.Labels[DocoCDVolumeLabels.Recreate]
+		if !exists {
+			continue
+		}
+
+		enabled, err := strconv.ParseBool(strings.TrimSpace(raw))
+		if err != nil {
+			return nil, fmt.Errorf("invalid volume label %s value %q for volume %s", DocoCDVolumeLabels.Recreate, raw, key)
+		}
+
+		if !enabled {
+			continue
+		}
+
+		if cfg.Name != "" {
+			recreatableVolumes.Add(cfg.Name)
+		}
+
+		recreatableVolumes.Add(key)
+	}
+
+	return recreatableVolumes, nil
+}
+
+func getMismatchVolumeNamesFromCreateError(err error) []string {
+	if err == nil {
+		return nil
+	}
+
+	matches := volumeMismatchRegex.FindAllStringSubmatch(err.Error(), -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	ret := set.New[string]()
+
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+
+		ret.Add(match[1])
+	}
+
+	return ret.ToSlice()
 }
 
 // LoadCompose parses and loads Compose files as specified by the Docker Compose specification.
@@ -384,7 +438,44 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 
 	err = service.Create(ctx, project, createOpts)
 	if err != nil {
-		return err
+		mismatchVolumes := getMismatchVolumeNamesFromCreateError(err)
+		if len(mismatchVolumes) == 0 {
+			return err
+		}
+
+		recreatableVolumes, parseErr := getRecreatableVolumeNames(project)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		volumesToRecreate := set.New[string]()
+
+		for _, volumeName := range mismatchVolumes {
+			if recreatableVolumes.Contains(volumeName) {
+				volumesToRecreate.Add(volumeName)
+			}
+		}
+
+		if volumesToRecreate.Len() == 0 {
+			return err
+		}
+
+		for _, volumeName := range volumesToRecreate.ToSlice() {
+			_, removeErr := dockerCli.Client().VolumeRemove(ctx, volumeName, client.VolumeRemoveOptions{Force: true})
+			if removeErr != nil {
+				removeErrLower := strings.ToLower(removeErr.Error())
+				if strings.Contains(removeErrLower, "no such volume") {
+					continue
+				}
+
+				return fmt.Errorf("failed to remove mismatched recreatable volume %s: %w", volumeName, removeErr)
+			}
+		}
+
+		err = service.Create(ctx, project, createOpts)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(startServices) > 0 {

--- a/internal/docker/compose_volume_recreate_test.go
+++ b/internal/docker/compose_volume_recreate_test.go
@@ -1,0 +1,136 @@
+package docker
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+)
+
+func TestGetMismatchVolumeNamesFromCreateError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "single mismatched volume",
+			err:  stringError("Volume \"beszel-agent_socket\" exists but doesn't match configuration in compose file. Recreate (data will be lost)?"),
+			want: []string{"beszel-agent_socket"},
+		},
+		{
+			name: "multiple mismatched volumes",
+			err: stringError("Volume \"vol_a\" exists but doesn't match configuration in compose file. Recreate (data will be lost)?\n" +
+				"Volume \"vol_b\" exists but doesn't match configuration in compose file. Recreate (data will be lost)?"),
+			want: []string{"vol_a", "vol_b"},
+		},
+		{
+			name: "unrelated error",
+			err:  stringError("failed to create service"),
+			want: nil,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := getMismatchVolumeNamesFromCreateError(tt.err)
+			slices.Sort(got)
+			slices.Sort(tt.want)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("getMismatchVolumeNamesFromCreateError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetRecreatableVolumeNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		project *types.Project
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "collects recreatable volume names",
+			project: &types.Project{
+				Volumes: map[string]types.VolumeConfig{
+					"socket": {
+						Name: "beszel-agent_socket",
+						Labels: map[string]string{
+							DocoCDVolumeLabels.Recreate: "true",
+						},
+					},
+					"cache": {
+						Name: "beszel-agent_cache",
+						Labels: map[string]string{
+							DocoCDVolumeLabels.Recreate: "false",
+						},
+					},
+					"state": {
+						Name: "beszel-agent_state",
+					},
+				},
+			},
+			want: []string{"socket", "beszel-agent_socket"},
+		},
+		{
+			name: "invalid label value",
+			project: &types.Project{
+				Volumes: map[string]types.VolumeConfig{
+					"socket": {
+						Labels: map[string]string{
+							DocoCDVolumeLabels.Recreate: "maybe",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getRecreatableVolumeNames(tt.project)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("getRecreatableVolumeNames() expected error, got nil")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("getRecreatableVolumeNames() failed: %v", err)
+			}
+
+			gotSlice := got.ToSlice()
+			slices.Sort(gotSlice)
+			slices.Sort(tt.want)
+
+			if !reflect.DeepEqual(gotSlice, tt.want) {
+				t.Fatalf("getRecreatableVolumeNames() = %v, want %v", gotSlice, tt.want)
+			}
+		})
+	}
+}
+
+type stringError string
+
+func (e stringError) Error() string {
+	return string(e)
+}

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -96,3 +96,12 @@ var docoCDJobLabelNames = struct {
 
 // DocoCDJobLabels exposes the scheduler/job labels for consumers outside this package.
 var DocoCDJobLabels = docoCDJobLabelNames
+
+var docoCDVolumeLabelNames = struct {
+	Recreate string // Allow recreating a named volume if compose reports a volume config mismatch
+}{
+	Recreate: "cd.doco.volume.recreate",
+}
+
+// DocoCDVolumeLabels exposes volume-related labels for consumers outside this package.
+var DocoCDVolumeLabels = docoCDVolumeLabelNames

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -499,6 +499,32 @@ services:
       - NET_BIND_SERVICE
 ```
 
+### Allow recreation of specific named volumes
+
+When Docker Compose detects a named volume definition change, deployment can fail with:
+
+```text
+Volume "<name>" exists but doesn't match configuration in compose file. Recreate (data will be lost)?
+```
+
+To opt in to automatic recreation for volumes that are safe to recreate (for example tmpfs-backed volumes),
+set the top-level volume label `cd.doco.volume.recreate: "true"`.
+
+Only volumes with this label are eligible. Unlabeled volumes are never removed automatically.
+
+```yaml title="docker-compose.yml" hl_lines="9-10"
+volumes:
+  socket:
+    name: beszel-agent_socket
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=1k,uid=65530,gid=0,mode=0700,noexec
+    labels:
+      cd.doco.volume.recreate: "true"
+```
+
 ## Multiple service deployments
 
 Multiple service deployments can be configured in a single deployment config file by specifying multiple YAML documents (separated by `#!yaml ---`).


### PR DESCRIPTION
### Allow recreation of specific named volumes

When Docker Compose detects a named volume definition change, deployment can fail with:

```text
Volume "<name>" exists but doesn't match configuration in compose file. Recreate (data will be lost)?
```

To opt in to automatic recreation for volumes that are safe to recreate (for example tmpfs-backed volumes),
set the top-level volume label `cd.doco.volume.recreate: "true"`.

Only volumes with this label are eligible. Unlabeled volumes are never removed automatically.

```yaml
volumes:
  socket:
    name: beszel-agent_socket
    driver: local
    driver_opts:
      type: tmpfs
      device: tmpfs
      o: size=1k,uid=65530,gid=0,mode=0700,noexec
    labels:
      cd.doco.volume.recreate: "true"
```