### PR TITLE
feat(hooks): per-deployment HTTP webhook hooks

### DIFF
--- a/internal/config/deploy/deploy.go
+++ b/internal/config/deploy/deploy.go
@@ -21,6 +21,7 @@ import (
 	"gopkg.in/validator.v2"
 
 	"github.com/kimdre/doco-cd/internal/config"
+	"github.com/kimdre/doco-cd/internal/hook"
 
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
 
@@ -66,6 +67,7 @@ type Config struct {
 	AutoDiscovery      AutoDiscoveryConfig                      `yaml:"auto_discovery" json:"auto_discovery"`                                                                                                                   // AutoDiscovery configures autodiscovery of services to deploy in the working directory
 	Reconciliation     ReconciliationConfig                     `yaml:"reconciliation" json:"reconciliation" doco:"allowOverride"`                                                                                              // Reconciliation is the configuration for the reconciliation feature
 	Oci                config.OciTrustPolicyOverride            `yaml:"oci" json:"oci" doco:"allowOverride"`                                                                                                                    // Oci allows per-target overrides for OCI signature verification policy
+	Hooks              hook.Config                              `yaml:"hooks" json:"hooks" doco:"allowOverride"`                                                                                                                // Hooks configures HTTP webhook hooks fired on deployment success/failure
 	Internal           struct {
 		File                          string            `yaml:"-"` // File is the path to the deployment configuration file
 		Environment                   map[string]string // Environment stores environment variables for variable interpolation in the compose project
@@ -182,6 +184,10 @@ func (c *Config) Validate() error {
 
 	if err := c.normalizeReconciliationEvents(); err != nil {
 		return err
+	}
+
+	if err := c.Hooks.Validate(); err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidConfig, err)
 	}
 
 	return nil

--- a/internal/config/deploy/deploy_test.go
+++ b/internal/config/deploy/deploy_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/config"
 
 	"github.com/kimdre/doco-cd/internal/filesystem"
+	"github.com/kimdre/doco-cd/internal/hook"
 )
 
 func createTestFile(t *testing.T, fileName string, content string) error {
@@ -283,6 +284,72 @@ func TestConfig_Validate_OciVersionField(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "unsupported oci version") {
 			t.Fatalf("expected unsupported oci version error, got %v", err)
+		}
+	})
+}
+
+func TestConfig_Hooks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses success and failure hooks from yaml", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		file := filepath.Join(dir, ".doco-cd.yaml")
+		content := `name: app
+reference: main
+hooks:
+  on_success:
+    - url: https://example.com/ok
+      headers:
+        X-Token: secret
+  on_failure:
+    - url: http://example.com/fail
+      method: PUT
+`
+
+		if err := createTestFile(t, file, content); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		configs, err := GetConfigFromYAML(file, true)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		dc := configs[0]
+		if err := dc.Validate(); err != nil {
+			t.Fatalf("validate: %v", err)
+		}
+
+		if len(dc.Hooks.OnSuccess) != 1 || dc.Hooks.OnSuccess[0].URL != "https://example.com/ok" {
+			t.Fatalf("unexpected on_success hooks: %+v", dc.Hooks.OnSuccess)
+		}
+
+		if dc.Hooks.OnSuccess[0].Headers["X-Token"] != "secret" {
+			t.Fatalf("expected header X-Token=secret, got %+v", dc.Hooks.OnSuccess[0].Headers)
+		}
+
+		if len(dc.Hooks.OnFailure) != 1 || dc.Hooks.OnFailure[0].Method != "PUT" {
+			t.Fatalf("unexpected on_failure hooks: %+v", dc.Hooks.OnFailure)
+		}
+	})
+
+	t.Run("rejects invalid hook url", func(t *testing.T) {
+		t.Parallel()
+
+		dc := Config{
+			Name:  "app",
+			Hooks: hook.Config{OnSuccess: []hook.Webhook{{URL: "ftp://example.com"}}},
+		}
+
+		if err := defaults.Set(&dc); err != nil {
+			t.Fatalf("defaults: %v", err)
+		}
+
+		err := dc.Validate()
+		if err == nil || !errors.Is(err, ErrInvalidConfig) {
+			t.Fatalf("expected ErrInvalidConfig, got %v", err)
 		}
 	})
 }

