### PR TITLE
fix(oci): prevent policy downgrades when trust policy is enabled globally

### DIFF
--- a/internal/config/deploy/deploy.go
+++ b/internal/config/deploy/deploy.go
@@ -67,9 +67,10 @@ type Config struct {
 	Reconciliation     ReconciliationConfig                     `yaml:"reconciliation" json:"reconciliation" doco:"allowOverride"`                                                                                              // Reconciliation is the configuration for the reconciliation feature
 	Oci                config.OciTrustPolicyOverride            `yaml:"oci" json:"oci" doco:"allowOverride"`                                                                                                                    // Oci allows per-target overrides for OCI signature verification policy
 	Internal           struct {
-		File        string            `yaml:"-"` // File is the path to the deployment configuration file
-		Environment map[string]string // Environment stores environment variables for variable interpolation in the compose project
-		Hash        string            `yaml:"-"` // Hash is a hash of the Config struct
+		File                          string            `yaml:"-"` // File is the path to the deployment configuration file
+		Environment                   map[string]string // Environment stores environment variables for variable interpolation in the compose project
+		Hash                          string            `yaml:"-"`          // Hash is a hash of the Config struct
+		OciTrustPolicyOverrideTrusted bool              `yaml:"-" json:"-"` // true only for trusted config sources (e.g. POLL_CONFIG inline deployments)
 	} // Internal holds internal configuration values that are not set by the user
 }
 
