### PR TITLE
fix(api): ensure missing API key gets rejected

### DIFF
--- a/internal/restapi/api.go
+++ b/internal/restapi/api.go
@@ -15,7 +15,7 @@ var (
 // ValidateApiKey checks if the provided API key matches the one in the request header.
 func ValidateApiKey(r *http.Request, apiKey string) bool {
 	if apiKey == "" {
-		return true
+		return false
 	}
 
 	return r.Header.Get(KeyHeader) == apiKey

--- a/internal/restapi/api_test.go
+++ b/internal/restapi/api_test.go
@@ -24,7 +24,7 @@ func TestValidateApiKey(t *testing.T) {
 		{"Valid API Key", appConfig.ApiSecret, appConfig.ApiSecret, true},
 		{"Invalid API Key", appConfig.ApiSecret, "invalid_key", false},
 		{"Missing API Key", appConfig.ApiSecret, "", false},
-		{"Unset API Key", "", "", true}, // If no API key is set in config, all requests should pass
+		{"Unset API Key", "", "", false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This  PR updates the API key validation logic to ensure that requests are only authorized when an API key is explicitly set and provided. Previously, if the API key was unset, all requests would pass validation; now, requests without a configured API key will be rejected.