### PR TITLE
feat(docker): add SSH transport support for Docker contexts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
         CGO_ENABLED=1 CC=musl-gcc go build -ldflags="-s -w -X github.com/kimdre/doco-cd/internal/config/app.Version=${APP_VERSION} ${BW_SDK_BUILD_FLAGS}" -o / ./...; \
     fi
 
+FROM debian:bookworm-slim AS ssh-client
+RUN apt-get update && apt-get install -y --no-install-recommends openssh-client && rm -rf /var/lib/apt/lists/*
+
 FROM gcr.io/distroless/base-debian13@sha256:f4a335ca209e1d2ee873102c17c389ad0142e3d5b21aee2817e9cc9c01d87d20 AS release
 
 WORKDIR /
@@ -70,6 +73,9 @@ COPY --from=docker/buildx-bin:0.35.0@sha256:917570d8d0ae91ae49251f84f848a6801eed
     /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 COPY --from=build /doco-cd /doco-cd
+
+# SSH client required for Docker contexts using the ssh:// transport
+COPY --from=ssh-client /usr/bin/ssh /usr/bin/ssh
 
 ENV TZ=UTC \
     HTTP_PORT=80 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,24 +61,30 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
         CGO_ENABLED=1 CC=musl-gcc go build -ldflags="-s -w -X github.com/kimdre/doco-cd/internal/config/app.Version=${APP_VERSION} ${BW_SDK_BUILD_FLAGS}" -o / ./...; \
     fi
 
+FROM gcr.io/distroless/base-debian13@sha256:f4a335ca209e1d2ee873102c17c389ad0142e3d5b21aee2817e9cc9c01d87d20 AS distroless-base
+
 FROM debian:trixie-slim AS ssh-client
+
+# Copy the distroless base filesystem so we can skip libraries already present there.
+COPY --from=distroless-base / /distroless-root/
 RUN apt-get update && \
     apt-get install -y --no-install-recommends openssh-client && \
     rm -rf /var/lib/apt/lists/* && \
-    # Collect the ssh binary and ALL its shared library dependencies into /ssh-root/, \
-    # preserving the real (resolved) directory structure for the release-stage COPY.
-    # realpath resolves /lib -> /usr/lib symlinks so libraries land under /usr/lib/
-    # in the distroless image (which uses the merged-usr layout: /lib -> usr/lib).
+    # Collect the ssh binary and only the shared library dependencies that are NOT
+    # already present in the distroless base image, to avoid duplicating layers.
+    # realpath on dirname resolves /lib -> /usr/lib so paths match distroless layout.
     mkdir -p /ssh-root/usr/bin && \
     cp /usr/bin/ssh /ssh-root/usr/bin/ssh && \
     ldd /usr/bin/ssh | awk '$3 ~ /^\// { print $3 }' | \
         while IFS= read -r lib; do \
           dir=$(realpath "$(dirname "$lib")"); \
+          name=$(basename "$lib"); \
+          [ -f "/distroless-root$dir/$name" ] && continue; \
           mkdir -p "/ssh-root$dir"; \
-          cp -L "$lib" "/ssh-root$dir/$(basename "$lib")"; \
+          cp -L "$lib" "/ssh-root$dir/$name"; \
         done
 
-FROM gcr.io/distroless/base-debian13@sha256:f4a335ca209e1d2ee873102c17c389ad0142e3d5b21aee2817e9cc9c01d87d20 AS release
+FROM distroless-base AS release
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,22 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
         CGO_ENABLED=1 CC=musl-gcc go build -ldflags="-s -w -X github.com/kimdre/doco-cd/internal/config/app.Version=${APP_VERSION} ${BW_SDK_BUILD_FLAGS}" -o / ./...; \
     fi
 
-FROM debian:bookworm-slim AS ssh-client
-RUN apt-get update && apt-get install -y --no-install-recommends openssh-client && rm -rf /var/lib/apt/lists/*
+FROM debian:trixie-slim AS ssh-client
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends openssh-client && \
+    rm -rf /var/lib/apt/lists/* && \
+    # Collect the ssh binary and ALL its shared library dependencies into /ssh-root/, \
+    # preserving the real (resolved) directory structure for the release-stage COPY.
+    # realpath resolves /lib -> /usr/lib symlinks so libraries land under /usr/lib/
+    # in the distroless image (which uses the merged-usr layout: /lib -> usr/lib).
+    mkdir -p /ssh-root/usr/bin && \
+    cp /usr/bin/ssh /ssh-root/usr/bin/ssh && \
+    ldd /usr/bin/ssh | awk '$3 ~ /^\// { print $3 }' | \
+        while IFS= read -r lib; do \
+          dir=$(realpath "$(dirname "$lib")"); \
+          mkdir -p "/ssh-root$dir"; \
+          cp -L "$lib" "/ssh-root$dir/$(basename "$lib")"; \
+        done
 
 FROM gcr.io/distroless/base-debian13@sha256:f4a335ca209e1d2ee873102c17c389ad0142e3d5b21aee2817e9cc9c01d87d20 AS release
 
@@ -74,8 +88,9 @@ COPY --from=docker/buildx-bin:0.35.0@sha256:917570d8d0ae91ae49251f84f848a6801eed
 
 COPY --from=build /doco-cd /doco-cd
 
-# SSH client required for Docker contexts using the ssh:// transport
-COPY --from=ssh-client /usr/bin/ssh /usr/bin/ssh
+# SSH client required for Docker contexts using the ssh:// transport.
+# The entire /ssh-root tree (binary + all shared library dependencies) is copied in.
+COPY --from=ssh-client /ssh-root/ /
 
 ENV TZ=UTC \
     HTTP_PORT=80 \

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -87,9 +88,13 @@ func CreateDockerCliWithContext(quiet bool, dockerContext string) (command.Cli, 
 		errorStream = os.Stderr
 	}
 
+	// Capture all writes to cli.Err() in a buffer so that the error printed by
+	// DockerEndpoint() (see below) is retrievable regardless of quiet mode.
+	var initErrBuf bytes.Buffer
+
 	dockerCli, err := command.NewDockerCli(
 		command.WithOutputStream(outputStream),
-		command.WithErrorStream(errorStream),
+		command.WithErrorStream(io.MultiWriter(errorStream, &initErrBuf)),
 		command.WithAPIClientOptions(client.FromEnv),
 	)
 	if err != nil {
@@ -106,6 +111,21 @@ func CreateDockerCliWithContext(quiet bool, dockerContext string) (command.Cli, 
 	err = dockerCli.Initialize(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize docker cli: %w", err)
+	}
+
+	// Discard any non-fatal warnings written by Initialize() (e.g. "WARNING: Error
+	// loading config file: permission denied") so they don't trip the check below.
+	initErrBuf.Reset()
+
+	/* DockerEndpoint() safely triggers the internal lazy initialization (sync.Once).
+	Unlike Client(), it does NOT call os.Exit(1) on failure — instead it prints the
+	error to cli.Err() (captured above in initErrBuf) and returns whatever partial
+	endpoint was resolved. Check the buffer first so we surface the real Docker error. */
+	_ = dockerCli.DockerEndpoint()
+
+	if initErrBuf.Len() > 0 {
+		return nil, fmt.Errorf("failed to initialize Docker CLI for context %q: %s",
+			contextName, strings.TrimSpace(initErrBuf.String()))
 	}
 
 	return dockerCli, nil

