### PR TITLE
feat: add ignore_tlog option for OCI trust policy

### DIFF
--- a/internal/config/oci.go
+++ b/internal/config/oci.go
@@ -12,12 +12,14 @@ type OciTrustPolicy struct {
 	Enabled           bool                 `yaml:"enabled" json:"enabled"`
 	KeylessIdentities []OciKeylessIdentity `yaml:"keyless_identities" json:"keyless_identities"`
 	PublicKeys        []string             `yaml:"public_keys" json:"public_keys"`
+	IgnoreTlog        bool                 `yaml:"ignore_tlog" json:"ignore_tlog"`
 }
 
 type OciTrustPolicyOverride struct {
 	Verify            *bool                `yaml:"verify" json:"verify"`
 	KeylessIdentities []OciKeylessIdentity `yaml:"keyless_identities" json:"keyless_identities"`
 	PublicKeys        []string             `yaml:"public_keys" json:"public_keys"`
+	IgnoreTlog        *bool                `yaml:"ignore_tlog" json:"ignore_tlog"`
 }
 
 func NormalizeOciTrustPolicy(p OciTrustPolicy) OciTrustPolicy {
@@ -59,6 +61,10 @@ func EffectiveOciTrustPolicy(global OciTrustPolicy, override OciTrustPolicyOverr
 
 	if len(override.PublicKeys) > 0 {
 		p.PublicKeys = override.PublicKeys
+	}
+
+	if override.IgnoreTlog != nil {
+		p.IgnoreTlog = *override.IgnoreTlog
 	}
 
 	return NormalizeOciTrustPolicy(p)

--- a/internal/config/oci_test.go
+++ b/internal/config/oci_test.go
@@ -55,3 +55,31 @@ func TestEffectiveOciTrustPolicy_OverrideCanEnableWhenGlobalDisabled(t *testing.
 		t.Fatal("expected override verify=true to enable verification when global is disabled")
 	}
 }
+
+func TestEffectiveOciTrustPolicy_IgnoreTlogOverride(t *testing.T) {
+	t.Parallel()
+
+	// Test: Override can set IgnoreTlog
+	effective := EffectiveOciTrustPolicy(
+		OciTrustPolicy{Enabled: true, IgnoreTlog: false},
+		OciTrustPolicyOverride{IgnoreTlog: new(true)},
+	)
+
+	if !effective.IgnoreTlog {
+		t.Fatal("expected override IgnoreTlog=true to override global IgnoreTlog=false")
+	}
+}
+
+func TestEffectiveOciTrustPolicy_IgnoreTlogGlobalDefault(t *testing.T) {
+	t.Parallel()
+
+	// Test: Global IgnoreTlog is used when no override
+	effective := EffectiveOciTrustPolicy(
+		OciTrustPolicy{Enabled: true, IgnoreTlog: true},
+		OciTrustPolicyOverride{},
+	)
+
+	if !effective.IgnoreTlog {
+		t.Fatal("expected global IgnoreTlog=true to be used when override is not set")
+	}
+}

--- a/internal/source/oci/verify.go
+++ b/internal/source/oci/verify.go
@@ -122,6 +122,7 @@ func VerifyWithCosign(ctx context.Context, artifactRef, digest string, globalPol
 			SigVerifier:       verifier,
 			TrustedMaterial:   trustedMaterial,
 			ExperimentalOCI11: true,
+			IgnoreTlog:        effectivePolicy.IgnoreTlog,
 		}, maxWorkers)
 		if err == nil {
 			return nil
@@ -140,6 +141,7 @@ func VerifyWithCosign(ctx context.Context, artifactRef, digest string, globalPol
 			Identities:        []cosign.Identity{toCosignIdentity(identity)},
 			TrustedMaterial:   trustedMaterial,
 			ExperimentalOCI11: true,
+			IgnoreTlog:        effectivePolicy.IgnoreTlog,
 		}, maxWorkers)
 		if err == nil {
 			return nil

--- a/wiki/docs/Advanced/OCI/Trust-Policy.md
+++ b/wiki/docs/Advanced/OCI/Trust-Policy.md
@@ -39,6 +39,7 @@ Both can be used together in a single trust policy.
 
 ```yaml
 enabled: true                    # Enable/disable verification
+ignore_tlog: false               # Skip Rekor transparency log verification (default: false)
 public_keys:                     # List of trusted public keys (PEM format)
   - |
     -----BEGIN PUBLIC KEY-----
@@ -81,6 +82,7 @@ keyless_identities:              # Keyless verification using OIDC
 | `enabled`            | boolean          | `false` | Enables OCI signature verification globally. When `false`, verification is skipped. |
 | `public_keys`        | array of strings | `[]`    | List of trusted public keys (PEM format) used by Cosign key verification.           |
 | `keyless_identities` | array of object  | `[]`    | List of trusted keyless identities used for OIDC-based verification.                |
+| `ignore_tlog`        | boolean          | `false` | When `true`, skip Rekor transparency log verification. Only use in air-gapped or private environments where signatures are not logged to Rekor. |
 
 ##### `keyless_identities` object fields
 
@@ -162,6 +164,7 @@ Override the global trust policy for specific [deployments](../../Poll-Settings.
 | `verify`             | boolean          | unset   | Can enforce verification (`true`) per deployment. It cannot disable verification when global `enabled: true` is set. |
 | `public_keys`        | array of strings | inherit | Replaces global `public_keys` when set and non-empty.                                                   |
 | `keyless_identities` | array of objects | inherit | Replaces global `keyless_identities` when set and non-empty.                                            |
+| `ignore_tlog`        | boolean          | inherit | When `true`, skip Rekor transparency log verification. Overrides the global `ignore_tlog` setting when set. |
 
 !!!note "Behavior"
 
@@ -205,6 +208,42 @@ Override the global trust policy for specific [deployments](../../Poll-Settings.
       - name: production
         oci:
           verify: true   # `verify: false` is ignored when global enabled=true
+    ```
+
+### Ignoring Rekor Transparency Logs
+
+By default, Doco-CD verifies that signatures are logged in the Rekor transparency log when verifying Cosign signatures. This is the security best practice and is enabled by default.
+
+However, in air-gapped, private, or Rekor-independent environments, signatures may not be uploaded to Rekor. In these cases, you can skip transparency log verification while still verifying the signature with the configured public key or keyless identity.
+
+!!! warning "Use with Caution"
+    Only skip transparency log verification when operating in a controlled environment where artifacts cannot be tampered with. In public environments, skipping transparency log verification reduces security guarantees.
+
+=== "Global Configuration"
+
+    ```yaml
+    OCI_TRUST_POLICY: |
+      enabled: true
+      ignore_tlog: true
+      public_keys:
+        - |
+          -----BEGIN PUBLIC KEY-----
+          MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
+          -----END PUBLIC KEY-----
+    ```
+
+=== "Per-deployment Override"
+
+    ```yaml
+    deployments:
+      - name: air-gapped-environment
+        oci:
+          ignore_tlog: true
+          public_keys:
+            - |
+              -----BEGIN PUBLIC KEY-----
+              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...
+              -----END PUBLIC KEY-----
     ```
 
 ---

--- a/wiki/docs/Advanced/OCI/Trust-Policy.md
+++ b/wiki/docs/Advanced/OCI/Trust-Policy.md
@@ -77,11 +77,11 @@ keyless_identities:              # Keyless verification using OIDC
 
 ##### Trust Policy Fields
 
-| Key                  | Type             | Default | Description                                                                         |
-|----------------------|------------------|---------|-------------------------------------------------------------------------------------|
-| `enabled`            | boolean          | `false` | Enables OCI signature verification globally. When `false`, verification is skipped. |
-| `public_keys`        | array of strings | `[]`    | List of trusted public keys (PEM format) used by Cosign key verification.           |
-| `keyless_identities` | array of object  | `[]`    | List of trusted keyless identities used for OIDC-based verification.                |
+| Key                  | Type             | Default | Description                                                                                                                                     |
+|----------------------|------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `enabled`            | boolean          | `false` | Enables OCI signature verification globally. When `false`, verification is skipped.                                                             |
+| `public_keys`        | array of strings | `[]`    | List of trusted public keys (PEM format) used by Cosign key verification.                                                                       |
+| `keyless_identities` | array of object  | `[]`    | List of trusted keyless identities used for OIDC-based verification.                                                                            |
 | `ignore_tlog`        | boolean          | `false` | When `true`, skip Rekor transparency log verification. Only use in air-gapped or private environments where signatures are not logged to Rekor. |
 
 ##### `keyless_identities` object fields
@@ -159,12 +159,12 @@ keyless_identities:              # Keyless verification using OIDC
 
 Override the global trust policy for specific [deployments](../../Poll-Settings.md#inline-deploy-configs):
 
-| Key                  | Type             | Default | Description                                                                                             |
-|----------------------|------------------|---------|---------------------------------------------------------------------------------------------------------|
+| Key                  | Type             | Default | Description                                                                                                          |
+|----------------------|------------------|---------|----------------------------------------------------------------------------------------------------------------------|
 | `verify`             | boolean          | unset   | Can enforce verification (`true`) per deployment. It cannot disable verification when global `enabled: true` is set. |
-| `public_keys`        | array of strings | inherit | Replaces global `public_keys` when set and non-empty.                                                   |
-| `keyless_identities` | array of objects | inherit | Replaces global `keyless_identities` when set and non-empty.                                            |
-| `ignore_tlog`        | boolean          | inherit | When `true`, skip Rekor transparency log verification. Overrides the global `ignore_tlog` setting when set. |
+| `public_keys`        | array of strings | inherit | Replaces global `public_keys` when set and non-empty.                                                                |
+| `keyless_identities` | array of objects | inherit | Replaces global `keyless_identities` when set and non-empty.                                                         |
+| `ignore_tlog`        | boolean          | inherit | When `true`, skip Rekor transparency log verification. Overrides the global `ignore_tlog` setting when set.          |
 
 !!!note "Behavior"
 


### PR DESCRIPTION
Add an IgnoreTlog field to OciTrustPolicy and OciTrustPolicyOverride to allow skipping Rekor transparency log verification. This enables signature verification in air-gapped, private, or Rekor-independent environments while maintaining full signature verification with public keys.

- Transparency log verification remains enabled by default
- Can be disabled globally or per-deployment via override
- Supports both public key and keyless (OIDC) verification modes
- Fully compatible with Cosign's IgnoreTlog CheckOpts field

Fixes the missing feature equivalent to Cosign's --insecure-ignore-tlog option for environments where signatures are intentionally not uploaded to Rekor.