@@ -505,6 +506,10 @@ func ResolveConfigs(inlineDeployments []*Config, customTarget, reference, repoRo
 		configs, err := expandInlineAutoDiscoverConfigs(repoRoot, inlineDeployments)
 		if err != nil {
 			return nil, err
+		}
+
+		for _, cfg := range configs {
+			cfg.Internal.OciTrustPolicyOverrideTrusted = true
 		}
 
 		return configs, nil

--- a/internal/config/deploy/deploy_test.go
+++ b/internal/config/deploy/deploy_test.go
@@ -330,6 +330,10 @@ func TestResolveConfigs_InlineOverride(t *testing.T) {
 	if len(cfg.ComposeFiles) == 0 {
 		t.Errorf("expected default compose files to be set")
 	}
+
+	if !cfg.Internal.OciTrustPolicyOverrideTrusted {
+		t.Errorf("expected inline deployment OCI trust policy override to be trusted")
+	}
 }
 
 func TestResolveConfigs_InlineMissingName(t *testing.T) {
@@ -740,6 +744,10 @@ reference: %s
 
 	if configs[0].Name != t.Name() {
 		t.Errorf("expected name to be %v, got %s", t.Name(), configs[0].Name)
+	}
+
+	if configs[0].Internal.OciTrustPolicyOverrideTrusted {
+		t.Errorf("expected repository config OCI trust policy override to be untrusted")
 	}
 }
 

--- a/internal/config/oci.go
+++ b/internal/config/oci.go
@@ -49,7 +49,8 @@ func EffectiveOciTrustPolicy(global OciTrustPolicy, override OciTrustPolicyOverr
 	p := NormalizeOciTrustPolicy(global)
 
 	if override.Verify != nil {
-		p.Enabled = *override.Verify
+		// A global enabled trust policy cannot be downgraded by per-deployment config.
+		p.Enabled = p.Enabled || *override.Verify
 	}
 
 	if len(override.KeylessIdentities) > 0 {

--- a/internal/config/oci_test.go
+++ b/internal/config/oci_test.go
@@ -29,3 +29,29 @@ func TestNormalizeOciTrustPolicy_TrimsSubjectRegexp(t *testing.T) {
 		t.Fatalf("unexpected subject_regexp: %q", id.SubjectRegexp)
 	}
 }
+
+func TestEffectiveOciTrustPolicy_GlobalEnabledCannotBeDisabled(t *testing.T) {
+	t.Parallel()
+
+	effective := EffectiveOciTrustPolicy(
+		OciTrustPolicy{Enabled: true},
+		OciTrustPolicyOverride{Verify: new(false)},
+	)
+
+	if !effective.Enabled {
+		t.Fatal("expected global enabled verification to remain enabled")
+	}
+}
+
+func TestEffectiveOciTrustPolicy_OverrideCanEnableWhenGlobalDisabled(t *testing.T) {
+	t.Parallel()
+
+	effective := EffectiveOciTrustPolicy(
+		OciTrustPolicy{Enabled: false},
+		OciTrustPolicyOverride{Verify: new(true)},
+	)
+
+	if !effective.Enabled {
+		t.Fatal("expected override verify=true to enable verification when global is disabled")
+	}
+}

--- a/internal/source/oci/trust_policy.go
+++ b/internal/source/oci/trust_policy.go
@@ -1,0 +1,13 @@
+package oci
+
+import "github.com/kimdre/doco-cd/internal/config"
+
+// SelectTrustPolicyOverride returns deployment-level OCI trust policy overrides
+// only when the deployment configuration origin is trusted.
+func SelectTrustPolicyOverride(override config.OciTrustPolicyOverride, trusted bool) config.OciTrustPolicyOverride {
+	if trusted {
+		return override
+	}
+
+	return config.OciTrustPolicyOverride{}
+}

--- a/internal/source/oci/trust_policy_test.go
+++ b/internal/source/oci/trust_policy_test.go
@@ -1,0 +1,53 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/kimdre/doco-cd/internal/config"
+)
+
+func TestSelectTrustPolicyOverride_TrustBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		override        config.OciTrustPolicyOverride
+		trusted         bool
+		globalPolicy    config.OciTrustPolicy
+		expectEnabled   bool
+		expectVerifyNil bool
+	}{
+		{
+			name:            "untrusted verify false is ignored and verification stays enabled",
+			override:        config.OciTrustPolicyOverride{Verify: new(false)},
+			trusted:         false,
+			globalPolicy:    config.OciTrustPolicy{Enabled: true},
+			expectEnabled:   true,
+			expectVerifyNil: true,
+		},
+		{
+			name:            "trusted verify true can enable when global verification is disabled",
+			override:        config.OciTrustPolicyOverride{Verify: new(true)},
+			trusted:         true,
+			globalPolicy:    config.OciTrustPolicy{Enabled: false},
+			expectEnabled:   true,
+			expectVerifyNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			selected := SelectTrustPolicyOverride(tt.override, tt.trusted)
+			if tt.expectVerifyNil != (selected.Verify == nil) {
+				t.Fatalf("unexpected override verify nil state: got %v want %v", selected.Verify == nil, tt.expectVerifyNil)
+			}
+
+			effective := config.EffectiveOciTrustPolicy(tt.globalPolicy, selected)
+			if effective.Enabled != tt.expectEnabled {
+				t.Fatalf("unexpected effective Enabled: got %v want %v", effective.Enabled, tt.expectEnabled)
+			}
+		})
+	}
+}

--- a/internal/stages/stage_1_init.go
+++ b/internal/stages/stage_1_init.go
@@ -73,7 +73,9 @@ func (s *StageManager) RunInitStage(ctx context.Context, stageLog *slog.Logger) 
 			return fmt.Errorf("failed to access extracted OCI artifact directory: %w", err)
 		}
 