--- a/internal/reconciliation/manager.go
+++ b/internal/reconciliation/manager.go
@@ -175,7 +175,18 @@ func (r *reconciliation) addJob(ctx context.Context, info jobInfo) {
 	newJob := newJob(info, cfg)
 
 	r.repoJobs[info.repoData.Name] = newJob
-	go newJob.run(context.WithoutCancel(ctx))
+
+	jobLog := info.jobLog
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				jobLog.Error("reconciliation job panicked", slog.Any("recover", r))
+			}
+		}()
+
+		newJob.run(context.WithoutCancel(ctx))
+	}()
 }
 
 func getDeployConfigGroupByEvent(dcs []*deployConfig.Config) map[string][]*deployConfig.Config {

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -289,7 +290,14 @@ func (j *job) forwardEvents(ctx context.Context, jobLog *slog.Logger, eventCh <-
 			}
 
 			if err != nil && !errors.Is(err, context.Canceled) {
+				if isFatalConnectionError(err) {
+					jobLog.Error("docker event listener stopped: unrecoverable connection error", slog.String("context", contextName), logger.ErrAttr(err))
+
+					return false, newestEventTime // do not retry
+				}
+
 				jobLog.Error("docker event listener failed", slog.String("context", contextName), logger.ErrAttr(err))
+
 				return true, newestEventTime // reconnect after error
 			}
 		case event, ok := <-eventCh:
@@ -548,4 +556,25 @@ func reconciliationTraceIDFromEvent(event events.Message) string {
 	}
 
 	return strings.TrimSpace(event.Actor.Attributes[reconciliationTraceIDAttr])
+}
+
+// isFatalConnectionError reports whether err represents a permanent, non-retryable
+// connection failure (e.g. a required transport binary like "ssh" is missing from PATH).
+// These errors will not resolve on their own, so the event listener should stop instead
+// of retrying indefinitely.
+func isFatalConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+
+	fatalSubstrings := []string{
+		"executable file not found in $PATH",
+		"no such file or directory",
+	}
+
+	return slices.ContainsFunc(fatalSubstrings, func(s string) bool {
+		return strings.Contains(msg, s)
+	})
 }

