### PR TITLE
fix(deploy): prevent scheduled job services from running during deployment

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -426,13 +426,22 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 	if len(startServices) > 0 {
 		setDeploymentPhase(setPhase, "starting services")
 
+		// Docker Compose's Start ignores StartOptions.Services and starts every
+		// service in the passed project (including containers in the "created" or
+		// "exited" state). Scheduled job services must not run at deploy time, so
+		// narrow the project to non-job services before starting.
+		startProject, err := projectForStart(project, jobServices)
+		if err != nil {
+			return err
+		}
+
 		startOpts := api.StartOptions{
-			Project:  project,
+			Project:  startProject,
 			Wait:     false,
 			Services: startServices,
 		}
 
-		err = service.Start(ctx, project.Name, startOpts)
+		err = service.Start(ctx, startProject.Name, startOpts)
 		if err != nil {
 			if !errors.Is(err, ErrNoContainerToStart) {
 				return err
@@ -1557,6 +1566,43 @@ func getNonJobServices(startServices []string, jobServices set.Set[string]) set.
 	}
 
 	return nonJobServices
+}
+
+// projectForStart returns a copy of the project containing only the services
+// that should be started at deploy time, i.e. all services except scheduled job
+// services. Docker Compose's Start starts every service present in the project
+// (ignoring StartOptions.Services), so job services must be removed from the
+// project to keep them from running on deployment.
+func projectForStart(project *types.Project, jobServices set.Set[string]) (*types.Project, error) {
+	nonJobServiceNames := make([]string, 0, len(project.Services))
+
+	for serviceName, svc := range project.Services {
+		if jobServices.Contains(serviceName) || (svc.Name != "" && jobServices.Contains(svc.Name)) {
+			continue
+		}
+
+		nonJobServiceNames = append(nonJobServiceNames, serviceName)
+	}
+
+	// WithSelectedServices treats an empty selection as "all services", which
+	// would re-include job services. Return an explicit empty-service project
+	// instead so nothing is started.
+	if len(nonJobServiceNames) == 0 {
+		emptyProject := *project
+		emptyProject.Services = types.Services{}
+
+		return &emptyProject, nil
+	}
+
+	// IgnoreDependencies keeps the selection to exactly the non-job services and
+	// strips any depends_on edges pointing at excluded (job) services, so a job
+	// service is never pulled back in as a dependency.
+	startProject, err := project.WithSelectedServices(nonJobServiceNames, types.IgnoreDependencies)
+	if err != nil {
+		return nil, fmt.Errorf("failed to select services to start: %w", err)
+	}
+
+	return startProject, nil
 }
 
 type serviceStartStatus struct {

--- a/internal/docker/compose_start_services_test.go
+++ b/internal/docker/compose_start_services_test.go
@@ -161,6 +161,132 @@ func TestGetJobServices(t *testing.T) {
 	}
 }
 
+func TestProjectForStart_ExcludesJobServices(t *testing.T) {
+	t.Parallel()
+
+	project := &types.Project{
+		Name: "stack",
+		Services: types.Services{
+			"api": {
+				Name: "api",
+			},
+			"init": {
+				Name: "init",
+			},
+			"web": {
+				Name: "web",
+				DependsOn: types.DependsOnConfig{
+					"init": {Condition: "service_completed_successfully"},
+				},
+			},
+			"job": {
+				Name: "job",
+				Labels: map[string]string{
+					docoCDJobLabelNames.JobEnabled:  "true",
+					docoCDJobLabelNames.JobSchedule: "*/5 * * * *",
+				},
+			},
+		},
+	}
+
+	jobServices, err := getJobServices(project)
+	if err != nil {
+		t.Fatalf("getJobServices() failed: %v", err)
+	}
+
+	startProject, err := projectForStart(project, jobServices)
+	if err != nil {
+		t.Fatalf("projectForStart() failed: %v", err)
+	}
+
+	if _, ok := startProject.Services["job"]; ok {
+		t.Fatalf("scheduled job service must be excluded from the start project")
+	}
+
+	for _, name := range []string{"api", "init", "web"} {
+		if _, ok := startProject.Services[name]; !ok {
+			t.Fatalf("expected non-job service %q to be retained in the start project", name)
+		}
+	}
+
+	// The original project must be left untouched.
+	if _, ok := project.Services["job"]; !ok {
+		t.Fatalf("original project must not be mutated")
+	}
+}
+
+func TestProjectForStart_DependencyOnJobServiceStripped(t *testing.T) {
+	t.Parallel()
+
+	project := &types.Project{
+		Name: "stack",
+		Services: types.Services{
+			"api": {
+				Name: "api",
+				DependsOn: types.DependsOnConfig{
+					"job": {Condition: "service_started"},
+				},
+			},
+			"job": {
+				Name: "job",
+				Labels: map[string]string{
+					docoCDJobLabelNames.JobEnabled:  "true",
+					docoCDJobLabelNames.JobSchedule: "*/5 * * * *",
+				},
+			},
+		},
+	}
+
+	jobServices, err := getJobServices(project)
+	if err != nil {
+		t.Fatalf("getJobServices() failed: %v", err)
+	}
+
+	startProject, err := projectForStart(project, jobServices)
+	if err != nil {
+		t.Fatalf("projectForStart() failed: %v", err)
+	}
+
+	if _, ok := startProject.Services["job"]; ok {
+		t.Fatalf("job service must not be pulled in as a dependency")
+	}
+
+	if _, ok := startProject.Services["api"].DependsOn["job"]; ok {
+		t.Fatalf("depends_on edge to job service must be stripped")
+	}
+}
+
+func TestProjectForStart_OnlyJobServices(t *testing.T) {
+	t.Parallel()
+
+	project := &types.Project{
+		Name: "stack",
+		Services: types.Services{
+			"job": {
+				Name: "job",
+				Labels: map[string]string{
+					docoCDJobLabelNames.JobEnabled:  "true",
+					docoCDJobLabelNames.JobSchedule: "*/5 * * * *",
+				},
+			},
+		},
+	}
+
+	jobServices, err := getJobServices(project)
+	if err != nil {
+		t.Fatalf("getJobServices() failed: %v", err)
+	}
+
+	startProject, err := projectForStart(project, jobServices)
+	if err != nil {
+		t.Fatalf("projectForStart() failed: %v", err)
+	}
+
+	if len(startProject.Services) != 0 {
+		t.Fatalf("expected no services to start when only job services exist, got: %v", startProject.ServiceNames())
+	}
+}
+
 func TestAssessStartedServiceStates_IgnoresExitedJobContainer(t *testing.T) {
 	t.Parallel()
 

--- a/internal/docker/container_run.go
+++ b/internal/docker/container_run.go
@@ -18,6 +18,17 @@ const (
 	containerRunActionRestart containerRunAction = "restart"
 )
 
+// ContainerExitError reports that a container finished with a non-zero exit code.
+// Callers can use errors.As to recover the exit code without parsing error strings.
+type ContainerExitError struct {
+	ContainerID string
+	ExitCode    int
+}
+
+func (e *ContainerExitError) Error() string {
+	return fmt.Sprintf("one-off container %s exited with status %d", e.ContainerID, e.ExitCode)
+}
+
 func RestartContainer(ctx context.Context, apiClient client.APIClient, containerID string) error {
 	inspectResult, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
 	if err != nil {
@@ -113,7 +124,7 @@ func RunContainerOneOffFromExisting(ctx context.Context, apiClient client.APICli
 		}
 
 		if waitStatus.StatusCode != 0 {
-			return fmt.Errorf("one-off container %s exited with status %d", createResult.ID, waitStatus.StatusCode)
+			return &ContainerExitError{ContainerID: createResult.ID, ExitCode: int(waitStatus.StatusCode)}
 		}
 	}
 

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -83,27 +83,29 @@ const (
 )
 
 var docoCDJobLabelNames = struct {
-	JobEnabled       string // Enable scheduling for a service/container
-	JobSchedule      string // Schedule of the job in 5-field cron format or @every duration
-	JobWaitRunning   string // Override if deployment waits for this running job based on wait_running_jobs
-	JobSkipRunning   string // Skip a schedule trigger when a previous run is still in progress
-	JobExecutionMode string // Defines if a run restarts/reruns the job or starts an ephemeral one-off execution
-	JobEphemeral     string // Marks a runtime-created scheduler one-off target that should be ignored as drift
-	JobNotifyOn      string // Controls notification behavior: none, success, failure, all
-	JobSwarmReplicas string // Number of replicas for one-off replicated-job runs in swarm mode
-	JobLastRun       string // Timestamp of the last run in RFC3339 format
-	JobNextRun       string // Timestamp of the next scheduled run in RFC3339 format
+	JobEnabled         string // Enable scheduling for a service/container
+	JobSchedule        string // Schedule of the job in 5-field cron format or @every duration
+	JobWaitRunning     string // Override if deployment waits for this running job based on wait_running_jobs
+	JobSkipRunning     string // Skip a schedule trigger when a previous run is still in progress
+	JobExecutionMode   string // Defines if a run restarts/reruns the job or starts an ephemeral one-off execution
+	JobEphemeral       string // Marks a runtime-created scheduler one-off target that should be ignored as drift
+	JobNotifyOn        string // Controls notification behavior: none, success, failure, all
+	JobSwarmReplicas   string // Number of replicas for one-off replicated-job runs in swarm mode
+	JobRestartReplicas string // Intended replica count for swarm restart-mode jobs deployed at 0 replicas
+	JobLastRun         string // Timestamp of the last run in RFC3339 format
+	JobNextRun         string // Timestamp of the next scheduled run in RFC3339 format
 }{
-	JobEnabled:       "cd.doco.job.enabled",
-	JobSchedule:      "cd.doco.job.schedule",
-	JobWaitRunning:   "cd.doco.job.wait_running_jobs",
-	JobSkipRunning:   "cd.doco.job.skip_running",
-	JobExecutionMode: "cd.doco.job.execution_mode",
-	JobEphemeral:     "cd.doco.job.ephemeral",
-	JobNotifyOn:      "cd.doco.job.notify_on",
-	JobSwarmReplicas: "cd.doco.job.swarm.replicas",
-	JobLastRun:       "cd.doco.job.last_run",
-	JobNextRun:       "cd.doco.job.next_run",
+	JobEnabled:         "cd.doco.job.enabled",
+	JobSchedule:        "cd.doco.job.schedule",
+	JobWaitRunning:     "cd.doco.job.wait_running_jobs",
+	JobSkipRunning:     "cd.doco.job.skip_running",
+	JobExecutionMode:   "cd.doco.job.execution_mode",
+	JobEphemeral:       "cd.doco.job.ephemeral",
+	JobNotifyOn:        "cd.doco.job.notify_on",
+	JobSwarmReplicas:   "cd.doco.job.swarm.replicas",
+	JobRestartReplicas: "cd.doco.job.swarm.restart_replicas",
+	JobLastRun:         "cd.doco.job.last_run",
+	JobNextRun:         "cd.doco.job.next_run",
 }
 
 // DocoCDJobLabels exposes the scheduler/job labels for consumers outside this package.

--- a/internal/docker/swarm.go
+++ b/internal/docker/swarm.go
@@ -441,6 +441,53 @@ func RestartService(ctx context.Context, cli dockerClient.APIClient, serviceName
 	return nil
 }
 
+// scheduledRestartReplicas returns the intended replica count for a restart-mode
+// scheduled Swarm service, read from the JobRestartReplicas label that is set at
+// deploy time when the service is pinned to 0 replicas. Defaults to 1.
+func scheduledRestartReplicas(spec swarmTypes.ServiceSpec) uint64 {
+	replicas := uint64(1)
+
+	if spec.TaskTemplate.ContainerSpec == nil || spec.TaskTemplate.ContainerSpec.Labels == nil {
+		return replicas
+	}
+
+	raw, ok := spec.TaskTemplate.ContainerSpec.Labels[docoCDJobLabelNames.JobRestartReplicas]
+	if !ok {
+		return replicas
+	}
+
+	if v, err := strconv.ParseUint(strings.TrimSpace(raw), 10, 64); err == nil && v > 0 {
+		replicas = v
+	}
+
+	return replicas
+}
+
+// RestartScheduledSwarmService runs a restart-mode scheduled Swarm service on its
+// schedule. Classic replicated scheduled services are deployed at 0 replicas so
+// they do not run on deployment; this scales them up to their intended replica
+// count (forcing a task re-run) when the schedule fires. Services that cannot be
+// scaled to 0 (e.g. global) fall back to a ForceUpdate bump.
+func RestartScheduledSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName string) error {
+	apiClient := dockerCLI.Client()
+
+	result, err := apiClient.ServiceInspect(ctx, serviceName, dockerClient.ServiceInspectOptions{
+		InsertDefaults: true,
+	})
+	if err != nil {
+		return fmt.Errorf("inspect service %s: %w", serviceName, err)
+	}
+
+	svc := result.Service
+
+	if svc.Spec.Mode.Replicated != nil {
+		replicas := scheduledRestartReplicas(svc.Spec)
+		return swarmInternal.ScaleService(ctx, dockerCLI, serviceName, replicas, false, true)
+	}
+
+	return RestartService(ctx, apiClient, serviceName)
+}
+
 // RerunJobService attempts to retrigger a Swarm job service (`replicated-job` or `global-job`)
 // by updating the service spec (bumping a dummy label), causing Swarm to create new job tasks.
 //

--- a/internal/docker/swarm/deploy_composefile.go
+++ b/internal/docker/swarm/deploy_composefile.go
@@ -248,6 +248,10 @@ const scheduledJobEnabledLabel = "cd.doco.job.enabled"
 // restart-mode scheduled job. The service is deployed at 0 replicas so it does
 // not run on deployment; the scheduler scales it up to this count when the job
 // runs on its schedule.
+//
+// This must stay in sync with docker.DocoCDJobLabels.JobRestartReplicas. It is
+// duplicated here because the docker package imports this package, so the label
+// definitions cannot be imported from there without creating an import cycle.
 const scheduledJobRestartReplicasLabel = "cd.doco.job.swarm.restart_replicas"
 
 // applyScheduledJobDeployReplicas ensures scheduled job services do not run as a

--- a/internal/docker/swarm/deploy_composefile.go
+++ b/internal/docker/swarm/deploy_composefile.go
@@ -82,6 +82,11 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, opts *options.Dep
 		return err
 	}
 
+	// Scheduled job services must not run as a side effect of the deployment.
+	// Pin replicated scheduled services to 0 replicas (recording the intended
+	// count) so only the scheduler runs them on their schedule.
+	applyScheduledJobDeployReplicas(services)
+
 	serviceIDs, err := deployServices(ctx, dockerCli, services, namespace, opts.SendRegistryAuth, opts.ResolveImage)
 	if err != nil {
 		return err
@@ -238,6 +243,47 @@ type deployedService struct {
 }
 
 const scheduledJobEnabledLabel = "cd.doco.job.enabled"
+
+// scheduledJobRestartReplicasLabel stores the intended replica count for a
+// restart-mode scheduled job. The service is deployed at 0 replicas so it does
+// not run on deployment; the scheduler scales it up to this count when the job
+// runs on its schedule.
+const scheduledJobRestartReplicasLabel = "cd.doco.job.swarm.restart_replicas"
+
+// applyScheduledJobDeployReplicas ensures scheduled job services do not run as a
+// side effect of a deployment. Classic replicated scheduled services are pinned
+// to 0 replicas and their intended replica count is recorded in a label so the
+// scheduler can scale them up when the job runs on its schedule.
+//
+// Global-mode scheduled services cannot be scaled to 0 (a global service always
+// runs one task per node) and are left unchanged.
+func applyScheduledJobDeployReplicas(services map[string]swarmTypes.ServiceSpec) {
+	for name, spec := range services {
+		if !isScheduledServiceSpec(spec) {
+			continue
+		}
+
+		if spec.Mode.Replicated == nil || spec.TaskTemplate.ContainerSpec == nil {
+			continue
+		}
+
+		replicas := uint64(1)
+		if spec.Mode.Replicated.Replicas != nil {
+			replicas = *spec.Mode.Replicated.Replicas
+		}
+
+		if spec.TaskTemplate.ContainerSpec.Labels == nil {
+			spec.TaskTemplate.ContainerSpec.Labels = map[string]string{}
+		}
+
+		spec.TaskTemplate.ContainerSpec.Labels[scheduledJobRestartReplicasLabel] = strconv.FormatUint(replicas, 10)
+
+		zero := uint64(0)
+		spec.Mode.Replicated.Replicas = &zero
+
+		services[name] = spec
+	}
+}
 
 func deployServices(ctx context.Context, dockerCLI command.Cli, services map[string]swarmTypes.ServiceSpec, namespace convert.Namespace, sendAuth bool, resolveImage string) ([]deployedService, error) {
 	apiClient := dockerCLI.Client()

--- a/internal/docker/swarm/deploy_replicas_test.go
+++ b/internal/docker/swarm/deploy_replicas_test.go
@@ -1,0 +1,114 @@
+package swarm
+
+import (
+	"testing"
+
+	swarmTypes "github.com/moby/moby/api/types/swarm"
+)
+
+func replicatedScheduledSpec(replicas *uint64) swarmTypes.ServiceSpec {
+	return swarmTypes.ServiceSpec{
+		Mode: swarmTypes.ServiceMode{
+			Replicated: &swarmTypes.ReplicatedService{Replicas: replicas},
+		},
+		TaskTemplate: swarmTypes.TaskSpec{
+			ContainerSpec: &swarmTypes.ContainerSpec{
+				Labels: map[string]string{scheduledJobEnabledLabel: "true"},
+			},
+		},
+	}
+}
+
+func TestApplyScheduledJobDeployReplicas_ReplicatedScheduled(t *testing.T) {
+	t.Parallel()
+
+	three := uint64(3)
+	services := map[string]swarmTypes.ServiceSpec{
+		"job": replicatedScheduledSpec(&three),
+	}
+
+	applyScheduledJobDeployReplicas(services)
+
+	spec := services["job"]
+	if spec.Mode.Replicated.Replicas == nil || *spec.Mode.Replicated.Replicas != 0 {
+		t.Fatalf("expected scheduled service to be pinned to 0 replicas, got %v", spec.Mode.Replicated.Replicas)
+	}
+
+	if got := spec.TaskTemplate.ContainerSpec.Labels[scheduledJobRestartReplicasLabel]; got != "3" {
+		t.Fatalf("expected intended replica count 3 to be recorded, got %q", got)
+	}
+}
+
+func TestApplyScheduledJobDeployReplicas_DefaultsToOne(t *testing.T) {
+	t.Parallel()
+
+	services := map[string]swarmTypes.ServiceSpec{
+		"job": replicatedScheduledSpec(nil),
+	}
+
+	applyScheduledJobDeployReplicas(services)
+
+	spec := services["job"]
+	if spec.Mode.Replicated.Replicas == nil || *spec.Mode.Replicated.Replicas != 0 {
+		t.Fatalf("expected scheduled service to be pinned to 0 replicas")
+	}
+
+	if got := spec.TaskTemplate.ContainerSpec.Labels[scheduledJobRestartReplicasLabel]; got != "1" {
+		t.Fatalf("expected default intended replica count 1, got %q", got)
+	}
+}
+
+func TestApplyScheduledJobDeployReplicas_IgnoresNonScheduled(t *testing.T) {
+	t.Parallel()
+
+	two := uint64(2)
+	services := map[string]swarmTypes.ServiceSpec{
+		"api": {
+			Mode: swarmTypes.ServiceMode{
+				Replicated: &swarmTypes.ReplicatedService{Replicas: &two},
+			},
+			TaskTemplate: swarmTypes.TaskSpec{
+				ContainerSpec: &swarmTypes.ContainerSpec{Labels: map[string]string{}},
+			},
+		},
+	}
+
+	applyScheduledJobDeployReplicas(services)
+
+	spec := services["api"]
+	if spec.Mode.Replicated.Replicas == nil || *spec.Mode.Replicated.Replicas != 2 {
+		t.Fatalf("non-scheduled service replicas must not change, got %v", spec.Mode.Replicated.Replicas)
+	}
+
+	if _, ok := spec.TaskTemplate.ContainerSpec.Labels[scheduledJobRestartReplicasLabel]; ok {
+		t.Fatalf("non-scheduled service must not receive the restart replicas label")
+	}
+}
+
+func TestApplyScheduledJobDeployReplicas_IgnoresGlobalScheduled(t *testing.T) {
+	t.Parallel()
+
+	services := map[string]swarmTypes.ServiceSpec{
+		"job": {
+			Mode: swarmTypes.ServiceMode{
+				Global: &swarmTypes.GlobalService{},
+			},
+			TaskTemplate: swarmTypes.TaskSpec{
+				ContainerSpec: &swarmTypes.ContainerSpec{
+					Labels: map[string]string{scheduledJobEnabledLabel: "true"},
+				},
+			},
+		},
+	}
+
+	applyScheduledJobDeployReplicas(services)
+
+	spec := services["job"]
+	if spec.Mode.Global == nil {
+		t.Fatalf("global scheduled service mode must be preserved")
+	}
+
+	if _, ok := spec.TaskTemplate.ContainerSpec.Labels[scheduledJobRestartReplicasLabel]; ok {
+		t.Fatalf("global scheduled service cannot be scaled to 0 and must not be labeled")
+	}
+}

--- a/internal/docker/swarm_restart_test.go
+++ b/internal/docker/swarm_restart_test.go
@@ -1,0 +1,75 @@
+package docker
+
+import (
+	"testing"
+
+	swarmTypes "github.com/moby/moby/api/types/swarm"
+)
+
+func TestScheduledRestartReplicas(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		spec swarmTypes.ServiceSpec
+		want uint64
+	}{
+		{
+			name: "no container spec defaults to one",
+			spec: swarmTypes.ServiceSpec{},
+			want: 1,
+		},
+		{
+			name: "missing label defaults to one",
+			spec: swarmTypes.ServiceSpec{
+				TaskTemplate: swarmTypes.TaskSpec{
+					ContainerSpec: &swarmTypes.ContainerSpec{Labels: map[string]string{}},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "reads stored replica count",
+			spec: swarmTypes.ServiceSpec{
+				TaskTemplate: swarmTypes.TaskSpec{
+					ContainerSpec: &swarmTypes.ContainerSpec{
+						Labels: map[string]string{docoCDJobLabelNames.JobRestartReplicas: "4"},
+					},
+				},
+			},
+			want: 4,
+		},
+		{
+			name: "invalid value defaults to one",
+			spec: swarmTypes.ServiceSpec{
+				TaskTemplate: swarmTypes.TaskSpec{
+					ContainerSpec: &swarmTypes.ContainerSpec{
+						Labels: map[string]string{docoCDJobLabelNames.JobRestartReplicas: "not-a-number"},
+					},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "zero value defaults to one",
+			spec: swarmTypes.ServiceSpec{
+				TaskTemplate: swarmTypes.TaskSpec{
+					ContainerSpec: &swarmTypes.ContainerSpec{
+						Labels: map[string]string{docoCDJobLabelNames.JobRestartReplicas: "0"},
+					},
+				},
+			},
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := scheduledRestartReplicas(tt.spec); got != tt.want {
+				t.Fatalf("scheduledRestartReplicas() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -58,6 +58,7 @@ type scheduledJob struct {
 	labels          map[string]string
 	containerState  string // Docker container state (container mode only), e.g. "running", "exited"
 	containerStatus string // Docker container status string (container mode only), e.g. "Exited (0) 2 hours ago"
+	running         bool   // An execution is currently active (e.g. a running one_off ephemeral container)
 }
 
 type scheduledJobState struct {
@@ -155,6 +156,11 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		info.LastRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobLastRun])
 		info.LabelNextRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobNextRun])
 
+		// A run is active if either an execution is currently observed (e.g. a
+		// running one_off ephemeral container) or the in-process scheduler is
+		// mid-run for this job.
+		running := job.running || runningStates[job.key]
+
 		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels, s.log)
 		if parseErr != nil {
 			info.Valid = false
@@ -167,7 +173,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 
 		info.Enabled = enabled
 		if !enabled {
-			info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], runningStates[job.key])
+			info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], running)
 			result = append(result, info)
 
 			continue
@@ -183,7 +189,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		if scheduleErr != nil {
 			info.Valid = false
 			info.ScheduleError = scheduleErr.Error()
-			info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], runningStates[job.key])
+			info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], running)
 			result = append(result, info)
 
 			continue
@@ -202,7 +208,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		}
 
 		info.NextRunAt = &nextRun