--- a/internal/config/deploy/hooks_multidoc_test.go
+++ b/internal/config/deploy/hooks_multidoc_test.go
@@ -1,0 +1,70 @@
+package deploy
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// Reproduces the server config shape: a multi-document file where only the
+// first document carries a hooks block (like .doco-cd.qa-epic-workspace.yaml).
+func TestGetConfigFromYAML_MultiDocHooks(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, ".doco-cd.qa-epic-workspace.yaml")
+	content := `name: qa-epic-chatbotix-backend
+repository_url: https://github.com/Truevoice/accentix-doco-cd-config.git
+reference: feat/multiple-hooks
+working_dir: qa-epic-workspace/backend
+compose_files:
+  - docker-compose-gcp.yaml
+force_recreate: true
+hooks:
+  on_success:
+    - url: https://idp-dev.accentix.dev/api/events
+      method: POST
+  on_failure:
+    - url: https://idp-dev.accentix.dev/api/events
+      method: POST
+---
+name: qa-epic-chatbotix-frontend
+repository_url: https://github.com/Truevoice/accentix-doco-cd-config.git
+reference: feat/multiple-hooks
+working_dir: qa-epic-workspace/frontend
+compose_files:
+  - docker-compose-gcp.yaml
+`
+
+	if err := createTestFile(t, file, content); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	configs, err := GetConfigFromYAML(file, true)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(configs) != 2 {
+		t.Fatalf("expected 2 docs, got %d", len(configs))
+	}
+
+	backend := configs[0]
+	t.Logf("backend.Hooks = %+v", backend.Hooks)
+
+	if len(backend.Hooks.OnSuccess) != 1 {
+		t.Fatalf("doc1 OnSuccess: expected 1, got %d", len(backend.Hooks.OnSuccess))
+	}
+
+	if len(backend.Hooks.OnFailure) != 1 {
+		t.Fatalf("doc1 OnFailure: expected 1, got %d", len(backend.Hooks.OnFailure))
+	}
+
+	if backend.Hooks.OnSuccess[0].URL != "https://idp-dev.accentix.dev/api/events" {
+		t.Fatalf("doc1 hook url wrong: %q", backend.Hooks.OnSuccess[0].URL)
+	}
+
+	// doc2 has no hooks
+	if len(configs[1].Hooks.OnSuccess) != 0 || len(configs[1].Hooks.OnFailure) != 0 {
+		t.Fatalf("doc2 should have no hooks, got %+v", configs[1].Hooks)
+	}
+}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,0 +1,107 @@
+// Package hook sends per-deployment HTTP webhook hooks on deployment success or failure.
+package hook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// requestTimeout bounds a single hook request.
+const requestTimeout = 10 * time.Second
+
+var (
+	ErrEmptyURL    = errors.New("hook url must not be empty")
+	ErrInvalidURL  = errors.New("hook url must be a valid http(s) url")
+	ErrHookFailed  = errors.New("hook request failed")
+	httpHookClient = &http.Client{Timeout: requestTimeout}
+)
+
+// Webhook is a single HTTP hook target.
+type Webhook struct {
+	URL     string            `yaml:"url" json:"url"`         // URL is the endpoint to call
+	Method  string            `yaml:"method" json:"method"`   // Method is the HTTP method (defaults to POST when empty)
+	Headers map[string]string `yaml:"headers" json:"headers"` // Headers are additional request headers
+}
+
+// Config holds the hooks fired at the success and failure lifecycle points of a deployment.
+type Config struct {
+	OnSuccess []Webhook `yaml:"on_success" json:"on_success"` // OnSuccess hooks fire after a successful deployment
+	OnFailure []Webhook `yaml:"on_failure" json:"on_failure"` // OnFailure hooks fire when a deployment fails
+}
+
+// Payload is the JSON body sent to a hook endpoint.
+type Payload struct {
+	Event      string   `json:"event"`            // Event is "success" or "failure"
+	Repository string   `json:"repository"`       // Repository is the source repository/artifact name
+	Stack      string   `json:"stack"`            // Stack is the deployment/stack name
+	Revision   string   `json:"revision"`         // Revision is the deployed reference/commit
+	JobID      string   `json:"job_id"`           // JobID is the unique job identifier
+	Images     []string `json:"images,omitempty"` // Images are the resolved image references of the changed services
+	Error      string   `json:"error,omitempty"`  // Error is the failure reason (failure event only)
+}
+
+// Validate checks that every configured hook has a valid http(s) URL.
+func (c Config) Validate() error {
+	for _, w := range append(append([]Webhook{}, c.OnSuccess...), c.OnFailure...) {
+		if strings.TrimSpace(w.URL) == "" {
+			return ErrEmptyURL
+		}
+
+		u, err := url.Parse(w.URL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("%w: %s", ErrInvalidURL, w.URL)
+		}
+	}
+
+	return nil
+}
+
+// Send delivers the payload to a single hook target. Any non-2xx response is an error.
+func Send(ctx context.Context, w Webhook, payload Payload) error {
+	method := strings.TrimSpace(w.Method)
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal hook payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, w.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create hook request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	for k, v := range w.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := httpHookClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrHookFailed, err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	// Drain the body so the underlying transport can safely reuse the connection.
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("%w: status %s", ErrHookFailed, resp.Status)
+	}
+
+	return nil
+}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1,0 +1,131 @@
+package hook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr error
+	}{
+		{
+			name:    "valid http and https",
+			config:  Config{OnSuccess: []Webhook{{URL: "http://example.com/a"}}, OnFailure: []Webhook{{URL: "https://example.com/b"}}},
+			wantErr: nil,
+		},
+		{
+			name:    "empty config",
+			config:  Config{},
+			wantErr: nil,
+		},
+		{
+			name:    "empty url",
+			config:  Config{OnSuccess: []Webhook{{URL: "  "}}},
+			wantErr: ErrEmptyURL,
+		},
+		{
+			name:    "non-http scheme",
+			config:  Config{OnFailure: []Webhook{{URL: "ftp://example.com"}}},
+			wantErr: ErrInvalidURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSend(t *testing.T) {
+	payload := Payload{Event: "success", Repository: "user/repo", Stack: "web", Revision: "main (abc1234)", JobID: "job-1", Images: []string{"nginx:1.27", "postgres:16"}}
+
+	var (
+		gotMethod string
+		gotHeader string
+		gotBody   Payload
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotHeader = r.Header.Get("X-Token")
+
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	hk := Webhook{URL: srv.URL, Headers: map[string]string{"X-Token": "secret"}}
+
+	if err := Send(context.Background(), hk, payload); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST (default)", gotMethod)
+	}
+
+	if gotHeader != "secret" {
+		t.Errorf("custom header = %q, want secret", gotHeader)
+	}
+
+	if !reflect.DeepEqual(gotBody, payload) {
+		t.Errorf("body = %+v, want %+v", gotBody, payload)
+	}
+}
+
+func TestSendCustomMethod(t *testing.T) {
+	var gotMethod string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if err := Send(context.Background(), Webhook{URL: srv.URL, Method: http.MethodPut}, Payload{}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+}
+
+func TestSendNon2xxIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	err := Send(context.Background(), Webhook{URL: srv.URL}, Payload{})
+	if !errors.Is(err, ErrHookFailed) {
+		t.Fatalf("Send() error = %v, want ErrHookFailed", err)
+	}
+}
+
+func TestSendConnectionError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // server is now unreachable
+
+	err := Send(context.Background(), Webhook{URL: url}, Payload{})
+	if !errors.Is(err, ErrHookFailed) {
+		t.Fatalf("Send() error = %v, want ErrHookFailed", err)
+	}
+}

--- a/internal/stages/hooks_images_test.go
+++ b/internal/stages/hooks_images_test.go
@@ -1,0 +1,80 @@
+package stages
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+
+	"github.com/kimdre/doco-cd/internal/docker"
+)
+
+func TestChangedServiceImages(t *testing.T) {
+	project := &types.Project{
+		Services: types.Services{
+			"web":   {Name: "web", Image: "nginx:1.27"},
+			"db":    {Name: "db", Image: "postgres:16"},
+			"proxy": {Name: "proxy", Image: "nginx:1.27"}, // duplicate image
+			"build": {Name: "build"},                      // no image (built locally)
+		},
+	}
+
+	tests := []struct {
+		name            string
+		project         *types.Project
+		changedServices []docker.Change
+		want            []string
+	}{
+		{
+			name:    "changed services map to deduped sorted images",
+			project: project,
+			changedServices: []docker.Change{
+				{Type: "config", Services: []string{"web", "proxy"}},
+				{Type: "image", Services: []string{"db"}},
+			},
+			want: []string{"nginx:1.27", "postgres:16"},
+		},
+		{
+			name:    "service without image is skipped",
+			project: project,
+			changedServices: []docker.Change{
+				{Type: "config", Services: []string{"build", "web"}},
+			},
+			want: []string{"nginx:1.27"},
+		},
+		{
+			name:    "unknown service name is skipped",
+			project: project,
+			changedServices: []docker.Change{
+				{Type: "config", Services: []string{"missing"}},
+			},
+			want: nil,
+		},
+		{
+			name:            "no changed services",
+			project:         project,
+			changedServices: nil,
+			want:            nil,
+		},
+		{
+			name:            "nil project returns nil",
+			project:         nil,
+			changedServices: []docker.Change{{Type: "config", Services: []string{"web"}}},
+			want:            nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &StageManager{
+				Docker:      &Docker{Project: tt.project},
+				DeployState: &DeploymentState{changedServices: tt.changedServices},
+			}
+
+			got := s.changedServiceImages()
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("changedServiceImages() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/stages/run.go
+++ b/internal/stages/run.go
@@ -80,7 +80,7 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 				return nil
 			}
 
-			s.NotifyFailure(err)
+			s.NotifyFailure(ctx, err)
 
 			return err
 		}

--- a/internal/stages/stage_4_post-deploy.go
+++ b/internal/stages/stage_4_post-deploy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/notification"
 )
 
-func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logger) error {
+func (s *StageManager) RunPostDeployStage(ctx context.Context, stageLog *slog.Logger) error {
 	s.Stages.PostDeploy.StartedAt = time.Now()
 
 	defer func() {
@@ -35,16 +35,20 @@ func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logg
 		}
 	}
 
+	revision := notification.GetRevision(s.DeployConfig.Reference, shortCommit)
+
 	metadata := s.Metadata
 	metadata.Repository = s.Repository.Name
 	metadata.Stack = s.DeployConfig.Name
-	metadata.Revision = notification.GetRevision(s.DeployConfig.Reference, shortCommit)
+	metadata.Revision = revision
 	metadata.JobID = s.JobID
 
 	err = notification.Send(notification.Success, "Deployment completed", "Successfully deployed stack "+s.DeployConfig.Name, metadata)
 	if err != nil {
 		stageLog.Error("failed to send notification", logger.ErrAttr(err))
 	}
+
+	s.fireHooks(ctx, s.DeployConfig.Hooks.OnSuccess, "success", revision, "")
 
 	return nil
 }

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -1,8 +1,10 @@
 package stages
 
 import (
+	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -16,6 +18,8 @@ import (
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker"
+	"github.com/kimdre/doco-cd/internal/hook"
+	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
 
 	gitInternal "github.com/kimdre/doco-cd/internal/git"
@@ -220,33 +224,32 @@ func (s *StageManager) GetStageMetaData(stageName StageName) (*MetaData, error) 
 	}
 }
 