--- a/wiki/docs/Advanced/Docker-Contexts.md
+++ b/wiki/docs/Advanced/Docker-Contexts.md
@@ -109,9 +109,11 @@ services:
     ```sh
     chmod -R a+r ~/.docker/contexts/
     find ~/.docker/contexts/ -type d -exec chmod a+rx {} \;
-    chmod 600 ~/.ssh/id_*
-    chmod 644 ~/.ssh/known_hosts ~/.ssh/authorized_keys 2>/dev/null || true
+    chmod 600 ~/.ssh/id_* # (1)!
+    chmod 644 ~/.ssh/known_hosts ~/.ssh/authorized_keys
     ```
+
+    1. Adjust the `chmod` command accordingly, depending on your SSH key filenames.
 
 If you need private registry access, ensure the mounted Docker config includes required auth data (see [Private Container Registries](Private-Container-Registries.md)).
 

--- a/wiki/docs/Advanced/Docker-Contexts.md
+++ b/wiki/docs/Advanced/Docker-Contexts.md
@@ -1,8 +1,9 @@
 ---
 tags:
+  - Setup
   - Advanced
+  - Deployment
   - Docker
-  - Contexts
 ---
 
 # Docker Contexts

--- a/wiki/docs/Advanced/Docker-Contexts.md
+++ b/wiki/docs/Advanced/Docker-Contexts.md
@@ -13,6 +13,40 @@ This lets one doco-cd instance manage and deploy to multiple Docker hosts/cluste
 !!! info "Default Docker context"
     Default Docker context means the local Docker host (usually via the mounted socket `/var/run/docker.sock`).
 
+## Supported transports
+
+doco-cd includes an SSH client, so both TCP and SSH Docker contexts work out of the box:
+
+| Transport | Example endpoint                 | Notes                                 |
+|-----------|----------------------------------|---------------------------------------|
+| TCP       | `tcp://host:2376`                | Plaintext; use TLS for production     |
+| TCP+TLS   | `tcp://host:2376` with TLS certs | Secure TCP                            |
+| SSH       | `ssh://user@host`                | Uses the `ssh` binary; mount SSH keys |
+
+### SSH context example
+
+```sh
+docker context create prod-remote --docker host=ssh://deploy@prod-host
+```
+
+Mount your SSH keys into the doco-cd container so the bundled `ssh` binary can authenticate:
+
+```yaml title="docker-compose.yml" hl_lines="7-8"
+services:
+  doco-cd:
+    image: ghcr.io/kimdre/doco-cd:latest
+    container_name: doco-cd
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ~/.docker:/root/.docker:ro
+      - ~/.ssh:/root/.ssh:ro # (1)!
+```
+
+1. Mount your SSH keys and `known_hosts` for context connections
+
+!!! tip "SSH host verification"
+    Docker's SSH transport respects `~/.ssh/known_hosts`. Pre-populate it (or use `StrictHostKeyChecking=accept-new` via `SSH_OPTIONS`) to avoid interactive prompts on first connection.
+
 ## 1. Create Docker contexts
 
 Create contexts on the host that runs doco-cd.

--- a/wiki/docs/Advanced/Docker-Contexts.md
+++ b/wiki/docs/Advanced/Docker-Contexts.md
@@ -68,7 +68,7 @@ The SSH key used must:
 !!! tip "Multiple SSH keys"
 
     Docker does not try all available keys, so you must specify the correct one for each host.  
