### PR TITLE
fix(git): handle unsafe reference names in GetReferenceSet

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -90,10 +90,11 @@ type RefSet struct {
 //  1. Commit SHA — returned directly; no reference store lookup is performed.
 //  2. For refs/-prefixed names: the exact name, then its remote-tracking counterpart.
 //  3. For short names: refs/heads/<ref>, refs/remotes/origin/<ref>, refs/tags/<ref>,
-//     and — only when the name passes plumbing.ReferenceName.IsSafe — the bare name
-//     (covering uppercase pseudo-refs such as HEAD or ORIG_HEAD).
+//     then the bare name (which only resolves for uppercase pseudo-refs like HEAD).
 //
-// Any storage error other than plumbing.ErrReferenceNotFound is treated as a
+// Candidates whose name cannot be stored safely (see plumbing.ReferenceName.IsSafe)
+// are skipped rather than queried, so a malformed ref yields ErrInvalidReference
+// instead of a storage-layer error. Any other storage error is treated as a
 // transient failure and returned immediately.
 func GetReferenceSet(repo *git.Repository, ref string) (RefSet, error) {
 	// Commit SHAs are used directly — there is no reference name to resolve.
@@ -126,26 +127,30 @@ func GetReferenceSet(repo *git.Repository, ref string) (RefSet, error) {
 			candidate{plumbing.NewBranchReferenceName(ref), remoteRef},
 			candidate{remoteRef, remoteRef},
 			candidate{plumbing.NewTagReferenceName(ref), plumbing.NewTagReferenceName(ref)},
+			// The bare name only ever resolves for uppercase pseudo-refs such as
+			// HEAD or ORIG_HEAD; the IsSafe filter below discards it otherwise.
+			candidate{plumbing.ReferenceName(ref), plumbing.ReferenceName(ref)},
 		)
-		// Only add the bare name as a candidate when it is safe for storage.
-		// go-git v5.19.2+ validates reference names at the storage layer and rejects
-		// unsafe names (those not under refs/ and not an uppercase pseudo-ref) with a
-		// distinct error instead of plumbing.ErrReferenceNotFound. Skipping the lookup
-		// for unsafe names avoids misclassifying that error as a transient failure.
-		// Valid cases are uppercase pseudo-refs such as HEAD or ORIG_HEAD.
-		if plumbing.ReferenceName(ref).IsSafe() {
-			candidates = append(candidates,
-				candidate{plumbing.ReferenceName(ref), plumbing.ReferenceName(ref)},
-			)
-		}
 	}
 
 	for _, c := range candidates {
-		_, err := repo.Reference(c.local, true)
+		// go-git v5.19.2+ validates reference names at the storage layer and rejects
+		// unsafe ones (not under refs/, escaping it, or not an uppercase pseudo-ref)
+		// with an error distinct from plumbing.ErrReferenceNotFound. Such a name can
+		// never exist, so skip the lookup instead of misreporting it as transient.
+		if !c.local.IsSafe() {
+			continue
+		}
+
+		localRef, err := repo.Reference(c.local, true)
 		if err == nil {
 			remoteHash := plumbing.ZeroHash
 
-			if c.remote != "" {
+			switch {
+			case c.remote == c.local:
+				// Already resolved above; avoid a redundant store lookup.
+				remoteHash = localRef.Hash()
+			case c.remote.IsSafe():
 				if rRef, rErr := repo.Reference(c.remote, true); rErr == nil {
 					remoteHash = rRef.Hash()
 				}

--- a/internal/git/references_test.go
+++ b/internal/git/references_test.go
@@ -1,0 +1,229 @@
+package git
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+// TestGetReferenceSet_LocalResolution exercises every resolution path of
+// GetReferenceSet using a fully local origin/clone pair, without requiring
+// network access. Covered cases:
+//
+//   - short branch name         → refs/heads/<name> with remote tracking ref
+//   - full refs/heads/...       → same as above
+//   - refs/remotes/origin/...   → returned directly
+//   - short tag name            → refs/tags/<name>
+//   - full refs/tags/...        → same
+//   - commit SHA                → returned as-is; RemoteRef is empty, RemoteHash is zero
+//   - remote-only tracking ref  → resolves via refs/remotes/origin/<name> only
+//   - non-existent refs         → ErrInvalidReference
+func TestGetReferenceSet_LocalResolution(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	originPath := filepath.Join(base, "origin")
+	clonePath := filepath.Join(base, "clone")
+
+	originRepo, err := gogit.PlainInit(originPath, false)
+	if err != nil {
+		t.Fatalf("init origin: %v", err)
+	}
+
+	mainHash := commitFile(t, originRepo, originPath, "README.md", "initial\n", "initial commit")
+
+	for _, ref := range []plumbing.Reference{
+		*plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), mainHash),
+		*plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main")),
+		*plumbing.NewHashReference(plumbing.NewTagReferenceName("v1.0.0"), mainHash),
+	} {
+		if err := originRepo.Storer.SetReference(&ref); err != nil {
+			t.Fatalf("set %s: %v", ref.Name(), err)
+		}
+	}
+
+	_ = originRepo.Storer.RemoveReference(plumbing.NewBranchReferenceName("master"))
+
+	// Checkout feature/foo before committing so that commitFile advances
+	// refs/heads/feature/foo, not refs/heads/main (which HEAD currently tracks).
+	originWt, err := originRepo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	if err := originWt.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.NewBranchReferenceName("feature/foo"),
+		Create: true,
+		Keep:   true,
+	}); err != nil {
+		t.Fatalf("checkout feature/foo: %v", err)
+	}
+
+	featureHash := commitFile(t, originRepo, originPath, "feature.txt", "feature\n", "feature commit")
+
+	clonedRepo, err := CloneRepository(clonePath, originPath, MainBranch, false, transport.ProxyOptions{}, nil, false, 0)
+	if err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	// go-git PlainClone creates local tracking branches for every remote branch,
+	// so refs/heads/feature/foo also exists in the clone. To test the remote-only
+	// path we manually inject a tracking ref that has no local counterpart.
+	remoteOnlyHash := featureHash
+	if err := clonedRepo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewRemoteReferenceName(RemoteName, "remote-only"), remoteOnlyHash),
+	); err != nil {
+		t.Fatalf("inject remote-only ref: %v", err)
+	}
+
+	remotePrefix := "refs/remotes/" + RemoteName + "/"
+
+	tests := []struct {
+		ref            string
+		wantLocalRef   string
+		wantRemoteRef  string
+		wantRemoteHash plumbing.Hash // zero means "don't care / expect ZeroHash"
+		wantErr        error
+	}{
+		// Short branch name resolves to the local tracking branch first.
+		{
+			ref:            "main",
+			wantLocalRef:   BranchPrefix + "main",
+			wantRemoteRef:  remotePrefix + "main",
+			wantRemoteHash: mainHash,
+		},
+		// Full refs/heads/ name — same resolution as the short form.
+		{
+			ref:            BranchPrefix + "main",
+			wantLocalRef:   BranchPrefix + "main",
+			wantRemoteRef:  remotePrefix + "main",
+			wantRemoteHash: mainHash,
+		},
+		// Remote tracking ref passed in full — resolved without local branch lookup.
+		{
+			ref:            remotePrefix + "main",
+			wantLocalRef:   remotePrefix + "main",
+			wantRemoteRef:  remotePrefix + "main",
+			wantRemoteHash: mainHash,
+		},
+		// Short tag name resolves after branch candidates fail.
+		{
+			ref:            "v1.0.0",
+			wantLocalRef:   TagPrefix + "v1.0.0",
+			wantRemoteRef:  TagPrefix + "v1.0.0",
+			wantRemoteHash: mainHash,
+		},
+		// Full tag ref passed directly.
+		{
+			ref:            TagPrefix + "v1.0.0",
+			wantLocalRef:   TagPrefix + "v1.0.0",
+			wantRemoteRef:  TagPrefix + "v1.0.0",
+			wantRemoteHash: mainHash,
+		},
+		// Commit SHA is returned directly; no reference store lookup.
+		{
+			ref:           mainHash.String(),
+			wantLocalRef:  mainHash.String(),
+			wantRemoteRef: "",
+			// RemoteHash stays ZeroHash for commit SHA refs.
+		},
+		// go-git PlainClone creates refs/heads/feature/foo locally too (unlike
+		// standard git), so "feature/foo" resolves to the local tracking branch.
+		{
+			ref:            "feature/foo",
+			wantLocalRef:   BranchPrefix + "feature/foo",
+			wantRemoteRef:  remotePrefix + "feature/foo",
+			wantRemoteHash: featureHash,
+		},
+		// Full remote tracking ref for that branch.
+		{
+			ref:            remotePrefix + "feature/foo",
+			wantLocalRef:   remotePrefix + "feature/foo",
+			wantRemoteRef:  remotePrefix + "feature/foo",
+			wantRemoteHash: featureHash,
+		},
+		// A tracking ref with no local refs/heads counterpart resolves via
+		// the remote-tracking candidate (second in the short-name list).
+		{
+			ref:            "remote-only",
+			wantLocalRef:   remotePrefix + "remote-only",
+			wantRemoteRef:  remotePrefix + "remote-only",
+			wantRemoteHash: remoteOnlyHash,
+		},
+		// Non-existent refs must yield ErrInvalidReference, not a storage error.
+		{ref: "no-such-branch", wantErr: ErrInvalidReference},
+		{ref: BranchPrefix + "no-such", wantErr: ErrInvalidReference},
+		{ref: TagPrefix + "no-such", wantErr: ErrInvalidReference},
+		{ref: remotePrefix + "no-such", wantErr: ErrInvalidReference},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.ref, func(t *testing.T) {
+			refSet, err := GetReferenceSet(clonedRepo, tc.ref)
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected error %v, got: %v", tc.wantErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if refSet.LocalRef.String() != tc.wantLocalRef {
+				t.Errorf("LocalRef:    got %q, want %q", refSet.LocalRef, tc.wantLocalRef)
+			}
+
+			if refSet.RemoteRef.String() != tc.wantRemoteRef {
+				t.Errorf("RemoteRef:   got %q, want %q", refSet.RemoteRef, tc.wantRemoteRef)
+			}
+
+			if tc.wantRemoteHash != plumbing.ZeroHash && refSet.RemoteHash != tc.wantRemoteHash {
+				t.Errorf("RemoteHash:  got %s, want %s", refSet.RemoteHash, tc.wantRemoteHash)
+			}
+
+			if tc.wantRemoteHash == plumbing.ZeroHash && refSet.RemoteHash != plumbing.ZeroHash {
+				t.Errorf("RemoteHash:  expected zero hash, got %s", refSet.RemoteHash)
+			}
+		})
+	}
+}
+
+// TestGetReferenceSet_UnsafeNames verifies that reference names that cannot be
+// stored safely (escaping, empty, containing a backslash, or single-level
+// non-pseudo-ref names) return ErrInvalidReference rather than surfacing the
+// go-git storage-layer validation error. Callers treat non-ErrInvalidReference
+// errors as transient failures and would otherwise retry or trigger a repair.
+func TestGetReferenceSet_UnsafeNames(t *testing.T) {
+	repo, err := gogit.PlainInit(t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+
+	unsafeRefs := []string{
+		"",
+		"..",
+		"../../config",
+		"refs/heads/..",
+		"refs/heads/../../config",
+		"refs/",
+		"a\\b",
+		"config",
+	}
+
+	for _, ref := range unsafeRefs {
+		t.Run(ref, func(t *testing.T) {
+			_, err := GetReferenceSet(repo, ref)
+			if !errors.Is(err, ErrInvalidReference) {
+				t.Fatalf("expected ErrInvalidReference for %q, got: %v", ref, err)
+			}
+		})
+	}
+}

--- a/internal/git/repair_test.go
+++ b/internal/git/repair_test.go
@@ -276,6 +276,37 @@ func TestUpdateRepository_BranchMissingOnRemote_SkipsRepair(t *testing.T) {
 	}
 }
 