-// NotifyFailure sends a failure notification using the provided NotifyFailureFunc.
-func (s *StageManager) NotifyFailure(notifyErr error) {
+// NotifyFailure sends a failure notification using the provided NotifyFailureFunc
+// and fires any configured on-failure hooks.
+func (s *StageManager) NotifyFailure(ctx context.Context, notifyErr error) {
 	var (
 		latestCommit string
 		commitErr    error
 		commitSha    string
 	)
 
+	if s.Repository.Git != nil {
+		latestCommit, commitErr = gitInternal.GetLatestCommit(s.Repository.Git, s.DeployConfig.Reference)
+		if commitErr != nil {
+			latestCommit = ""
+		}
+
+		commitSha, commitErr = gitInternal.GetShortestUniqueCommitHash(s.Repository.Git, latestCommit, gitInternal.DefaultShortSHALength)
+		if commitErr != nil {
+			commitSha = latestCommit
+		}
+	} else {
+		commitSha = strings.TrimSpace(s.Repository.Revision)
+	}
+
+	revision := notification.GetRevision(s.DeployConfig.Reference, commitSha)
+
 	if s.NotifyFailureFunc != nil {
-		if s.Repository.Git != nil {
-			latestCommit, commitErr = gitInternal.GetLatestCommit(s.Repository.Git, s.DeployConfig.Reference)
-			if commitErr != nil {
-				latestCommit = ""
-			}
-
-			commitSha, commitErr = gitInternal.GetShortestUniqueCommitHash(s.Repository.Git, latestCommit, gitInternal.DefaultShortSHALength)
-			if commitErr != nil {
-				commitSha = latestCommit
-			}
-		}
-
-		if s.Repository.Git == nil {
-			commitSha = strings.TrimSpace(s.Repository.Revision)
-		}
-
-		revision := notification.GetRevision(s.DeployConfig.Reference, commitSha)
-
 		metadata := s.Metadata
 		metadata.Repository = s.Repository.Name
 		metadata.Stack = s.DeployConfig.Name
@@ -254,5 +257,77 @@ func (s *StageManager) NotifyFailure(notifyErr error) {
 		metadata.JobID = s.JobID
 
 		s.NotifyFailureFunc(s.Log, notifyErr, metadata)
+	}
+
+	s.fireHooks(ctx, s.DeployConfig.Hooks.OnFailure, "failure", revision, notifyErr.Error())
+}
+
+// changedServiceImages returns the resolved image references of the services that
+// changed in this deployment, deduplicated and sorted. It returns nil when the
+// compose project is unavailable (e.g. a failure before the project was loaded).
+func (s *StageManager) changedServiceImages() []string {
+	if s.Docker == nil || s.Docker.Project == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+
+	var images []string
+
+	for _, change := range s.DeployState.changedServices {
+		for _, name := range change.Services {
+			svc, ok := s.Docker.Project.Services[name]
+			if !ok || svc.Image == "" {
+				continue
+			}
+
+			if _, dup := seen[svc.Image]; dup {
+				continue
+			}
+
+			seen[svc.Image] = struct{}{}
+			images = append(images, svc.Image)
+		}
+	}
+
+	slices.Sort(images)
+
+	return images
+}
+
+// fireHooks delivers the configured webhook hooks for a lifecycle event.
+// Hook failures are logged but never abort the deployment.
+func (s *StageManager) fireHooks(ctx context.Context, webhooks []hook.Webhook, event, revision, errMsg string) {
+	if len(webhooks) == 0 {
+		return
+	}
+
+	payload := hook.Payload{
+		Event:      event,
+		Repository: s.Repository.Name,
+		Stack:      s.DeployConfig.Name,
+		Revision:   revision,
+		JobID:      s.JobID,
+		Images:     s.changedServiceImages(),
+		Error:      errMsg,
+	}
+
+	s.Log.Info("sending deployment hooks",
+		slog.String("event", event),
+		slog.Int("count", len(webhooks)))
+
+	for _, w := range webhooks {
+		if err := hook.Send(ctx, w, payload); err != nil {
+			s.Log.Error("failed to send deployment hook",
+				slog.String("event", event),
+				slog.String("url", w.URL),
+				logger.ErrAttr(err))
+
+			continue
+		}
+
+		s.Log.Info("sent deployment hook",
+			slog.String("event", event),
+			slog.String("url", w.URL))
 	}
 }

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -63,6 +63,7 @@ The docker compose deployment can be configured inside the [deployment configura
 | `destroy`           | boolean \| object | (⚠️ Destructive) Configure stack/project destruction behavior. Use `destroy: true` as shorthand to enable destruction with default options, or use `destroy.enabled: true` inside the object form to customize removal behavior. See [Destroy settings](#destroy-settings).                                                                                                                                                                                                          | see [Destroy settings](#destroy-settings)                                                                              |
 | `auto_discovery`    | boolean \| object | Enables [autodiscovery](#auto-discovery) of services to deploy in the working directory by scanning for subdirectories with Docker Compose files (see the `compose_files` setting). Use `auto_discovery: true` as shorthand to enable it with default options, or use the object form to customize settings such as `depth` and `delete`. See [Auto-Discovery Settings](#auto-discovery-settings).                                                                                   | see [Auto-Discovery Settings](#auto-discovery-settings)                                                                |
 | `reconciliation`    | boolean \| object | Enables event-driven reconciliation for deployments. Use `reconciliation: true` as shorthand to enable reconciliation with default options, or use the object form to customize settings. See [reconciliation settings](#reconciliation-settings).                                                                                                                                                                                                                                   | see [Reconciliation Settings](#reconciliation-settings)                                                                |
+| `hooks`             | object            | HTTP webhook hooks fired after a deployment succeeds or fails. See [Hook Settings](#hook-settings).                                                                                                                                                                                                                                                                                                                                                                                  | `null` (No hooks)                                                                                                      |
 
 
 !!! example
@@ -437,6 +438,60 @@ The following events are supported as reconciliation triggers in Docker (Standal
         - destroy
         - unhealthy
     ```
+
+### Hook Settings
+
+Hooks send an HTTP request to one or more endpoints when a deployment finishes, so you can trigger external systems (CI pipelines, alerting, dashboards) on the outcome.
+
+!!! info "Hooks vs. Notifications"
+    Hooks are raw HTTP calls configured per deployment in the deployment config. For ready-made messages to chat/email services, use [Notifications](Advanced/Notifications.md) instead.
+
+`hooks` is a nested object with two independent lists. Each list contains one or more hook entries:
+
+| Key          | Type                  | Description                                                  | Default value |
+|--------------|-----------------------|--------------------------------------------------------------|---------------|
+| `on_success` | array of hook entries | Hooks called after the deployment completes successfully.    | `[]`          |
+| `on_failure` | array of hook entries | Hooks called when the deployment fails.                      | `[]`          |
+
+Each hook entry accepts:
+
+| Key       | Type           | Description                                                        | Default value |
+|-----------|----------------|--------------------------------------------------------------------|---------------|
+| `url`     | string         | Target endpoint. Must be a valid `http`/`https` URL.               |               |
+| `method`  | string         | HTTP method to use.                                                | `POST`        |
+| `headers` | map of strings | Additional request headers (e.g. an authorization token).         | `null`        |
+
+The request body is JSON (`Content-Type: application/json`) with the following fields:
+
+| Field        | Description                                            |
+|--------------|--------------------------------------------------------|
+| `event`      | `success` or `failure`.                                |
+| `repository` | Source repository / OCI artifact name.                 |
+| `stack`      | Deployment / stack name.                               |
+| `revision`   | Deployed reference and commit (e.g. `main (abc1234)`). |
+| `job_id`     | Unique job identifier.                                 |
+| `images`     | Resolved image references (`name:tag`) of the changed services. Omitted when no service images are available. |
+| `error`      | Failure reason (present on `failure` events only).     |
+
+!!! note "Hooks are best-effort"
+    A hook request has a 10 second timeout. A non-2xx response or an unreachable endpoint is logged but does **not** fail the deployment.
+
+!!! example
+
+    ```yaml title=".doco-cd.yml"
+    name: some-project
+    hooks:
+      on_success:
+        - url: https://ci.example.com/notify # (1)!
+          headers:
+            Authorization: Bearer xxx
+      on_failure:
+        - url: https://alerts.example.com/webhook # (2)!
+          method: PUT
+    ```
+
+    1. Called with an `event: success` payload after a successful deployment.
+    2. Called with an `event: failure` payload (including the `error` field) when the deployment fails.
 
 ### Webhook Filter
 


### PR DESCRIPTION
## What

Adds per-deployment HTTP webhook hooks. A deploy config can declare `hooks.on_success` and `hooks.on_failure` lists; each entry POSTs a JSON payload to an endpoint when the deployment succeeds or fails.

## Why

Lets external systems (CI, alerting, chatops) react to doco-cd deployments without polling — e.g. notify a channel on success or page on failure.

## Config

```yaml
name: some-project
hooks:
  on_success:
    - url: https://ci.example.com/notify
      headers:
        Authorization: Bearer xxx
  on_failure:
    - url: https://alerts.example.com/webhook
      method: PUT   # defaults to POST
```

Fields per entry: `url` (required, http/https), `method` (default `POST`), `headers` (optional map).

## Payload

JSON body (`Content-Type: application/json`):

| Field | Description |
|-------|-------------|
| `event` | `success` or `failure` |
| `repository` | source repo / OCI artifact name |
| `stack` | deployment / stack name |
| `revision` | deployed reference + commit (e.g. `main (abc1234)`) |
| `job_id` | unique job id |
| `images` | resolved image refs (`name:tag`) of the **changed** services; omitted when empty |
| `error` | failure reason (failure events only) |

## Behaviour

- Success hooks fire from the post-deploy stage; failure hooks from `StageManager.NotifyFailure`.
- **Best-effort**: 10s timeout per request; a non-2xx response or unreachable endpoint is logged but never fails the deployment.
- Config validated up front (`Hooks.Validate` rejects empty / non-http(s) URLs).
- Multi-doc deploy YAML and `allowOverride` per-target overrides supported.

## Tests

- `internal/hook`: URL validation, send (method/headers/body), non-2xx + bad-URL paths.
- `internal/config/deploy`: hook parsing from YAML, invalid-URL rejection, multi-doc handling.
- `internal/stages`: `changedServiceImages` (dedup/sort, missing-image, nil-project).

## Notes

`images` currently reflects only **changed** services, so it is omitted on deploys with no file-detected service changes (e.g. force-recreate / mismatch-driven redeploys). Can be widened to all stack services if desired.