-    If multiple keys are present, or host key prompts block non-interactive SSH, add an SSH config entry for the host in the container-mounted `~/.ssh/config`.
+    If multiple keys are present, or host key prompts block non-interactive SSH, add an [SSH config](https://man.openbsd.org/ssh_config) entry for the host in the container-mounted `~/.ssh/config`.
 
     ```sshconfig title="~/.ssh/config"
     Host docker-host

--- a/wiki/docs/Advanced/Docker-Contexts.md
+++ b/wiki/docs/Advanced/Docker-Contexts.md
@@ -56,13 +56,28 @@ The SSH key used must:
 - Have the corresponding **public key in `~/.ssh/authorized_keys`** on the remote host for the connecting user
 - Be a supported key type (Ed25519 recommended: `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_doco-cd -N ""`)
 
-To verify the key works from inside the container before using it with doco-cd:
+!!! tip "Verify SSH key"
+    To verify the key works from inside the container before using it with doco-cd:
+    
+    ```sh
+    docker exec doco-cd ssh -l <user> -o ConnectTimeout=30 -T -- <host> docker system dial-stdio
+    ```
+    
+    If this command hangs or returns output (even garbled binary), the SSH connection and key are working correctly.
 
-```sh
-docker exec doco-cd ssh -l <user> -o ConnectTimeout=30 -T -- <host> docker system dial-stdio
-```
+!!! tip "Multiple SSH keys"
 
-If this command hangs or returns output (even garbled binary), the SSH connection and key are working correctly.
+    Docker does not try all available keys, so you must specify the correct one for each host.  
+    If multiple keys are present, or host key prompts block non-interactive SSH, add an SSH config entry for the host in the container-mounted `~/.ssh/config`.
+
+    ```sshconfig title="~/.ssh/config"
+    Host docker-host
+        IdentityFile /root/.ssh/doco-cd-control
+        IdentitiesOnly yes
+        StrictHostKeyChecking no
+    ```
+    
+    Use `Host docker-host` to match the hostname used by your Docker context endpoint (for example `ssh://user@docker-host`).
 
 ## 1. Create Docker contexts
 

--- a/wiki/docs/Advanced/Docker-Contexts.md
+++ b/wiki/docs/Advanced/Docker-Contexts.md
@@ -48,6 +48,22 @@ services:
 !!! tip "SSH host verification"
     Docker's SSH transport respects `~/.ssh/known_hosts`. Pre-populate it (or use `StrictHostKeyChecking=accept-new` via `SSH_OPTIONS`) to avoid interactive prompts on first connection.
 
+### SSH key requirements
+
+The SSH key used must:
+
+- Be **passphrase-free** — Docker's SSH transport runs `ssh` non-interactively inside the container; a passphrase prompt will cause the connection to fail with `Permission denied`
+- Have the corresponding **public key in `~/.ssh/authorized_keys`** on the remote host for the connecting user
+- Be a supported key type (Ed25519 recommended: `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_doco-cd -N ""`)
+
+To verify the key works from inside the container before using it with doco-cd:
+
+```sh
+docker exec doco-cd ssh -l <user> -o ConnectTimeout=30 -T -- <host> docker system dial-stdio
+```
+
+If this command hangs or returns output (even garbled binary), the SSH connection and key are working correctly.
+
 ## 1. Create Docker contexts
 
 Create contexts on the host that runs doco-cd.
@@ -70,9 +86,9 @@ docker --context staging-remote info
 
 ## 3. Mount Docker context config into doco-cd
 
-Docker context config must be available in the doco-cd container.
+Docker context metadata and the SSH directory must be available in the doco-cd container.
 
-```yaml title="docker-compose.yml" hl_lines="7"
+```yaml title="docker-compose.yml" hl_lines="7-8"
 services:
   doco-cd:
     image: ghcr.io/kimdre/doco-cd:latest
@@ -80,9 +96,22 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ~/.docker:/root/.docker:ro # (1)!
+      - ~/.ssh:/root/.ssh:ro       # (2)!
 ```
 
-1. Docker contexts + credentials
+1. Docker context metadata and credentials — required for all non-default contexts
+2. SSH keys and `known_hosts` — required for SSH contexts only
+
+!!! warning "File permissions"
+    The mounted `~/.docker` and `~/.ssh` directories (and all files within them) must be **readable by the user running inside the container** (root by default).
+    If you see `permission denied` errors referencing context metadata or SSH keys, fix permissions on the host:
+
+    ```sh
+    chmod -R a+r ~/.docker/contexts/
+    find ~/.docker/contexts/ -type d -exec chmod a+rx {} \;
+    chmod 600 ~/.ssh/id_*
+    chmod 644 ~/.ssh/known_hosts ~/.ssh/authorized_keys 2>/dev/null || true
+    ```
 
 If you need private registry access, ensure the mounted Docker config includes required auth data (see [Private Container Registries](Private-Container-Registries.md)).
 
@@ -120,3 +149,68 @@ working_dir: deploy
 ```
 
 Each deployment uses its own Docker context for deploy, destroy, and cleanup operations.
+
+## Remote host limitations
+
+When deploying to a remote Docker context, the **remote daemon** executes the compose stack. This has important implications for bind mounts, configs, and secrets.
+
+### Bind mounts
+
+Bind mount source paths must exist on the **remote host**, not the doco-cd host:
+
+```yaml
+volumes:
+  - /data/myapp:/app/data  # ← this path must exist on the remote host
+```
+
+Named volumes work fine — they are created on the remote host automatically:
+
+```yaml
+volumes:
+  mydata:  # ← created on the remote host
+
+services:
+  app:
+    volumes:
+      - mydata:/app/data
+```
+
+### Configs and secrets with `file:` sources
+
+Docker Compose resolves `file:` references to absolute paths on the doco-cd host, then sends those paths to the remote daemon. The remote daemon tries to bind-mount them locally — and fails because the files don't exist there.
+
+```yaml
+# ✗ Will fail on remote contexts — remote daemon can't access this path
+configs:
+  app.conf:
+    file: app.conf
+
+secrets:
+  api_key:
+    file: api_key.txt
+```
+
+**Alternatives that work with remote contexts:**
+
+=== "Inline content"
+
+    ```yaml
+    configs:
+      app.conf:
+        content: |
+          key=value
+          other=setting
+    ```
+
+=== "Environment variable (secrets)"
+
+    ```yaml
+    secrets:
+      api_key:
+        environment: API_KEY  # read from env var on the remote host
+    ```
+
+=== "Docker Swarm"
+
+    Swarm secrets and configs are uploaded to the cluster and distributed automatically — they work correctly with remote contexts.
+    See [Swarm Mode](Swarm-Mode.md) for details.


### PR DESCRIPTION
This pull request adds robust support for Docker SSH contexts, ensuring the required `ssh` binary and dependencies are included in the release image, improving error handling for missing SSH dependencies, and significantly expanding the documentation to guide users on using SSH and remote Docker contexts. The changes also improve resilience in the reconciliation job manager and clarify remote context limitations in the documentation.

**Docker image and SSH support:**
- Added a new `ssh-client` build stage in the `Dockerfile` to install the `ssh` client and copy all its shared library dependencies into the release image, ensuring SSH-based Docker contexts work out of the box. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R64-R80) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R91-R94)

