### PR TITLE
feat(compose): improve service readiness check

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -385,6 +385,11 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 		return err
 	}
 
+	jobServices, err := getJobServices(project)
+	if err != nil {
+		return err
+	}
+
 	err = service.Create(ctx, project, createOpts)
 	if err != nil {
 		return err
@@ -392,10 +397,9 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 
 	if len(startServices) > 0 {
 		startOpts := api.StartOptions{
-			Project:     project,
-			Wait:        true,
-			WaitTimeout: time.Duration(deployConfig.Timeout) * time.Second,
-			Services:    startServices,
+			Project:  project,
+			Wait:     false,
+			Services: startServices,
 		}
 
 		err = service.Start(ctx, project.Name, startOpts)
@@ -403,6 +407,12 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 			if !errors.Is(err, ErrNoContainerToStart) {
 				return err
 			}
+		}
+
+		err = waitForStartedServices(ctx, dockerCli, project.Name, startServices, jobServices,
+			time.Duration(deployConfig.Timeout)*time.Second)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1360,6 +1370,151 @@ func getStartServicesForDeploy(project *types.Project) ([]string, error) {
 	}
 
 	return startServices, nil
+}
+
+func getJobServices(project *types.Project) (set.Set[string], error) {
+	jobServices := set.New[string]()
+
+	if project == nil {
+		return jobServices, nil
+	}
+
+	for serviceName, svc := range project.Services {
+		labels := getServiceSchedulerLabels(svc)
+
+		_, enabled, err := ParseJobScheduleLabels(labels)
+		if err != nil {
+			return nil, fmt.Errorf("service %s: %w", serviceName, err)
+		}
+
+		if !enabled {
+			continue
+		}
+
+		if svc.Name != "" {
+			jobServices.Add(svc.Name)
+		} else {
+			jobServices.Add(serviceName)
+		}
+	}
+
+	return jobServices, nil
+}
+
+func getNonJobServices(startServices []string, jobServices set.Set[string]) set.Set[string] {
+	nonJobServices := set.New[string]()
+
+	for _, serviceName := range startServices {
+		if jobServices.Contains(serviceName) {
+			continue
+		}
+
+		nonJobServices.Add(serviceName)
+	}
+
+	return nonJobServices
+}
+
+type serviceStartStatus struct {
+	running   bool
+	unhealthy bool
+	terminal  string
+}
+
+func assessStartedServiceStates(containers []api.ContainerSummary, targetServices set.Set[string]) (bool, []string, error) {
+	statusByService := make(map[string]serviceStartStatus, targetServices.Len())
+	for svc := range targetServices {
+		statusByService[svc] = serviceStartStatus{}
+	}
+
+	for _, cont := range containers {
+		serviceName := strings.TrimSpace(cont.Labels[api.ServiceLabel])
+		if serviceName == "" || !targetServices.Contains(serviceName) {
+			continue
+		}
+
+		status := statusByService[serviceName]
+
+		state := strings.ToLower(strings.TrimSpace(string(cont.State)))
+		health := strings.ToLower(strings.TrimSpace(string(cont.Health)))
+
+		switch state {
+		case "running":
+			switch health {
+			case "", "healthy":
+				status.running = true
+			case "unhealthy":
+				status.unhealthy = true
+			}
+		case "exited", "dead":
+			status.terminal = state
+		}
+
+		statusByService[serviceName] = status
+	}
+
+	waiting := make([]string, 0, len(statusByService))
+	for serviceName, status := range statusByService {
+		if status.unhealthy {
+			return false, nil, fmt.Errorf("service %s is unhealthy", serviceName)
+		}
+
+		if status.terminal != "" && !status.running {
+			return false, nil, fmt.Errorf("service %s has a %s container", serviceName, status.terminal)
+		}
+
+		if !status.running {
+			waiting = append(waiting, serviceName)
+		}
+	}
+
+	slices.Sort(waiting)
+
+	return len(waiting) == 0, waiting, nil
+}
+
+func waitForStartedServices(ctx context.Context, dockerCli command.Cli, projectName string,
+	startServices []string, jobServices set.Set[string], timeout time.Duration,
+) error {
+	nonJobServices := getNonJobServices(startServices, jobServices)
+	if nonJobServices.Len() == 0 {
+		return nil
+	}
+
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	deadline := time.Now().Add(timeout)
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		containers, err := GetProjectContainers(ctx, dockerCli, projectName)
+		if err != nil {
+			return fmt.Errorf("failed to inspect project containers: %w", err)
+		}
+
+		allReady, waiting, stateErr := assessStartedServiceStates(containers, nonJobServices)
+		if stateErr != nil {
+			return stateErr
+		}
+
+		if allReady {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for services to start: %s", timeout, strings.Join(waiting, ", "))
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func getServiceSchedulerLabels(svc types.ServiceConfig) map[string]string {

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1496,12 +1496,12 @@ func waitForStartedServices(ctx context.Context, dockerCli command.Cli, projectN
 			return fmt.Errorf("failed to inspect project containers: %w", err)
 		}
 
-		allReady, waiting, stateErr := assessStartedServiceStates(containers, nonJobServices)
+		ready, waiting, stateErr := assessStartedServiceStates(containers, nonJobServices)
 		if stateErr != nil {
 			return stateErr
 		}
 
-		if allReady {
+		if ready {
 			return nil
 		}
 

--- a/internal/docker/compose_start_services_test.go
+++ b/internal/docker/compose_start_services_test.go
@@ -138,12 +138,12 @@ func TestAssessStartedServiceStates_IgnoresExitedJobContainer(t *testing.T) {
 		},
 	}
 
-	allReady, waiting, err := assessStartedServiceStates(containers, set.New[string]("api"))
+	ready, waiting, err := assessStartedServiceStates(containers, set.New[string]("api"))
 	if err != nil {
 		t.Fatalf("assessStartedServiceStates() returned unexpected error: %v", err)
 	}
 
-	if !allReady {
+	if !ready {
 		t.Fatalf("expected all target services to be ready, waiting: %v", waiting)
 	}
 }

--- a/internal/docker/compose_start_services_test.go
+++ b/internal/docker/compose_start_services_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/docker/compose/v5/pkg/api"
+
+	"github.com/kimdre/doco-cd/internal/utils/set"
 )
 
 func TestGetStartServicesForDeploy(t *testing.T) {
@@ -76,5 +79,89 @@ func TestGetStartServicesForDeploy_InvalidLabels(t *testing.T) {
 
 	if _, err := getStartServicesForDeploy(project); err == nil {
 		t.Fatalf("expected error for invalid schedule labels")
+	}
+}
+
+func TestGetJobServices(t *testing.T) {
+	t.Parallel()
+
+	project := &types.Project{
+		Services: types.Services{
+			"job": {
+				Name: "job",
+				Labels: map[string]string{
+					docoCDJobLabelNames.JobEnabled:  "true",
+					docoCDJobLabelNames.JobSchedule: "*/5 * * * *",
+				},
+			},
+			"disabled-job": {
+				Name: "disabled-job",
+				Labels: map[string]string{
+					docoCDJobLabelNames.JobEnabled: "false",
+				},
+			},
+			"api": {
+				Name: "api",
+			},
+		},
+	}
+
+	jobServices, err := getJobServices(project)
+	if err != nil {
+		t.Fatalf("getJobServices() failed: %v", err)
+	}
+
+	if !jobServices.Contains("job") {
+		t.Fatalf("expected job service to be included: %v", jobServices.ToSlice())
+	}
+
+	if jobServices.Contains("disabled-job") || jobServices.Contains("api") {
+		t.Fatalf("unexpected service marked as job: %v", jobServices.ToSlice())
+	}
+}
+
+func TestAssessStartedServiceStates_IgnoresExitedJobContainer(t *testing.T) {
+	t.Parallel()
+
+	containers := []api.ContainerSummary{
+		{
+			State: "running",
+			Labels: map[string]string{
+				api.ServiceLabel: "api",
+			},
+		},
+		{
+			State: "exited",
+			Labels: map[string]string{
+				api.ServiceLabel: "backup",
+			},
+		},
+	}
+
+	allReady, waiting, err := assessStartedServiceStates(containers, set.New[string]("api"))
+	if err != nil {
+		t.Fatalf("assessStartedServiceStates() returned unexpected error: %v", err)
+	}
+
+	if !allReady {
+		t.Fatalf("expected all target services to be ready, waiting: %v", waiting)
+	}
+}
+
+func TestAssessStartedServiceStates_FailsWhenNonJobExited(t *testing.T) {
+	t.Parallel()
+
+	containers := []api.ContainerSummary{
+		{
+			State: "exited",
+			Labels: map[string]string{
+				api.ServiceLabel: "api",
+			},
+		},
+	}
+
+	_, _, err := assessStartedServiceStates(containers, set.New[string]("api"))
+	if err == nil {
+		t.Fatalf("expected error when target service has an exited container")
 	}
 }


### PR DESCRIPTION
Implemented a deployment wait-path update so job containers (`cd.doco.job.enabled=true`) no longer fail deploys when they finish/exit fast.