### PR TITLE
fix(oci): preserve destination inode during artifact sync

### DIFF
--- a/internal/source/oci/service.go
+++ b/internal/source/oci/service.go
@@ -94,13 +94,15 @@ func PullAndExtract(ctx context.Context, artifactRef, expectedDigest, layout, de
 		return PullResult{}, fmt.Errorf("%w: no layers in artifact", ErrInvalidArtifactLayout)
 	}
 
-	if err := os.RemoveAll(destination); err != nil {
-		return PullResult{}, fmt.Errorf("failed to reset artifact destination: %w", err)
+	// Extract into a sibling temp directory so that validation can run before
+	// touching the live destination. Using the same parent ensures src and dst
+	// are on the same filesystem, which allows cheap os.Rename moves.
+	tmpDir, err := os.MkdirTemp(filepath.Dir(destination), ".oci-extract-*")
+	if err != nil {
+		return PullResult{}, fmt.Errorf("failed to create temp extraction directory: %w", err)
 	}
 
-	if err := os.MkdirAll(destination, filesystem.PermDir); err != nil {
-		return PullResult{}, fmt.Errorf("failed to create artifact destination: %w", err)
-	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
 
 	for _, layer := range layers {
 		r, err := layer.Uncompressed()
@@ -108,7 +110,7 @@ func PullAndExtract(ctx context.Context, artifactRef, expectedDigest, layout, de
 			return PullResult{}, fmt.Errorf("failed to read artifact layer stream: %w", err)
 		}
 
-		err = extractTarStream(destination, r)
+		err = extractTarStream(tmpDir, r)
 		_ = r.Close()
 
 		if err != nil {
@@ -116,11 +118,56 @@ func PullAndExtract(ctx context.Context, artifactRef, expectedDigest, layout, de
 		}
 	}
 
-	if err := validateDocoLayoutV1(destination, customTarget); err != nil {
+	if err := validateDocoLayoutV1(tmpDir, customTarget); err != nil {
 		return PullResult{}, err
 	}
 
+	// Sync contents into the existing destination directory without removing
+	// the directory itself. Preserving the directory inode ensures that Docker
+	// bind mounts referencing destination remain valid across syncs.
+	if err := syncDirectoryContents(tmpDir, destination); err != nil {
+		return PullResult{}, fmt.Errorf("failed to sync artifact to destination: %w", err)
+	}
+
 	return PullResult{Digest: digest}, nil
+}
+
+// syncDirectoryContents replaces the contents of dst with those from src
+// without removing dst itself. This keeps the dst inode stable so that Docker
+// bind mounts that reference dst are not orphaned.
+func syncDirectoryContents(src, dst string) error {
+	if err := os.MkdirAll(dst, filesystem.PermDir); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	// Remove all existing entries in dst.
+	existing, err := os.ReadDir(dst)
+	if err != nil {
+		return fmt.Errorf("failed to read destination directory: %w", err)
+	}
+
+	for _, entry := range existing {
+		if err := os.RemoveAll(filepath.Join(dst, entry.Name())); err != nil {
+			return fmt.Errorf("failed to remove %q from destination: %w", entry.Name(), err)
+		}
+	}
+
+	// Move each entry from src into dst.
+	incoming, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("failed to read source directory: %w", err)
+	}
+
+	for _, entry := range incoming {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if err := os.Rename(srcPath, dstPath); err != nil {
+			return fmt.Errorf("failed to move %q to destination: %w", entry.Name(), err)
+		}
+	}
+
+	return nil
 }
 
 func extractTarStream(destination string, reader io.Reader) error {

--- a/internal/source/oci/service_test.go
+++ b/internal/source/oci/service_test.go
@@ -3,6 +3,7 @@ package oci
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -137,4 +138,98 @@ func TestFindArtifactConfigFile_CustomTargetReturnsTargetConfig(t *testing.T) {
 	if filepath.Base(got) != ".doco-cd.production.yaml" {
 		t.Fatalf("expected .doco-cd.production.yaml, got %s", filepath.Base(got))
 	}
+}
+
+func TestSyncDirectoryContents_PreservesDestinationInode(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	dst := filepath.Join(base, "destination")
+
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("create dst: %v", err)
+	}
+
+	// Record the inode of the destination directory before the sync.
+	inodeBefore := dirInode(t, dst)
+
+	// Populate a source directory.
+	src := filepath.Join(base, "source")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("create src: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(src, "file.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write src file: %v", err)
+	}
+
+	if err := syncDirectoryContents(src, dst); err != nil {
+		t.Fatalf("syncDirectoryContents: %v", err)
+	}
+
+	// The destination directory inode must be unchanged.
+	inodeAfter := dirInode(t, dst)
+	if inodeBefore != inodeAfter {
+		t.Fatalf("destination inode changed: before=%d after=%d — bind mounts would be broken", inodeBefore, inodeAfter)
+	}
+
+	// The new file must be present.
+	if _, err := os.Stat(filepath.Join(dst, "file.txt")); err != nil {
+		t.Fatalf("expected file.txt in destination: %v", err)
+	}
+}
+
+func TestSyncDirectoryContents_RemovesStaleEntries(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	dst := filepath.Join(base, "destination")
+
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("create dst: %v", err)
+	}
+
+	// Write a stale file that must be removed during sync.
+	stale := filepath.Join(dst, "stale.txt")
+	if err := os.WriteFile(stale, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	src := filepath.Join(base, "source")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("create src: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(src, "new.txt"), []byte("new"), 0o644); err != nil {
+		t.Fatalf("write src file: %v", err)
+	}
+
+	if err := syncDirectoryContents(src, dst); err != nil {
+		t.Fatalf("syncDirectoryContents: %v", err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatal("stale.txt should have been removed from destination")
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, "new.txt")); err != nil {
+		t.Fatalf("new.txt should exist in destination: %v", err)
+	}
+}
+
+// dirInode returns the inode number of a directory, failing the test on error.
+func dirInode(t *testing.T, path string) uint64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("cannot read inode on this platform")
+	}
+
+	return sys.Ino
 }