**Error handling and resilience:**
- Improved error handling in `CreateDockerCliWithContext` to capture and surface initialization errors (including missing SSH binary) by buffering error output and checking for fatal errors after Docker CLI initialization. [[1]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dR4) [[2]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dR91-R97) [[3]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dR116-R130)
- Added a panic recovery mechanism to the reconciliation job runner to log unexpected panics instead of crashing the goroutine.
- Implemented detection of fatal connection errors (e.g., missing `ssh` binary) in the Docker event listener, preventing infinite retries and logging unrecoverable errors clearly. [[1]](diffhunk://#diff-0fbd669c2d95a9611030061d0519c1c32c08b2db56f1a7f542c1eee958bec52bR8) [[2]](diffhunk://#diff-0fbd669c2d95a9611030061d0519c1c32c08b2db56f1a7f542c1eee958bec52bR293-R300) [[3]](diffhunk://#diff-0fbd669c2d95a9611030061d0519c1c32c08b2db56f1a7f542c1eee958bec52bR560-R580)

**Documentation improvements:**
- Expanded the Docker Contexts documentation to cover supported transports (including SSH), SSH key requirements, mounting instructions, troubleshooting permissions, and limitations of remote contexts (e.g., bind mounts, configs, and secrets). [[1]](diffhunk://#diff-2c4b0ffcb3287908208206b8cc65fe031f7ab2a077fbbb68e138bfb4e3d1b098R3-L5) [[2]](diffhunk://#diff-2c4b0ffcb3287908208206b8cc65fe031f7ab2a077fbbb68e138bfb4e3d1b098R17-R66) [[3]](diffhunk://#diff-2c4b0ffcb3287908208206b8cc65fe031f7ab2a077fbbb68e138bfb4e3d1b098L38-R114) [[4]](diffhunk://#diff-2c4b0ffcb3287908208206b8cc65fe031f7ab2a077fbbb68e138bfb4e3d1b098R152-R216)