-		if err := oci.VerifyWithCosign(ctx, s.Repository.SourceUrl, s.Repository.Revision, s.AppConfig.OciTrustPolicy, s.DeployConfig.Oci, s.AppConfig.OciVerifyMaxWorkers); err != nil {
+		override := oci.SelectTrustPolicyOverride(s.DeployConfig.Oci, s.DeployConfig.Internal.OciTrustPolicyOverrideTrusted)
+
+		if err := oci.VerifyWithCosign(ctx, s.Repository.SourceUrl, s.Repository.Revision, s.AppConfig.OciTrustPolicy, override, s.AppConfig.OciVerifyMaxWorkers); err != nil {
 			return fmt.Errorf("failed OCI signature verification: %w", err)
 		}
 

--- a/wiki/docs/Advanced/OCI/Trust-Policy.md
+++ b/wiki/docs/Advanced/OCI/Trust-Policy.md
@@ -159,15 +159,18 @@ Override the global trust policy for specific [deployments](../../Poll-Settings.
 
 | Key                  | Type             | Default | Description                                                                                             |
 |----------------------|------------------|---------|---------------------------------------------------------------------------------------------------------|
-| `verify`             | boolean          | unset   | Overrides global `enabled` for this deployment only. `true` enforces verification, `false` disables it. |
+| `verify`             | boolean          | unset   | Can enforce verification (`true`) per deployment. It cannot disable verification when global `enabled: true` is set. |
 | `public_keys`        | array of strings | inherit | Replaces global `public_keys` when set and non-empty.                                                   |
 | `keyless_identities` | array of objects | inherit | Replaces global `keyless_identities` when set and non-empty.                                            |
 
 !!!note "Behavior"
 
-    - If `verify` is unset, the deployment inherits the global `enabled` value. If `verify: true` is set, verification is enforced regardless of the global setting.
+    - If `verify` is unset, the deployment inherits the global `enabled` value.
+    - If `verify: true` is set, verification is enforced regardless of the global setting.
+    - If global `enabled: true` is set, `verify: false` is ignored (no downgrade allowed).
     - If both `public_keys` and `keyless_identities` are empty while verification is enabled, verification fails because no trust rules are defined.
     - Per-deployment `public_keys` and `keyless_identities` override global values only when the respective lists are non-empty.
+    - For OCI sources, trust-policy overrides are only accepted from trusted inline poll deployments (`POLL_CONFIG.deployments`). Artifact-contained `.doco-cd.yml` cannot define the policy used to verify itself.
 
 !!! example "Per-deployment Override Example"
     ```yaml
@@ -201,7 +204,7 @@ Override the global trust policy for specific [deployments](../../Poll-Settings.
     deployments:
       - name: production
         oci:
-          verify: true   # or false to skip verification
+          verify: true   # `verify: false` is ignored when global enabled=true
     ```
 
 ---
@@ -437,11 +440,9 @@ POLL_CONFIG: |
     reference: main
     interval: 300
     deployments:
-      # Development: No verification required
+      # Development: Inherits global policy
       - name: development
         compose_file: docker-compose.yml
-        oci:
-          verify: false
       
       # Staging: Single signer required
       - name: staging
@@ -486,7 +487,7 @@ POLL_CONFIG: |
 1. Verify artifact was actually signed: `cosign verify --key public.pem artifact:tag`
 2. Check that you're using the correct public key in valid PEM format
 3. Ensure artifact hasn't been modified since signing
-4. Try disabling verification temporarily: `verify: false`
+4. In non-production, temporarily set global `enabled: false` only while debugging policy issues
 
 ### Verification Failed: "No Matching Identity"
 
@@ -518,7 +519,7 @@ POLL_CONFIG: |
 
 1. Check `enabled: true` in policy
 2. Verify public keys or keyless identities are configured
-3. Check deployment-level overrides aren't disabling verification
+3. Check global policy and deployment-level trust rules (`public_keys` / `keyless_identities`) for mismatches
 4. Review logs for detailed verification status
 
 ### No Signatures Found on Artifact
@@ -551,7 +552,7 @@ POLL_CONFIG: |
 3. **Separate keys by role** - Use different keys for different teams/environments
 4. **Rotate keys regularly** - Plan for key rotation and maintain key history
 5. **Document your policy** - Maintain clear documentation of your trust setup
-6. **Test before enforcing** - Test verification with `verify: false` first
+6. **Test rollout safely** - Validate in staging first, then enforce with global `enabled: true`
 7. **Monitor verification failures** - Alert on signature verification failures
 8. **Use version tags for releases** - Sign releases with specific version tags
 


### PR DESCRIPTION
- Prevent policy downgrades when global `OCI_TRUST_POLICY.enabled: true` is set (`oci.verify: false` can no longer disable globally enabled verification).
- Ignore OCI trust-policy overrides from untrusted artifact-contained `.doco-cd.yml`; only trusted inline poll deployment configs can supply overrides.