--- a/internal/source/oci/service_test.go
+++ b/internal/source/oci/service_test.go
@@ -5,13 +5,15 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+
+	"github.com/kimdre/doco-cd/internal/filesystem"
 )
 
 func TestValidateDocoLayoutV1_AcceptsVersionInConfig(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("version: doco.v1\nname: app\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("version: doco.v1\nname: app\n"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -24,7 +26,7 @@ func TestValidateDocoLayoutV1_AcceptsMissingVersion_DefaultsToV1(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("name: app\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("name: app\n"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -37,7 +39,7 @@ func TestValidateDocoLayoutV1_RejectsUnsupportedVersion(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("version: doco.v2\nname: app\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("version: doco.v2\nname: app\n"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -51,7 +53,7 @@ func TestValidateDocoLayoutV1_AcceptsCustomTargetConfig(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.production.yaml"), []byte("version: doco.v1\nname: app\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.production.yaml"), []byte("version: doco.v1\nname: app\n"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -65,7 +67,7 @@ func TestValidateDocoLayoutV1_CustomTargetDoesNotFallBackToDefault(t *testing.T)
 
 	dir := t.TempDir()
 	// Only the default config exists — custom target must NOT fall back to it.
-	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("version: doco.v1\nname: app\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("version: doco.v1\nname: app\n"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -90,7 +92,7 @@ func TestFindArtifactConfigFile_NoCustomTarget(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yml"), []byte("name: app\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yml"), []byte("name: app\n"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -109,7 +111,7 @@ func TestFindArtifactConfigFile_CustomTargetDoesNotFallBackToDefault(t *testing.
 
 	dir := t.TempDir()
 	// Only the default config exists — should not be returned when a custom target is set.
-	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("name: app\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".doco-cd.yaml"), []byte("name: app\n"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
 
@@ -125,7 +127,7 @@ func TestFindArtifactConfigFile_CustomTargetReturnsTargetConfig(t *testing.T) {
 	dir := t.TempDir()
 
 	for _, name := range []string{".doco-cd.yaml", ".doco-cd.production.yaml"} {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte("name: app\n"), 0o600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("name: app\n"), filesystem.PermOwner); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}
 	}
@@ -146,7 +148,7 @@ func TestSyncDirectoryContents_PreservesDestinationInode(t *testing.T) {
 	base := t.TempDir()
 	dst := filepath.Join(base, "destination")
 
-	if err := os.MkdirAll(dst, 0o755); err != nil {
+	if err := os.MkdirAll(dst, filesystem.PermOwner); err != nil {
 		t.Fatalf("create dst: %v", err)
 	}
 
@@ -155,11 +157,11 @@ func TestSyncDirectoryContents_PreservesDestinationInode(t *testing.T) {
 
 	// Populate a source directory.
 	src := filepath.Join(base, "source")
-	if err := os.MkdirAll(src, 0o755); err != nil {
+	if err := os.MkdirAll(src, filesystem.PermDir); err != nil {
 		t.Fatalf("create src: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(src, "file.txt"), []byte("hello"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "file.txt"), []byte("hello"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write src file: %v", err)
 	}
 
@@ -185,22 +187,22 @@ func TestSyncDirectoryContents_RemovesStaleEntries(t *testing.T) {
 	base := t.TempDir()
 	dst := filepath.Join(base, "destination")
 
-	if err := os.MkdirAll(dst, 0o755); err != nil {
+	if err := os.MkdirAll(dst, filesystem.PermDir); err != nil {
 		t.Fatalf("create dst: %v", err)
 	}
 
 	// Write a stale file that must be removed during sync.
 	stale := filepath.Join(dst, "stale.txt")
-	if err := os.WriteFile(stale, []byte("old"), 0o644); err != nil {
+	if err := os.WriteFile(stale, []byte("old"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write stale file: %v", err)
 	}
 
 	src := filepath.Join(base, "source")
-	if err := os.MkdirAll(src, 0o755); err != nil {
+	if err := os.MkdirAll(src, filesystem.PermDir); err != nil {
 		t.Fatalf("create src: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(src, "new.txt"), []byte("new"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "new.txt"), []byte("new"), filesystem.PermOwner); err != nil {
 		t.Fatalf("write src file: %v", err)
 	}
 

--- a/internal/source/oci/service_test.go
+++ b/internal/source/oci/service_test.go
@@ -148,7 +148,7 @@ func TestSyncDirectoryContents_PreservesDestinationInode(t *testing.T) {
 	base := t.TempDir()
 	dst := filepath.Join(base, "destination")
 
-	if err := os.MkdirAll(dst, filesystem.PermOwner); err != nil {
+	if err := os.MkdirAll(dst, filesystem.PermDir); err != nil {
 		t.Fatalf("create dst: %v", err)
 	}
 
@@ -161,7 +161,7 @@ func TestSyncDirectoryContents_PreservesDestinationInode(t *testing.T) {
 		t.Fatalf("create src: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(src, "file.txt"), []byte("hello"), filesystem.PermOwner); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "file.txt"), []byte("hello"), filesystem.PermPublic); err != nil {
 		t.Fatalf("write src file: %v", err)
 	}
 
@@ -193,7 +193,7 @@ func TestSyncDirectoryContents_RemovesStaleEntries(t *testing.T) {
 
 	// Write a stale file that must be removed during sync.
 	stale := filepath.Join(dst, "stale.txt")
-	if err := os.WriteFile(stale, []byte("old"), filesystem.PermOwner); err != nil {
+	if err := os.WriteFile(stale, []byte("old"), filesystem.PermPublic); err != nil {
 		t.Fatalf("write stale file: %v", err)
 	}
 
@@ -202,7 +202,7 @@ func TestSyncDirectoryContents_RemovesStaleEntries(t *testing.T) {
 		t.Fatalf("create src: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(src, "new.txt"), []byte("new"), filesystem.PermOwner); err != nil {
+	if err := os.WriteFile(filepath.Join(src, "new.txt"), []byte("new"), filesystem.PermPublic); err != nil {
 		t.Fatalf("write src file: %v", err)
 	}
 


### PR DESCRIPTION
preserve destination inode during artifact sync to avoid bind mount issues