-		info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], runningStates[job.key])
+		info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], running)
 
 		result = append(result, info)
 	}
@@ -595,23 +601,26 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 	}
 
 	jobByKey := make(map[string]scheduledJob)
+	runningEphemeralByKey := make(map[string]bool)
 
 	for _, c := range containers.Items {
+		key := containerJobKey(c.ID, c.Labels)
+
+		// One_off runs execute in an ephemeral clone of the source container that
+		// carries the same compose project/service labels. It must not be treated
+		// as the job itself, but while it is running it signals that the job is
+		// currently executing.
 		if isEphemeralScheduledContainer(c.Labels) {
+			if c.State == container.StateRunning {
+				runningEphemeralByKey[key] = true
+			}
+
 			continue
 		}
 
 		name := strings.TrimPrefix(firstContainerName(c.Names), "/")
 		if name == "" {
 			name = c.ID[:12]
-		}
-
-		service := c.Labels[api.ServiceLabel]
-		project := c.Labels[api.ProjectLabel]
-
-		key := "container:" + c.ID
-		if project != "" && service != "" {
-			key = "container:" + project + "/" + service
 		}
 
 		existing, exists := jobByKey[key]
@@ -631,7 +640,8 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 	}
 
 	result := make([]scheduledJob, 0, len(jobByKey))
