### PR TITLE
feat(notification): expose deployment target in notification templates

### DIFF
--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -192,6 +192,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 
 	if customTarget != "" {
 		jobLog = jobLog.With(slog.String("target", customTarget))
+		metadata.Target = strings.TrimSpace(customTarget)
 	}
 
 	if strings.Contains(repoName, "..") {

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -83,6 +83,7 @@ func (h *handlerData) PollHandler(ctx context.Context, pollJob *poll.Job) {
 			metadata := notification.Metadata{
 				Repository: repoName,
 				Stack:      "",
+				Target:     pollJob.Config.CustomTarget,
 				Revision:   notification.GetRevision(pollJob.Config.Reference, ""),
 				JobID:      jobID,
 			}

--- a/cmd/doco-cd/handler_poll_test.go
+++ b/cmd/doco-cd/handler_poll_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestPollHandlerAllowsConcurrentRunsForSameRepository(t *testing.T) {
 	log := logger.New(logger.LevelCritical)
-	started := make(chan string, 2)
+	started := make(chan notification.Metadata, 2)
 	release := make(chan struct{})
 
 	h := handlerData{
@@ -38,7 +38,7 @@ func TestPollHandlerAllowsConcurrentRunsForSameRepository(t *testing.T) {
 		runPoll: func(_ context.Context, _ poll.Config, _ *app.Config, _ container.MountPoint,
 			_ command.Cli, _ *slog.Logger, metadata notification.Metadata, _ *secretprovider.SecretProvider,
 		) error {
-			started <- metadata.JobID
+			started <- metadata
 
 			<-release
 
@@ -47,10 +47,11 @@ func TestPollHandlerAllowsConcurrentRunsForSameRepository(t *testing.T) {
 	}
 
 	jobConfig := poll.Config{
-		SourceUrl: "https://github.com/kimdre/doco-cd_tests.git",
-		Reference: "main",
-		Interval:  poll.MinPollInterval,
-		RunOnce:   true,
+		SourceUrl:    "https://github.com/kimdre/doco-cd_tests.git",
+		Reference:    "main",
+		Interval:     poll.MinPollInterval,
+		CustomTarget: "prod-vm",
+		RunOnce:      true,
 	}
 
 	ctx := t.Context()
@@ -72,7 +73,16 @@ func TestPollHandlerAllowsConcurrentRunsForSameRepository(t *testing.T) {
 
 	for range 2 {
 		select {
-		case <-started:
+		case metadata := <-started:
+			if metadata.JobID == "" {
+				close(release)
+				t.Fatal("expected poll metadata to include a job id")
+			}
+
+			if metadata.Target != "prod-vm" {
+				close(release)
+				t.Fatalf("expected poll metadata target prod-vm, got %q", metadata.Target)
+			}
 		case <-time.After(500 * time.Millisecond):
 			close(release)
 			t.Fatal("expected both poll handlers to start their runs without serializing on the repository")

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -212,6 +212,7 @@ func (h *handlerData) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 		JobID:      jobID,
 		Repository: "unknown", // Will be updated later if we can parse the payload
 		Stack:      "",
+		Target:     strings.TrimSpace(customTarget),
 		Revision:   "",
 	}
 

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -68,6 +68,7 @@ type Metadata struct {
 	Repository          string
 	Stack               string
 	Context             string // Docker context the stack is deployed to (empty = default context)
+	Target              string // Custom webhook/poll target suffix (e.g., "prod-vm" for .doco-cd.prod-vm.yml)
 	Revision            string
 	JobID               string
 	TraceID             string

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -255,7 +255,7 @@ func TestValidateTemplate(t *testing.T) {
 	t.Run("valid template parses", func(t *testing.T) {
 		t.Parallel()
 
-		if _, err := validateTemplate("{{.Emoji}} {{.Title}} on {{.Stack}}"); err != nil {
+		if _, err := validateTemplate("{{.Emoji}} {{.Title}} on {{.Target}}/{{.Stack}}"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -283,17 +283,18 @@ func TestRenderTemplate(t *testing.T) {
 	t.Run("renders metadata fields and trims trailing newlines", func(t *testing.T) {
 		t.Parallel()
 
-		tmpl, err := validateTemplate("{{.Emoji}} {{.Title}} — {{.Stack}} @ {{.Revision}}\n")
+		tmpl, err := validateTemplate("{{.Emoji}} {{.Title}} — {{.Target}}/{{.Stack}} @ {{.Revision}}\n")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
 		got := renderTemplate(tmpl, Success, "Deployment completed", "ignored body", Metadata{
+			Target:   "prod-vm",
 			Stack:    "app",
 			Revision: "main (abc123)",
 			JobID:    "job-1",
 		})
-		expected := "✅ Deployment completed — app @ main (abc123)"
+		expected := "✅ Deployment completed — prod-vm/app @ main (abc123)"
 
 		if got != expected {
 			t.Errorf("expected %q, got %q", expected, got)

--- a/internal/reconciliation/clean.go
+++ b/internal/reconciliation/clean.go
@@ -146,6 +146,10 @@ func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.L
 
 			stackLog.Info("removing obsolete auto-discovered stack")
 
+			notifyMetadata := metadata
+			notifyMetadata.Target = stackConfigTarget
+			notifyMetadata.Stack = stackName
+
 			removeConfig := &deployConfig.Config{Name: stackName}
 			removeConfig.Destroy.Enabled = true
 			removeConfig.Destroy.RemoveVolumes = autoDiscoverCfg.RemoveVolumes
@@ -157,7 +161,7 @@ func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.L
 				return fmt.Errorf("failed to remove obsolete auto-discovered stack '%s': %w", stackName, err)
 			}
 
-			err = notification.Send(notification.Success, "Stack destroyed", "successfully destroyed stack "+removeConfig.Name, metadata)
+			err = notification.Send(notification.Success, "Stack destroyed", "successfully destroyed stack "+removeConfig.Name, notifyMetadata)
 			if err != nil {
 				stackLog.Error("failed to send notification", logger.ErrAttr(err))
 			}

--- a/internal/reconciliation/reconciliation_event_test.go
+++ b/internal/reconciliation/reconciliation_event_test.go
@@ -458,11 +458,14 @@ func TestRestartOptionsFromDeployConfig(t *testing.T) {
 func TestRestartNotificationMetadata(t *testing.T) {
 	t.Parallel()
 
+	dc := &deployConfig.Config{Context: "remote-vm"}
+	dc.Internal.ConfigTarget = "prod-vm"
+
 	metadata := restartNotificationMetadata(notification.Metadata{
 		Repository: "owner/repo",
 		Stack:      "stack-a",
 		JobID:      "job-1",
-	}, &deployConfig.Config{Context: "remote-vm"}, "unhealthy", "container", "1234567890abcdef", "stack-a-web-1", "trace-1")
+	}, dc, "unhealthy", "container", "1234567890abcdef", "stack-a-web-1", "trace-1")
 
 	if metadata.Repository != "owner/repo" || metadata.Stack != "stack-a" || metadata.JobID != "job-1" {
 		t.Fatalf("expected base metadata to be preserved, got %#v", metadata)
@@ -470,6 +473,10 @@ func TestRestartNotificationMetadata(t *testing.T) {
 
 	if metadata.Context != "remote-vm" {
 		t.Fatalf("expected context remote-vm from deploy config, got %q", metadata.Context)
+	}
+
+	if metadata.Target != "prod-vm" {
+		t.Fatalf("expected target prod-vm from deploy config, got %q", metadata.Target)
 	}
 
 	if metadata.ReconciliationEvent != "unhealthy" {

--- a/internal/reconciliation/reconciliation_restart.go
+++ b/internal/reconciliation/reconciliation_restart.go
@@ -116,6 +116,7 @@ func restartNotificationMetadata(base notification.Metadata, dc *deployConfig.Co
 	metadata := base
 	if dc != nil {
 		metadata.Context = dc.Context
+		metadata.Target = dc.Internal.ConfigTarget
 	}
 
 	metadata.ReconciliationEvent = action

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -776,6 +776,7 @@ func (s *scheduler) sendRunNotification(job scheduledJob, cfg docker.JobSchedule
 	metadata := notification.Metadata{
 		Repository:        job.labels[docker.DocoCDLabels.Source.Name],
 		Stack:             job.labels[docker.DocoCDLabels.Deployment.Name],
+		Target:            job.labels[docker.DocoCDLabels.Deployment.ConfigTarget],
 		Revision:          notification.GetRevision("", job.labels[docker.DocoCDLabels.Deployment.CommitSHA]),
 		JobID:             runID,
 		AffectedActorKind: actorKind,

--- a/internal/stages/manager_test.go
+++ b/internal/stages/manager_test.go
@@ -1,6 +1,7 @@
 package stages
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"slices"
@@ -81,6 +82,29 @@ func TestStageManagerGetStageMetaData(t *testing.T) {
 
 	if _, err := sm.GetStageMetaData(StageName("unknown")); err == nil {
 		t.Fatal("GetStageMetaData(unknown) = nil, want error")
+	}
+}
+
+func TestStageManagerNotifyFailureIncludesTarget(t *testing.T) {
+	t.Parallel()
+
+	sm := newTestStageManager()
+	sm.Repository.Revision = "abc123"
+	sm.DeployConfig.Name = "app"
+	sm.DeployConfig.Context = "remote-vm"
+	sm.DeployConfig.Reference = "main"
+	sm.DeployConfig.Internal.ConfigTarget = "prod-vm"
+
+	var got notification.Metadata
+
+	sm.NotifyFailureFunc = func(_ *slog.Logger, _ error, metadata notification.Metadata) {
+		got = metadata
+	}
+
+	sm.NotifyFailure(errors.New("boom"))
+
+	if got.Target != "prod-vm" {
+		t.Fatalf("expected target prod-vm, got %q", got.Target)
 	}
 }
 

--- a/internal/stages/stage_4_post-deploy.go
+++ b/internal/stages/stage_4_post-deploy.go
@@ -39,6 +39,7 @@ func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logg
 	metadata.Repository = s.Repository.Name
 	metadata.Stack = s.DeployConfig.Name
 	metadata.Context = s.DeployConfig.Context
+	metadata.Target = s.DeployConfig.Internal.ConfigTarget
 	metadata.Revision = notification.GetRevision(s.DeployConfig.Reference, shortCommit)
 	metadata.JobID = s.JobID
 

--- a/internal/stages/stage_4_post-destroy.go
+++ b/internal/stages/stage_4_post-destroy.go
@@ -20,6 +20,7 @@ func (s *StageManager) RunPostDestroyStage(_ context.Context, stageLog *slog.Log
 	metadata.Repository = s.Repository.Name
 	metadata.Stack = s.DeployConfig.Name
 	metadata.Context = s.DeployConfig.Context
+	metadata.Target = s.DeployConfig.Internal.ConfigTarget
 	metadata.JobID = s.JobID
 
 	err := notification.Send(notification.Success, "Stack destroyed", "successfully destroyed stack "+s.DeployConfig.Name, metadata)

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -255,6 +255,7 @@ func (s *StageManager) NotifyFailure(notifyErr error) {
 		metadata.Repository = s.Repository.Name
 		metadata.Stack = s.DeployConfig.Name
 		metadata.Context = s.DeployConfig.Context
+		metadata.Target = s.DeployConfig.Internal.ConfigTarget
 		metadata.Revision = revision
 		metadata.JobID = s.JobID
 

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -82,6 +82,7 @@ The following fields are available:
 | `.IsReconciliation`   | `true` when triggered by a [reconciliation](#reconciliation-notifications) event |
 | `.Repository`         | Repository name                                                          |
 | `.Stack`              | Project/Stack name                                                       |
+| `.Target`             | Custom webhook/poll target (empty for the default target)                |
 | `.Context`            | Docker context the stack is deployed to (empty for the default context)  |
 | `.Revision`           | Branch/tag and commit SHA                                                |
 | `.JobID`              | Deployment job ID (empty for reconciliation events)                      |
@@ -97,10 +98,10 @@ The following fields are available:
 
     ```yaml
     environment:
-      APPRISE_NOTIFY_BODY_TEMPLATE: "{{.Emoji}} {{.Stack}} — {{.Message}} ({{.Revision}})"
+      APPRISE_NOTIFY_BODY_TEMPLATE: "{{.Emoji}} {{if .Target}}{{.Target}}/{{end}}{{.Stack}} — {{.Message}} ({{.Revision}})"
     ```
 
-    renders e.g. `✅ app — Successfully deployed stack app (main (abc123))`.
+    renders e.g. `✅ prod-vm/app — Successfully deployed stack app (main (abc123))` for target `prod-vm`, or `✅ app — Successfully deployed stack app (main (abc123))` without a custom target.
 
 ## Reconciliation notifications
 


### PR DESCRIPTION
I'm using [custom webhook targets](https://doco.cd/latest/Endpoints/Webhook-Listener/#with-custom-target) to deploy to multiple servers from a single repository. In my notifications I would like to have a reference to the deployment target, but this value was missing from the notification metadata added in #1558. I added it to the metadata and you can now use it in custom notification body templates:
```
{{.Message}}

{{if .Target}}target: {{.Target}}
{{end}}job_id: {{.JobID}}
revision: {{.Revision}}
stack: {{.Stack}}
```
I tested this successfully with ntfy:
<img width="1543" height="471" alt="image" src="https://github.com/user-attachments/assets/40b5e14b-04f2-46be-b3a2-f1f040c83f45" />
<img width="1543" height="471" alt="image" src="https://github.com/user-attachments/assets/6b7dd632-75f3-4a1a-9de0-cbeefe64355a" />


The implementation was done using GitHub Copilot with GPT-5.5 but I reviewed it manually and tested it successfully on my server.