+// GetReferenceSet must classify names that cannot be stored as a reference
+// (escaping, empty, or containing a backslash) as ErrInvalidReference rather
+// than surfacing the go-git storage-layer validation error, which callers would
+// otherwise treat as a transient failure and retry or trigger a repair for.
+func TestGetReferenceSet_UnsafeNames(t *testing.T) {
+	repo, err := gogit.PlainInit(t.TempDir(), false)
+	if err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+
+	unsafeRefs := []string{
+		"",
+		"..",
+		"../../config",
+		"refs/heads/..",
+		"refs/heads/../../config",
+		"refs/",
+		"a\\b",
+		"config",
+	}
+
+	for _, ref := range unsafeRefs {
+		t.Run(ref, func(t *testing.T) {
+			_, err := GetReferenceSet(repo, ref)
+			if !errors.Is(err, ErrInvalidReference) {
+				t.Fatalf("expected ErrInvalidReference for %q, got: %v", ref, err)
+			}
+		})
+	}
+}
+
 func TestRemoteRefExists(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/git/repair_test.go
+++ b/internal/git/repair_test.go
@@ -276,37 +276,6 @@ func TestUpdateRepository_BranchMissingOnRemote_SkipsRepair(t *testing.T) {
 	}
 }
 
-// GetReferenceSet must classify names that cannot be stored as a reference
-// (escaping, empty, or containing a backslash) as ErrInvalidReference rather
-// than surfacing the go-git storage-layer validation error, which callers would
-// otherwise treat as a transient failure and retry or trigger a repair for.
-func TestGetReferenceSet_UnsafeNames(t *testing.T) {
-	repo, err := gogit.PlainInit(t.TempDir(), false)
-	if err != nil {
-		t.Fatalf("init repo: %v", err)
-	}
-
-	unsafeRefs := []string{
-		"",
-		"..",
-		"../../config",
-		"refs/heads/..",
-		"refs/heads/../../config",
-		"refs/",
-		"a\\b",
-		"config",
-	}
-
-	for _, ref := range unsafeRefs {
-		t.Run(ref, func(t *testing.T) {
-			_, err := GetReferenceSet(repo, ref)
-			if !errors.Is(err, ErrInvalidReference) {
-				t.Fatalf("expected ErrInvalidReference for %q, got: %v", ref, err)
-			}
-		})
-	}
-}
-
 func TestRemoteRefExists(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
handle unsafe reference names in GetReferenceSet to return ErrInvalidReference