-	for _, job := range jobByKey {
+	for key, job := range jobByKey {
+		job.running = runningEphemeralByKey[key]
 		result = append(result, job)
 	}
 
@@ -931,6 +941,21 @@ func isEphemeralScheduledContainer(labels map[string]string) bool {
 	}
 
 	return isEphemeral
+}
+
+// containerJobKey derives the stable scheduler key for a container from its
+// compose project/service labels, falling back to the container ID. An ephemeral
+// one_off clone shares the source's project/service labels, so it resolves to the
+// same key as its source job.
+func containerJobKey(containerID string, labels map[string]string) string {
+	service := labels[api.ServiceLabel]
+	project := labels[api.ProjectLabel]
+
+	if project != "" && service != "" {
+		return "container:" + project + "/" + service
+	}
+
+	return "container:" + containerID
 }
 
 func formatRunStatus(state, status string) string {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -713,7 +713,7 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 			}
 
 			if errors.Is(err, docker.ErrNotAJobService) {
-				return docker.RestartService(ctx, s.dockerCli.Client(), job.id)
+				return docker.RestartScheduledSwarmService(ctx, s.dockerCli, job.id)
 			}
 
 			return err

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -42,7 +41,6 @@ var (
 	runtimeStates        = map[string]scheduledJobState{}
 	runtimeRunStatuses   = map[string]string{}
 	runtimeRunningStates = map[string]bool{}
-	exitCodeMatcher      = regexp.MustCompile(`exited with status (\d+)`)
 )
 
 type scheduledJobMode string
@@ -961,6 +959,12 @@ func formatRunStatus(state, status string) string {
 	return state + " (" + code + ")"
 }
 
+// formatExitStatus renders an exited container status with its exit code,
+// matching the format produced by formatRunStatus (e.g. "exited (0)").
+func formatExitStatus(code int) string {
+	return fmt.Sprintf("%s (%d)", container.StateExited, code)
+}
+
 func statusForScheduledJob(job scheduledJob, cfg docker.JobScheduleConfig, runtimeStatus string, running bool) string {
 	if running {
 		return string(container.StateRunning)
@@ -1007,20 +1011,14 @@ func setRuntimeStatesSnapshot(states map[string]scheduledJobState) {
 	runtimeStatesMu.Lock()
 	defer runtimeStatesMu.Unlock()
 
-	next := make(map[string]scheduledJobState, len(states))
-	maps.Copy(next, states)
-
-	runtimeStates = next
+	runtimeStates = copyMapLocked(states)
 }
 
 func getRuntimeStatesSnapshot() map[string]scheduledJobState {
 	runtimeStatesMu.RLock()
 	defer runtimeStatesMu.RUnlock()
 
-	ret := make(map[string]scheduledJobState, len(runtimeStates))
-	maps.Copy(ret, runtimeStates)
-
-	return ret
+	return copyMapLocked(runtimeStates)
 }
 
 func setRuntimeLastRun(key string, lastRun time.Time) {
@@ -1040,10 +1038,7 @@ func getRuntimeRunStatusesSnapshot() map[string]string {
 	runtimeStatesMu.RLock()
 	defer runtimeStatesMu.RUnlock()
 
-	ret := make(map[string]string, len(runtimeRunStatuses))
-	maps.Copy(ret, runtimeRunStatuses)
-
-	return ret
+	return copyMapLocked(runtimeRunStatuses)
 }
 
 func setRuntimeRunStatus(key, status string) {
@@ -1062,10 +1057,7 @@ func getRuntimeRunningStatesSnapshot() map[string]bool {
 	runtimeStatesMu.RLock()
 	defer runtimeStatesMu.RUnlock()
 
-	ret := make(map[string]bool, len(runtimeRunningStates))
-	maps.Copy(ret, runtimeRunningStates)
-
-	return ret
+	return copyMapLocked(runtimeRunningStates)
 }
 
 func setRuntimeRunInProgress(key string, inProgress bool) {
@@ -1091,19 +1083,20 @@ func updateRuntimeRunStatus(job scheduledJob, cfg docker.JobScheduleConfig, runE
 	}
 
 	if runErr == nil {
-		setRuntimeRunStatus(job.key, "exited (0)")
+		setRuntimeRunStatus(job.key, formatExitStatus(0))
 		return
 	}
 
-	matches := exitCodeMatcher.FindStringSubmatch(runErr.Error())
-	if len(matches) != 2 {
-		return
+	var exitErr *docker.ContainerExitError
+	if errors.As(runErr, &exitErr) {
+		setRuntimeRunStatus(job.key, formatExitStatus(exitErr.ExitCode))
 	}
+}
 
-	code, err := strconv.Atoi(matches[1])
-	if err != nil {
-		return
-	}
+// copyMapLocked returns a shallow copy of m. Callers must hold runtimeStatesMu.
+func copyMapLocked[K comparable, V any](m map[K]V) map[K]V {
+	ret := make(map[K]V, len(m))
+	maps.Copy(ret, m)
 
-	setRuntimeRunStatus(job.key, fmt.Sprintf("exited (%d)", code))
+	return ret
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,8 +38,11 @@ var (
 	ErrScheduledJobDisabled  = errors.New("scheduled job is disabled")
 	ErrScheduledJobAmbiguous = errors.New("multiple scheduled jobs matched, narrow your selection")
 
-	runtimeStatesMu sync.RWMutex
-	runtimeStates   = map[string]scheduledJobState{}
+	runtimeStatesMu      sync.RWMutex
+	runtimeStates        = map[string]scheduledJobState{}
+	runtimeRunStatuses   = map[string]string{}
+	runtimeRunningStates = map[string]bool{}
+	exitCodeMatcher      = regexp.MustCompile(`exited with status (\d+)`)
 )
 
 type scheduledJobMode string
@@ -133,6 +137,8 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 	stackName = strings.TrimSpace(stackName)
 	result := make([]JobInfo, 0, len(jobs))
 	states := getRuntimeStatesSnapshot()
+	runStatuses := getRuntimeRunStatusesSnapshot()
+	runningStates := getRuntimeRunningStatesSnapshot()
 
 	for _, job := range jobs {
 		stack := getJobStackName(job)
@@ -148,8 +154,6 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 			Valid:      true,
 		}
 
-		info.Status = formatRunStatus(job.containerState, job.containerStatus)
-
 		info.LastRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobLastRun])
 		info.LabelNextRunAt = parseRFC3339Time(job.labels[docker.DocoCDJobLabels.JobNextRun])
 
@@ -157,6 +161,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		if parseErr != nil {
 			info.Valid = false
 			info.ScheduleError = parseErr.Error()
+			info.Status = formatRunStatus(job.containerState, job.containerStatus)
 			result = append(result, info)
 
 			continue
@@ -164,7 +169,9 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 
 		info.Enabled = enabled
 		if !enabled {
+			info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], runningStates[job.key])
 			result = append(result, info)
+
 			continue
 		}
 
@@ -178,21 +185,26 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		if scheduleErr != nil {
 			info.Valid = false
 			info.ScheduleError = scheduleErr.Error()
+			info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], runningStates[job.key])
 			result = append(result, info)
 
 			continue
 		}
 
 		nextRun := schedule.Next(now)
-		if state, ok := states[job.key]; ok && !state.nextRun.IsZero() {
+
+		if state, ok := states[job.key]; ok {
 			if !state.lastRun.IsZero() {
 				info.LastRunAt = new(state.lastRun)
 			}
 
-			nextRun = state.nextRun
+			if !state.nextRun.IsZero() {
+				nextRun = state.nextRun
+			}
 		}
 
 		info.NextRunAt = &nextRun
+		info.Status = statusForScheduledJob(job, cfg, runStatuses[job.key], runningStates[job.key])
 
 		result = append(result, info)
 	}
@@ -218,6 +230,7 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 	s := &scheduler{
 		dockerCli: dockerCli,
 		log:       log.With(slog.String("component", "scheduler")),
+		running:   map[string]bool{},
 	}
 
 	jobs, err := s.discoverJobs(ctx)
@@ -263,7 +276,11 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 
 	defer lock.UnlockStack(stack)
 
+	setRuntimeRunInProgress(job.key, true)
+	defer setRuntimeRunInProgress(job.key, false)
+
 	err = s.executeScheduledRun(ctx, job, cfg)
+	updateRuntimeRunStatus(job, cfg, err)
 	setRuntimeLastRun(job.key, schedulerNow())
 
 	if err != nil {
@@ -676,6 +693,8 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 		runLog.Debug("triggering scheduled run")
 
 		err := s.executeScheduledRun(ctx, job, cfg)
+		updateRuntimeRunStatus(job, cfg, err)
+
 		if err != nil {
 			runFailed = true
 
@@ -765,6 +784,8 @@ func (s *scheduler) isRunInProgress(key string) bool {
 func (s *scheduler) setRunInProgress(key string, inProgress bool) {
 	s.runningMu.Lock()
 	defer s.runningMu.Unlock()
+
+	setRuntimeRunInProgress(key, inProgress)
 
 	if inProgress {
 		s.running[key] = true
@@ -918,6 +939,29 @@ func formatRunStatus(state, status string) string {
 	return state + " (" + code + ")"
 }
 
+func statusForScheduledJob(job scheduledJob, cfg docker.JobScheduleConfig, runtimeStatus string, running bool) string {
+	if running {
+		return string(container.StateRunning)
+	}
+
+	status := formatRunStatus(job.containerState, job.containerStatus)
+
+	if job.mode != scheduledJobModeContainer || cfg.ExecutionMode != docker.JobExecutionModeOneOff {
+		return status
+	}
+
+	if strings.TrimSpace(job.containerState) != string(container.StateCreated) {
+		return status
+	}
+
+	runtimeStatus = strings.TrimSpace(runtimeStatus)
+	if runtimeStatus == "" {
+		return status
+	}
+
+	return runtimeStatus
+}
+
 func parseRFC3339Time(raw string) *time.Time {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -968,4 +1012,76 @@ func setRuntimeLastRun(key string, lastRun time.Time) {
 	state := runtimeStates[key]
 	state.lastRun = lastRun
 	runtimeStates[key] = state
+}
+
+func getRuntimeRunStatusesSnapshot() map[string]string {
+	runtimeStatesMu.RLock()
+	defer runtimeStatesMu.RUnlock()
+
+	ret := make(map[string]string, len(runtimeRunStatuses))
+	maps.Copy(ret, runtimeRunStatuses)
+
+	return ret
+}
+
+func setRuntimeRunStatus(key, status string) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+
+	runtimeStatesMu.Lock()
+	defer runtimeStatesMu.Unlock()
+
+	runtimeRunStatuses[key] = strings.TrimSpace(status)
+}
+
+func getRuntimeRunningStatesSnapshot() map[string]bool {
+	runtimeStatesMu.RLock()
+	defer runtimeStatesMu.RUnlock()
+
+	ret := make(map[string]bool, len(runtimeRunningStates))
+	maps.Copy(ret, runtimeRunningStates)
+
+	return ret
+}
+
+func setRuntimeRunInProgress(key string, inProgress bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return
+	}
+
+	runtimeStatesMu.Lock()
+	defer runtimeStatesMu.Unlock()
+
+	if inProgress {
+		runtimeRunningStates[key] = true
+		return
+	}
+
+	delete(runtimeRunningStates, key)
+}
+
+func updateRuntimeRunStatus(job scheduledJob, cfg docker.JobScheduleConfig, runErr error) {
+	if job.mode != scheduledJobModeContainer || cfg.ExecutionMode != docker.JobExecutionModeOneOff {
+		return
+	}
+
+	if runErr == nil {
+		setRuntimeRunStatus(job.key, "exited (0)")
+		return
+	}
+
+	matches := exitCodeMatcher.FindStringSubmatch(runErr.Error())
+	if len(matches) != 2 {
+		return
+	}
+
+	code, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return
+	}
+
+	setRuntimeRunStatus(job.key, fmt.Sprintf("exited (%d)", code))
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -599,6 +599,10 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 	jobByKey := make(map[string]scheduledJob)
 
 	for _, c := range containers.Items {
+		if isEphemeralScheduledContainer(c.Labels) {
+			continue
+		}
+
 		name := strings.TrimPrefix(firstContainerName(c.Names), "/")
 		if name == "" {
 			name = c.ID[:12]
@@ -911,6 +915,24 @@ func firstContainerName(names []string) string {
 	}
 
 	return names[0]
+}
+
+func isEphemeralScheduledContainer(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+
+	raw, ok := labels[docker.DocoCDJobLabels.JobEphemeral]
+	if !ok {
+		return false
+	}
+
+	isEphemeral, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+
+	return isEphemeral
 }
 
 func formatRunStatus(state, status string) string {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -435,3 +435,40 @@ func TestIsEphemeralScheduledContainer(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerJobKey_EphemeralMatchesSource(t *testing.T) {
+	t.Parallel()
+
+	sourceLabels := map[string]string{
+		api.ProjectLabel: "my-stack",
+		api.ServiceLabel: "nas-backup",
+	}
+
+	// The ephemeral one_off clone copies the source labels and adds the ephemeral
+	// marker, so it must resolve to the same key to be attributed to the source job.
+	ephemeralLabels := map[string]string{
+		api.ProjectLabel:                    "my-stack",
+		api.ServiceLabel:                    "nas-backup",
+		docker.DocoCDJobLabels.JobEphemeral: "true",
+	}
+
+	sourceKey := containerJobKey("source-id", sourceLabels)
+	ephemeralKey := containerJobKey("ephemeral-id", ephemeralLabels)
+
+	if sourceKey != ephemeralKey {
+		t.Fatalf("containerJobKey() ephemeral=%q source=%q, want equal", ephemeralKey, sourceKey)
+	}
+
+	if want := "container:my-stack/nas-backup"; sourceKey != want {
+		t.Fatalf("containerJobKey()=%q want=%q", sourceKey, want)
+	}
+}
+
+func TestContainerJobKey_FallsBackToContainerID(t *testing.T) {
+	t.Parallel()
+
+	got := containerJobKey("abc123", map[string]string{api.ProjectLabel: "only-project"})
+	if want := "container:abc123"; got != want {
+		t.Fatalf("containerJobKey()=%q want=%q", got, want)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -378,8 +378,57 @@ func TestUpdateRuntimeRunStatus(t *testing.T) {
 	}
 
 	updateRuntimeRunStatus(job, cfg, errors.New("one-off container abc exited with status 143"))
-
 	if got := getRuntimeRunStatusesSnapshot()[job.key]; got != "exited (143)" {
 		t.Fatalf("updateRuntimeRunStatus() error status=%q want=%q", got, "exited (143)")
+	}
+}
+
+func TestIsEphemeralScheduledContainer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   bool
+	}{
+		{
+			name: "missing label",
+			labels: map[string]string{
+				docker.DocoCDJobLabels.JobEnabled: "true",
+			},
+			want: false,
+		},
+		{
+			name: "ephemeral true",
+			labels: map[string]string{
+				docker.DocoCDJobLabels.JobEphemeral: "true",
+			},
+			want: true,
+		},
+		{
+			name: "ephemeral false",
+			labels: map[string]string{
+				docker.DocoCDJobLabels.JobEphemeral: "false",
+			},
+			want: false,
+		},
+		{
+			name: "invalid boolean",
+			labels: map[string]string{
+				docker.DocoCDJobLabels.JobEphemeral: "not-bool",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isEphemeralScheduledContainer(tt.labels)
+			if got != tt.want {
+				t.Fatalf("isEphemeralScheduledContainer()=%v want=%v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -377,7 +378,9 @@ func TestUpdateRuntimeRunStatus(t *testing.T) {
 		t.Fatalf("updateRuntimeRunStatus() success status=%q want=%q", got, "exited (0)")
 	}
 
-	updateRuntimeRunStatus(job, cfg, errors.New("one-off container abc exited with status 143"))
+	wrapped := fmt.Errorf("scheduled run: %w", &docker.ContainerExitError{ContainerID: "abc", ExitCode: 143})
+	updateRuntimeRunStatus(job, cfg, wrapped)
+
 	if got := getRuntimeRunStatusesSnapshot()[job.key]; got != "exited (143)" {
 		t.Fatalf("updateRuntimeRunStatus() error status=%q want=%q", got, "exited (143)")
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -283,3 +283,103 @@ func TestShouldStopContainerForOneOffDeployRun(t *testing.T) {
 		})
 	}
 }
+
+func TestStatusForScheduledJob(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		job           scheduledJob
+		cfg           docker.JobScheduleConfig
+		runtimeStatus string
+		running       bool
+		want          string
+	}{
+		{
+			name: "container one_off created without runtime status stays created",
+			job: scheduledJob{
+				mode:           scheduledJobModeContainer,
+				containerState: "created",
+			},
+			cfg:  docker.JobScheduleConfig{ExecutionMode: docker.JobExecutionModeOneOff},
+			want: "created",
+		},
+		{
+			name: "container one_off created with runtime status uses exit code",
+			job: scheduledJob{
+				mode:           scheduledJobModeContainer,
+				containerState: "created",
+			},
+			cfg:           docker.JobScheduleConfig{ExecutionMode: docker.JobExecutionModeOneOff},
+			runtimeStatus: "exited (143)",
+			want:          "exited (143)",
+		},
+		{
+			name: "container restart keeps docker state",
+			job: scheduledJob{
+				mode:            scheduledJobModeContainer,
+				containerState:  "exited",
+				containerStatus: "Exited (0) 2 seconds ago",
+			},
+			cfg:  docker.JobScheduleConfig{ExecutionMode: docker.JobExecutionModeRestart},
+			want: "exited (0)",
+		},
+		{
+			name: "swarm one_off not rewritten",
+			job: scheduledJob{
+				mode: scheduledJobModeSwarm,
+			},
+			cfg:           docker.JobScheduleConfig{ExecutionMode: docker.JobExecutionModeOneOff},
+			runtimeStatus: "exited (0)",
+			want:          "",
+		},
+		{
+			name: "running state has priority",
+			job: scheduledJob{
+				mode:           scheduledJobModeContainer,
+				containerState: "created",
+			},
+			cfg:           docker.JobScheduleConfig{ExecutionMode: docker.JobExecutionModeOneOff},
+			runtimeStatus: "exited (0)",
+			running:       true,
+			want:          "running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := statusForScheduledJob(tt.job, tt.cfg, tt.runtimeStatus, tt.running)
+			if got != tt.want {
+				t.Fatalf("statusForScheduledJob()=%q want=%q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateRuntimeRunStatus(t *testing.T) {
+	t.Parallel()
+
+	runtimeStatesMu.Lock()
+	runtimeRunStatuses = map[string]string{}
+	runtimeStatesMu.Unlock()
+
+	job := scheduledJob{
+		key:  "container:project/service",
+		mode: scheduledJobModeContainer,
+	}
+	cfg := docker.JobScheduleConfig{ExecutionMode: docker.JobExecutionModeOneOff}
+
+	updateRuntimeRunStatus(job, cfg, nil)
+
+	if got := getRuntimeRunStatusesSnapshot()[job.key]; got != "exited (0)" {
+		t.Fatalf("updateRuntimeRunStatus() success status=%q want=%q", got, "exited (0)")
+	}
+
+	updateRuntimeRunStatus(job, cfg, errors.New("one-off container abc exited with status 143"))
+
+	if got := getRuntimeRunStatusesSnapshot()[job.key]; got != "exited (143)" {
+		t.Fatalf("updateRuntimeRunStatus() error status=%q want=%q", got, "exited (143)")
+	}
+}

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -91,10 +91,22 @@ This is useful for running periodic tasks such as backups, maintenance scripts, 
 
 The execution mode determines how scheduled jobs are run and managed by doco-cd and can be configured using the `cd.doco.job.execution_mode` label on the service.
 
+!!! info "Scheduled jobs never run on deployment"
+    Scheduled jobs only run when their [schedule](#schedule-formats) fires, never as a side effect of a (re)deployment.
+    On deployment the job's service/container is prepared but left idle:
+
+    - Docker (Standalone): the container is created but not started.
+    - Docker Swarm: the service is deployed with `0` replicas (see the limitation for `global` restart-mode jobs below).
+
 ### `restart`
 
 By default, scheduled jobs will be executed in `restart` mode, which means the service will be created on deployment 
 and then re-/started at the scheduled time without being removed after completion.
+
+!!! warning "Docker Swarm `global` + `restart` limitation"
+    In Docker Swarm, restart-mode scheduled jobs are deployed with `0` replicas so they do not run on deployment.
+    `global` services cannot be scaled to `0` (a global service always runs one task per node), so a `global` service
+    combined with `restart` mode **will** run on deployment. Use [`one_off`](#one_off) mode for global scheduled jobs instead.
 
 ### `one_off`
 


### PR DESCRIPTION
This pull request introduces several improvements to the handling of scheduled job services in Docker Compose and Swarm deployments. The changes ensure that scheduled jobs do not run unintentionally during deployment, add robust tracking and reporting of job run status, and improve error handling and test coverage. The most important changes are summarized below.

**Scheduled job deployment and execution logic:**

* Scheduled job services are now excluded from being started during deployment by filtering them out of the project before invoking the start operation (`projectForStart` in `compose.go`). This prevents scheduled jobs from running outside their intended schedule. [[1]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dR429-R444) [[2]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dR1571-R1607)
* When deploying scheduled job services in Swarm, replicated jobs are pinned to 0 replicas and their intended replica count is recorded in a label. This ensures they only run when triggered by the scheduler, not as a side effect of deployment. [[1]](diffhunk://#diff-ef6bd05f916bb3a604db97a3fff5036cf4ea5f974d493cde1aa59a65df34f39aR85-R89) [[2]](diffhunk://#diff-ef6bd05f916bb3a604db97a3fff5036cf4ea5f974d493cde1aa59a65df34f39aR247-R291) [[3]](diffhunk://#diff-36889ffc0132096110fcf8672f861548d9bd3032939aa6f65f4bfcc90ea6fd55R94) [[4]](diffhunk://#diff-36889ffc0132096110fcf8672f861548d9bd3032939aa6f65f4bfcc90ea6fd55R106)

**Swarm scheduled job restart and scaling:**

* A new function, `RestartScheduledSwarmService`, is introduced to scale up scheduled replicated Swarm services to their intended replica count when their schedule fires, using the stored label. This ensures jobs run with the correct number of replicas.

**Error handling improvements:**

* Introduced a new `ContainerExitError` type to report non-zero exit codes from one-off containers, allowing callers to recover the exit code programmatically. [[1]](diffhunk://#diff-63c234b4c2bb915348fa4e1cbf6f61f28e10890201d54722432d33be8d2bc0efR21-R31) [[2]](diffhunk://#diff-63c234b4c2bb915348fa4e1cbf6f61f28e10890201d54722432d33be8d2bc0efL116-R127)

**Scheduler status tracking and reporting:**

* The scheduler now tracks and reports more granular runtime status for jobs, including whether a run is currently active, and provides improved status reporting in `ListJobs`. [[1]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0R42-R43) [[2]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0R61) [[3]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0R139-R140) [[4]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0L151-R178) [[5]](diffhunk://#diff-c3753ff27e79b7da6571efc4fffc45e729b031a39337eec9b22a04425bbd69f0R192-R211)

**Test coverage:**

* Added comprehensive tests for the new deployment logic, scheduled job replica management, and error handling to ensure correct behavior and prevent regressions. [[1]](diffhunk://#diff-f010d41a8a8c7396ca5e8bfe71465bff9f8a12ea5cb1a9e704ca72f874cd5adbR164-R289) [[2]](diffhunk://#diff-55c894d845f4c35bbff872795fe0435322dd9d1c1b336502ba767cd7ac698fd5R1-R114) [[3]](diffhunk://#diff-6cfc10337ca5a234951bae80d99c47da99f8215d2c8b73a71c3080a54d91ebd5R1-R75)

These changes significantly improve the safety, correctness, and observability of scheduled job handling in Compose and Swarm deployments.