### PR TITLE
feat(job-scheduling): implement service stop/start during scheduled job execution

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1345,6 +1345,10 @@ func StopProject(ctx context.Context, dockerCli command.Cli, projectName string,
 // Containers are stopped directly via the Docker API (instead of compose Stop
 // with a services filter) to ensure only explicitly targeted services are
 // affected, without implicit dependency traversal.
+//
+// This is best-effort: if stopping one container fails, the remaining
+// containers are still attempted, and all failures are aggregated into the
+// returned error.
 func StopProjectServices(ctx context.Context, dockerCli command.Cli, projectName string, services []string, timeout time.Duration) error {
 	if len(services) == 0 {
 		return nil
@@ -1367,6 +1371,8 @@ func StopProjectServices(ctx context.Context, dockerCli command.Cli, projectName
 		stopOpts.Timeout = &timeoutSecs
 	}
 
+	var errs []string
+
 	for _, c := range containers {
 		svcName := c.Labels[api.ServiceLabel]
 		if _, ok := serviceSet[svcName]; !ok {
@@ -1378,8 +1384,12 @@ func StopProjectServices(ctx context.Context, dockerCli command.Cli, projectName
 		}
 
 		if _, err := dockerCli.Client().ContainerStop(ctx, c.ID, stopOpts); err != nil {
-			return fmt.Errorf("failed to stop container %s (service %q): %w", c.ID[:12], svcName, err)
+			errs = append(errs, fmt.Sprintf("container %s (service %q): %v", c.ID[:12], svcName, err))
 		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to stop %d container(s): %s", len(errs), strings.Join(errs, "; "))
 	}
 
 	return nil
@@ -1392,7 +1402,11 @@ func StopProjectServices(ctx context.Context, dockerCli command.Cli, projectName
 // Note: the compose Start API ignores StartOptions.Services, so containers are
 // looked up directly by the com.docker.compose.project and com.docker.compose.service
 // labels and started individually.
-func StartProjectServices(ctx context.Context, dockerCli command.Cli, projectName string, services []string, timeout time.Duration) error {
+//
+// This is best-effort: if starting one container fails, the remaining
+// containers are still attempted, and all failures are aggregated into the
+// returned error.
+func StartProjectServices(ctx context.Context, dockerCli command.Cli, projectName string, services []string) error {
 	if len(services) == 0 {
 		return nil
 	}
@@ -1407,6 +1421,8 @@ func StartProjectServices(ctx context.Context, dockerCli command.Cli, projectNam
 		return fmt.Errorf("failed to list containers for project %q: %w", projectName, err)
 	}
 
+	var errs []string
+
 	for _, c := range containers {
 		svcName := c.Labels[api.ServiceLabel]
 		if _, ok := serviceSet[svcName]; !ok {
@@ -1414,11 +1430,13 @@ func StartProjectServices(ctx context.Context, dockerCli command.Cli, projectNam
 		}
 
 		if _, err := dockerCli.Client().ContainerStart(ctx, c.ID, client.ContainerStartOptions{}); err != nil {
-			return fmt.Errorf("failed to start container %s (service %q): %w", c.ID[:12], svcName, err)
+			errs = append(errs, fmt.Sprintf("container %s (service %q): %v", c.ID[:12], svcName, err))
 		}
 	}
 
-	_ = timeout // reserved for future health-check polling
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to start %d container(s): %s", len(errs), strings.Join(errs, "; "))
+	}
 
 	return nil
 }

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1338,6 +1338,91 @@ func StopProject(ctx context.Context, dockerCli command.Cli, projectName string,
 	})
 }
 
+// StopProjectServices stops specific named services within a compose project.
+// Services are identified by their service name as declared in the compose file
+// (the map key under `services:`), not by container_name.
+//
+// Containers are stopped directly via the Docker API (instead of compose Stop
+// with a services filter) to ensure only explicitly targeted services are
+// affected, without implicit dependency traversal.
+func StopProjectServices(ctx context.Context, dockerCli command.Cli, projectName string, services []string, timeout time.Duration) error {
+	if len(services) == 0 {
+		return nil
+	}
+
+	serviceSet := make(map[string]struct{}, len(services))
+	for _, s := range services {
+		serviceSet[s] = struct{}{}
+	}
+
+	containers, err := GetLabeledContainers(ctx, dockerCli.Client(), api.ProjectLabel, projectName, true)
+	if err != nil {
+		return fmt.Errorf("failed to list containers for project %q: %w", projectName, err)
+	}
+
+	timeoutSecs := int(timeout.Seconds())
+
+	stopOpts := client.ContainerStopOptions{}
+	if timeoutSecs > 0 {
+		stopOpts.Timeout = &timeoutSecs
+	}
+
+	for _, c := range containers {
+		svcName := c.Labels[api.ServiceLabel]
+		if _, ok := serviceSet[svcName]; !ok {
+			continue
+		}
+
+		if string(c.State) != "running" {
+			continue
+		}
+
+		if _, err := dockerCli.Client().ContainerStop(ctx, c.ID, stopOpts); err != nil {
+			return fmt.Errorf("failed to stop container %s (service %q): %w", c.ID[:12], svcName, err)
+		}
+	}
+
+	return nil
+}
+
+// StartProjectServices starts specific named services within a compose project.
+// Services are identified by their service name as declared in the compose file
+// (the map key under `services:`), not by container_name.
+//
+// Note: the compose Start API ignores StartOptions.Services, so containers are
+// looked up directly by the com.docker.compose.project and com.docker.compose.service
+// labels and started individually.
+func StartProjectServices(ctx context.Context, dockerCli command.Cli, projectName string, services []string, timeout time.Duration) error {
+	if len(services) == 0 {
+		return nil
+	}
+
+	serviceSet := make(map[string]struct{}, len(services))
+	for _, s := range services {
+		serviceSet[s] = struct{}{}
+	}
+
+	containers, err := GetLabeledContainers(ctx, dockerCli.Client(), api.ProjectLabel, projectName, true)
+	if err != nil {
+		return fmt.Errorf("failed to list containers for project %q: %w", projectName, err)
+	}
+
+	for _, c := range containers {
+		svcName := c.Labels[api.ServiceLabel]
+		if _, ok := serviceSet[svcName]; !ok {
+			continue
+		}
+
+		if _, err := dockerCli.Client().ContainerStart(ctx, c.ID, client.ContainerStartOptions{}); err != nil {
+			return fmt.Errorf("failed to start container %s (service %q): %w", c.ID[:12], svcName, err)
+		}
+	}
+
+	_ = timeout // reserved for future health-check polling
+
+	return nil
+}
+
 // StartProject starts all services in the specified project.
 func StartProject(ctx context.Context, dockerCli command.Cli, projectName string, timeout time.Duration) error {
 	service, err := compose.NewComposeService(dockerCli)

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -2059,7 +2059,7 @@ func TestStopAndStartProjectServices(t *testing.T) {
 	assertServiceState("db", "exited")
 	assertServiceState("app", "running")
 
-	if err = StartProjectServices(ctx, dockerCli, stackName, []string{"db"}, timeout); err != nil {
+	if err = StartProjectServices(ctx, dockerCli, stackName, []string{"db"}); err != nil {
 		t.Fatalf("failed to start project service: %v", err)
 	}
 
@@ -2148,7 +2148,7 @@ func TestStopAndStartProjectServices_SchedulerSequence_WithDependsOn(t *testing.
 	t.Log("Restarting db service to simulate scheduler post-run hook")
 
 	// 3) Scheduler post-run hook: restart selected services.
-	if err = StartProjectServices(ctx, dockerCli, stackName, []string{"db"}, timeout); err != nil {
+	if err = StartProjectServices(ctx, dockerCli, stackName, []string{"db"}); err != nil {
 		t.Fatalf("failed to start project service: %v", err)
 	}
 

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -1990,6 +1990,172 @@ func TestStartProject(t *testing.T) {
 	}
 }
 
+func TestStopAndStartProjectServices(t *testing.T) {
+	ctx := context.Background()
+
+	const composeYAML = `services:
+  app:
+    image: nginx:latest
+  db:
+    image: nginx:latest
+`
+
+	stack := test.ComposeUp(ctx, t, test.WithYAML(composeYAML))
+
+	c, err := app.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dockerCli, err := CreateDockerCli(c.DockerQuietDeploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stackName := stack.Name
+	timeout := 30 * time.Second
+
+	assertServiceState := func(serviceName, wantState string) {
+		t.Helper()
+
+		err = retry.New(
+			retry.Attempts(20),
+			retry.Delay(500*time.Millisecond),
+			retry.DelayType(retry.FixedDelay),
+		).Do(func() error {
+			containers, getErr := GetProjectContainers(ctx, dockerCli, stackName)
+			if getErr != nil {
+				return getErr
+			}
+
+			foundServices := make([]string, 0, len(containers))
+
+			for _, cont := range containers {
+				currService := cont.Labels[api.ServiceLabel]
+
+				foundServices = append(foundServices, fmt.Sprintf("%s:%s", currService, cont.State))
+				if currService != serviceName {
+					continue
+				}
+
+				if string(cont.State) == wantState {
+					return nil
+				}
+
+				return fmt.Errorf("service %q state=%q want=%q", serviceName, cont.State, wantState)
+			}
+
+			return fmt.Errorf("service %q container not found (have: %v)", serviceName, foundServices)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err = StopProjectServices(ctx, dockerCli, stackName, []string{"db"}, timeout); err != nil {
+		t.Fatalf("failed to stop project service: %v", err)
+	}
+
+	assertServiceState("db", "exited")
+	assertServiceState("app", "running")
+
+	if err = StartProjectServices(ctx, dockerCli, stackName, []string{"db"}, timeout); err != nil {
+		t.Fatalf("failed to start project service: %v", err)
+	}
+
+	assertServiceState("db", "running")
+	assertServiceState("app", "running")
+}
+
+func TestStopAndStartProjectServices_SchedulerSequence_WithDependsOn(t *testing.T) {
+	ctx := context.Background()
+
+	const composeYAML = `services:
+  db:
+    image: nginx:latest
+  app:
+    image: nginx:latest
+    depends_on:
+      db:
+        condition: service_started
+`
+
+	stack := test.ComposeUp(ctx, t, test.WithYAML(composeYAML))
+
+	c, err := app.GetConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dockerCli, err := CreateDockerCli(c.DockerQuietDeploy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stackName := stack.Name
+	timeout := 30 * time.Second
+
+	assertServiceState := func(serviceName, wantState string) {
+		t.Helper()
+
+		err = retry.New(
+			retry.Attempts(20),
+			retry.Delay(500*time.Millisecond),
+			retry.DelayType(retry.FixedDelay),
+		).Do(func() error {
+			containers, getErr := GetProjectContainers(ctx, dockerCli, stackName)
+			if getErr != nil {
+				return getErr
+			}
+
+			foundServices := make([]string, 0, len(containers))
+
+			for _, cont := range containers {
+				currService := cont.Labels[api.ServiceLabel]
+
+				foundServices = append(foundServices, fmt.Sprintf("%s:%s", currService, cont.State))
+				if currService != serviceName {
+					continue
+				}
+
+				if string(cont.State) == wantState {
+					return nil
+				}
+
+				return fmt.Errorf("service %q state=%q want=%q", serviceName, cont.State, wantState)
+			}
+
+			return fmt.Errorf("service %q container not found (have: %v)", serviceName, foundServices)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Log("Stopping db service to simulate scheduler pre-run hook")
+
+	// 1) Scheduler pre-run hook: stop selected services (db).
+	if err = StopProjectServices(ctx, dockerCli, stackName, []string{"db"}, timeout); err != nil {
+		t.Fatalf("failed to stop project service: %v", err)
+	}
+
+	t.Log("Check service states")
+
+	// 2) During job run: db remains stopped, dependent app remains untouched.
+	assertServiceState("db", "exited")
+	assertServiceState("app", "running")
+
+	t.Log("Restarting db service to simulate scheduler post-run hook")
+
+	// 3) Scheduler post-run hook: restart selected services.
+	if err = StartProjectServices(ctx, dockerCli, stackName, []string{"db"}, timeout); err != nil {
+		t.Fatalf("failed to start project service: %v", err)
+	}
+
+	assertServiceState("db", "running")
+	assertServiceState("app", "running")
+}
+
 func TestRemoveProject(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/docker/container_run.go
+++ b/internal/docker/container_run.go
@@ -107,7 +107,13 @@ func RunContainerOneOffFromExisting(ctx context.Context, apiClient client.APICli
 	// (auto-removed) container: if ContainerStart is called first the container
 	// may finish and be removed before ContainerWait registers, causing a
 	// "No such container" error.
-	waitResult := apiClient.ContainerWait(ctx, createResult.ID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNotRunning})
+	//
+	// Use WaitConditionNextExit ("next-exit"), NOT WaitConditionNotRunning
+	// ("not-running"). A newly-created container is already "not running" (it
+	// is in the "created" state), so WaitConditionNotRunning would be satisfied
+	// immediately and ContainerWait would return before the container even
+	// starts, causing the caller to think the job has completed.
+	waitResult := apiClient.ContainerWait(ctx, createResult.ID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNextExit})
 
 	if _, err = apiClient.ContainerStart(ctx, createResult.ID, client.ContainerStartOptions{}); err != nil {
 		return fmt.Errorf("start one-off container %s: %w", createResult.ID, err)

--- a/internal/docker/container_run.go
+++ b/internal/docker/container_run.go
@@ -26,7 +26,7 @@ type ContainerExitError struct {
 }
 
 func (e *ContainerExitError) Error() string {
-	return fmt.Sprintf("one-off container %s exited with status %d", e.ContainerID, e.ExitCode)
+	return fmt.Sprintf("container %s exited with status %d", e.ContainerID, e.ExitCode)
 }
 
 func RestartContainer(ctx context.Context, apiClient client.APIClient, containerID string) error {

--- a/internal/docker/container_run.go
+++ b/internal/docker/container_run.go
@@ -49,6 +49,67 @@ func RestartContainer(ctx context.Context, apiClient client.APIClient, container
 	return nil
 }
 
+// RestartContainerAndWait starts or restarts the container (identically to
+// RestartContainer) and then blocks until the container exits. This is the
+// blocking variant of RestartContainer used when stop_services requires
+// knowing when the job has finished.
+//
+// For a stopped container the wait is subscribed BEFORE starting to avoid
+// racing with a fast-exiting container. For a running container,
+// ContainerRestart is called first (it blocks until the container is running
+// again after the restart cycle), and then the wait is subscribed.
+func RestartContainerAndWait(ctx context.Context, apiClient client.APIClient, containerID string) error {
+	inspectResult, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		return fmt.Errorf("inspect container %s: %w", containerID, err)
+	}
+
+	if getContainerRunAction(inspectResult.Container) == containerRunActionStart {
+		// Container is stopped. Subscribe to wait BEFORE starting so we don't
+		// race with a fast-exiting container.
+		waitResult := apiClient.ContainerWait(ctx, containerID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNextExit})
+
+		if _, err = apiClient.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
+			return fmt.Errorf("start container %s: %w", containerID, err)
+		}
+
+		return awaitContainerExit(waitResult, containerID)
+	}
+
+	// Container is running. ContainerRestart stops and starts it in one API
+	// call; subscribing to WaitConditionNextExit BEFORE the restart would
+	// fire on the stop step (not the eventual job completion). Restart first
+	// — which blocks until the container is running again — then subscribe.
+	if _, err = apiClient.ContainerRestart(ctx, containerID, client.ContainerRestartOptions{}); err != nil {
+		return fmt.Errorf("restart container %s: %w", containerID, err)
+	}
+
+	waitResult := apiClient.ContainerWait(ctx, containerID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNextExit})
+
+	return awaitContainerExit(waitResult, containerID)
+}
+
+// awaitContainerExit waits for a ContainerWait response and translates it into
+// an error, returning nil on a clean zero-exit.
+func awaitContainerExit(waitResult client.ContainerWaitResult, containerID string) error {
+	select {
+	case waitErr := <-waitResult.Error:
+		if waitErr != nil {
+			return fmt.Errorf("wait for container %s: %w", containerID, waitErr)
+		}
+	case waitStatus := <-waitResult.Result:
+		if waitStatus.Error != nil && waitStatus.Error.Message != "" {
+			return fmt.Errorf("container %s failed: %s", containerID, waitStatus.Error.Message)
+		}
+
+		if waitStatus.StatusCode != 0 {
+			return &ContainerExitError{ContainerID: containerID, ExitCode: int(waitStatus.StatusCode)}
+		}
+	}
+
+	return nil
+}
+
 func getContainerRunAction(inspectResult containerTypes.InspectResponse) containerRunAction {
 	if inspectResult.State == nil {
 		return containerRunActionRestart
@@ -104,35 +165,13 @@ func RunContainerOneOffFromExisting(ctx context.Context, apiClient client.APICli
 	}
 
 	// Subscribe to wait BEFORE starting so we don't race with a fast-exiting
-	// (auto-removed) container: if ContainerStart is called first the container
-	// may finish and be removed before ContainerWait registers, causing a
-	// "No such container" error.
-	//
-	// Use WaitConditionNextExit ("next-exit"), NOT WaitConditionNotRunning
-	// ("not-running"). A newly-created container is already "not running" (it
-	// is in the "created" state), so WaitConditionNotRunning would be satisfied
-	// immediately and ContainerWait would return before the container even
-	// starts, causing the caller to think the job has completed.
+	// (auto-removed) container. See RestartContainerAndWait for the reasoning
+	// behind WaitConditionNextExit vs WaitConditionNotRunning.
 	waitResult := apiClient.ContainerWait(ctx, createResult.ID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNextExit})
 
 	if _, err = apiClient.ContainerStart(ctx, createResult.ID, client.ContainerStartOptions{}); err != nil {
 		return fmt.Errorf("start one-off container %s: %w", createResult.ID, err)
 	}
 
-	select {
-	case waitErr := <-waitResult.Error:
-		if waitErr != nil {
-			return fmt.Errorf("wait for one-off container %s: %w", createResult.ID, waitErr)
-		}
-	case waitStatus := <-waitResult.Result:
-		if waitStatus.Error != nil && waitStatus.Error.Message != "" {
-			return fmt.Errorf("one-off container %s failed: %s", createResult.ID, waitStatus.Error.Message)
-		}
-
-		if waitStatus.StatusCode != 0 {
-			return &ContainerExitError{ContainerID: createResult.ID, ExitCode: int(waitStatus.StatusCode)}
-		}
-	}
-
-	return nil
+	return awaitContainerExit(waitResult, createResult.ID)
 }

--- a/internal/docker/container_run_test.go
+++ b/internal/docker/container_run_test.go
@@ -1,9 +1,18 @@
 package docker
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
 	"testing"
+	"time"
 
 	containerTypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+
+	"github.com/kimdre/doco-cd/internal/test"
 )
 
 func TestGetContainerRunAction(t *testing.T) {
@@ -58,5 +67,194 @@ func TestGetContainerRunAction(t *testing.T) {
 				t.Fatalf("getContainerRunAction() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// containerWaitTestImage is the image used for integration tests that need a
+// minimal shell with a sleep command.
+const containerWaitTestImage = "alpine:latest"
+
+// setupContainerWaitTest creates a Docker CLI and pulls the test image. It
+// skips the test if Docker is unavailable or the image cannot be pulled (e.g.
+// no network in CI).
+func setupContainerWaitTest(t *testing.T) client.APIClient {
+	t.Helper()
+
+	dockerCli, err := test.NewDockerCli()
+	if err != nil {
+		t.Skipf("docker unavailable: %v", err)
+	}
+
+	apiClient := dockerCli.Client()
+
+	ctx := context.Background()
+
+	reader, err := apiClient.ImagePull(ctx, containerWaitTestImage, client.ImagePullOptions{})
+	if err != nil {
+		t.Skipf("cannot pull %s: %v", containerWaitTestImage, err)
+	}
+
+	_, _ = io.Copy(io.Discard, reader)
+	_ = reader.Close()
+
+	return apiClient
+}
+
+// createTestContainer creates a container (not started) with the given command
+// and registers cleanup. Returns the container ID.
+func createTestContainer(ctx context.Context, t *testing.T, apiClient client.APIClient, cmd []string) string { //nolint:contextcheck
+	t.Helper()
+
+	name := fmt.Sprintf("doco-test-%s-%d", test.ConvertTestName(t.Name()), time.Now().UnixNano())
+
+	result, err := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Config: &containerTypes.Config{
+			Image: containerWaitTestImage,
+			Cmd:   cmd,
+		},
+		Name: name,
+	})
+	if err != nil {
+		t.Fatalf("ContainerCreate: %v", err)
+	}
+
+	cleanupCtx := context.Background()
+
+	t.Cleanup(func() {
+		_, _ = apiClient.ContainerRemove(cleanupCtx, result.ID, client.ContainerRemoveOptions{Force: true})
+	})
+
+	return result.ID
+}
+
+// TestRunContainerOneOffFromExisting_WaitsForCompletion verifies that
+// RunContainerOneOffFromExisting blocks until the spawned container exits,
+// rather than returning as soon as the container is created (the
+// WaitConditionNotRunning regression).
+func TestRunContainerOneOffFromExisting_WaitsForCompletion(t *testing.T) {
+	ctx := context.Background()
+	apiClient := setupContainerWaitTest(t)
+
+	const sleepSeconds = 1
+
+	// Create a source container (not started) that sleeps for sleepSeconds.
+	srcID := createTestContainer(ctx, t, apiClient, []string{"sleep", strconv.Itoa(sleepSeconds)})
+
+	start := time.Now()
+
+	if err := RunContainerOneOffFromExisting(ctx, apiClient, srcID); err != nil {
+		t.Fatalf("RunContainerOneOffFromExisting: %v", err)
+	}
+
+	elapsed := time.Since(start)
+
+	if elapsed < sleepSeconds*time.Second {
+		t.Fatalf("RunContainerOneOffFromExisting returned too early: elapsed=%s, want >= %ds (WaitConditionNextExit regression?)", elapsed, sleepSeconds)
+	}
+}
+
+// TestRunContainerOneOffFromExisting_NonZeroExit verifies that a non-zero exit
+// code from the spawned container is surfaced as a ContainerExitError.
+func TestRunContainerOneOffFromExisting_NonZeroExit(t *testing.T) {
+	ctx := context.Background()
+	apiClient := setupContainerWaitTest(t)
+
+	srcID := createTestContainer(ctx, t, apiClient, []string{"sh", "-c", "exit 42"})
+
+	err := RunContainerOneOffFromExisting(ctx, apiClient, srcID)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit, got nil")
+	}
+
+	var exitErr *ContainerExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ContainerExitError, got %T: %v", err, err)
+	}
+
+	if exitErr.ExitCode != 42 {
+		t.Fatalf("expected exit code 42, got %d", exitErr.ExitCode)
+	}
+}
+
+// TestRestartContainerAndWait_StoppedContainer verifies that
+// RestartContainerAndWait blocks until a stopped (not-yet-started) container
+// exits after being started.
+func TestRestartContainerAndWait_StoppedContainer(t *testing.T) {
+	ctx := context.Background()
+	apiClient := setupContainerWaitTest(t)
+
+	const sleepSeconds = 1
+
+	containerID := createTestContainer(ctx, t, apiClient, []string{"sleep", strconv.Itoa(sleepSeconds)})
+
+	start := time.Now()
+
+	if err := RestartContainerAndWait(ctx, apiClient, containerID); err != nil {
+		t.Fatalf("RestartContainerAndWait: %v", err)
+	}
+
+	elapsed := time.Since(start)
+
+	if elapsed < sleepSeconds*time.Second {
+		t.Fatalf("RestartContainerAndWait returned too early: elapsed=%s, want >= %ds", elapsed, sleepSeconds)
+	}
+}
+
+// TestRestartContainerAndWait_RunningContainer verifies that
+// RestartContainerAndWait waits for the container to complete its run after
+// being restarted (i.e. it does not fire on the stop step of the restart cycle).
+func TestRestartContainerAndWait_RunningContainer(t *testing.T) {
+	ctx := context.Background()
+	apiClient := setupContainerWaitTest(t)
+
+	// Use a sleep long enough that the container is definitely still running
+	// when RestartContainerAndWait is called. After restart it will sleep again
+	// and the function must wait for that second run to complete.
+	const sleepSeconds = 2
+
+	containerID := createTestContainer(ctx, t, apiClient, []string{"sleep", strconv.Itoa(sleepSeconds)})
+
+	// Start the container so it is in "running" state.
+	if _, err := apiClient.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
+		t.Fatalf("ContainerStart: %v", err)
+	}
+
+	start := time.Now()
+
+	// Container is running. RestartContainerAndWait should: restart → wait for
+	// the post-restart run to finish.
+	if err := RestartContainerAndWait(ctx, apiClient, containerID); err != nil {
+		t.Fatalf("RestartContainerAndWait: %v", err)
+	}
+
+	elapsed := time.Since(start)
+
+	// The restart cycle adds some overhead but the post-restart sleep is the
+	// dominant component; require at least sleepSeconds to confirm we waited.
+	if elapsed < sleepSeconds*time.Second {
+		t.Fatalf("RestartContainerAndWait returned too early: elapsed=%s, want >= %ds", elapsed, sleepSeconds)
+	}
+}
+
+// TestRestartContainerAndWait_NonZeroExit verifies that a non-zero exit code
+// is surfaced as a ContainerExitError in the restart-and-wait flow.
+func TestRestartContainerAndWait_NonZeroExit(t *testing.T) {
+	ctx := context.Background()
+	apiClient := setupContainerWaitTest(t)
+
+	containerID := createTestContainer(ctx, t, apiClient, []string{"sh", "-c", "exit 7"})
+
+	err := RestartContainerAndWait(ctx, apiClient, containerID)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit, got nil")
+	}
+
+	var exitErr *ContainerExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ContainerExitError, got %T: %v", err, err)
+	}
+
+	if exitErr.ExitCode != 7 {
+		t.Fatalf("expected exit code 7, got %d", exitErr.ExitCode)
 	}
 }

--- a/internal/docker/job_schedule.go
+++ b/internal/docker/job_schedule.go
@@ -176,20 +176,6 @@ func ParseJobScheduleLabels(labels map[string]string, log ...*slog.Logger) (JobS
 			return cfg, false, fmt.Errorf("invalid %s label value %q: %w", docoCDJobLabelNames.JobStopServices, stopRaw, parseErr)
 		}
 
-		// Stopped services are restored as soon as the job execution call
-		// returns, so the stop window is only meaningful when doco-cd can
-		// observe job completion. Only one_off waits for the job to finish
-		// (ContainerWait / WaitOnServices); restart mode returns as soon as
-		// the restart has been issued, which would restore the stopped
-		// services while the job is still running.
-		if len(refs) > 0 && cfg.ExecutionMode != JobExecutionModeOneOff {
-			return cfg, false, fmt.Errorf(
-				"%s requires %s=%q (got %q): doco-cd cannot detect job completion in %q mode, so stopped services would be restarted before the job finishes",
-				docoCDJobLabelNames.JobStopServices, docoCDJobLabelNames.JobExecutionMode,
-				JobExecutionModeOneOff, cfg.ExecutionMode, cfg.ExecutionMode,
-			)
-		}
-
 		cfg.StopServices = refs
 	}
 

--- a/internal/docker/job_schedule.go
+++ b/internal/docker/job_schedule.go
@@ -176,6 +176,20 @@ func ParseJobScheduleLabels(labels map[string]string, log ...*slog.Logger) (JobS
 			return cfg, false, fmt.Errorf("invalid %s label value %q: %w", docoCDJobLabelNames.JobStopServices, stopRaw, parseErr)
 		}
 
+		// Stopped services are restored as soon as the job execution call
+		// returns, so the stop window is only meaningful when doco-cd can
+		// observe job completion. Only one_off waits for the job to finish
+		// (ContainerWait / WaitOnServices); restart mode returns as soon as
+		// the restart has been issued, which would restore the stopped
+		// services while the job is still running.
+		if len(refs) > 0 && cfg.ExecutionMode != JobExecutionModeOneOff {
+			return cfg, false, fmt.Errorf(
+				"%s requires %s=%q (got %q): doco-cd cannot detect job completion in %q mode, so stopped services would be restarted before the job finishes",
+				docoCDJobLabelNames.JobStopServices, docoCDJobLabelNames.JobExecutionMode,
+				JobExecutionModeOneOff, cfg.ExecutionMode, cfg.ExecutionMode,
+			)
+		}
+
 		cfg.StopServices = refs
 	}
 

--- a/internal/docker/job_schedule.go
+++ b/internal/docker/job_schedule.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/compose/v5/pkg/api"
 	"github.com/go-co-op/gocron/v2"
 )
 
@@ -177,25 +176,36 @@ func ParseJobScheduleLabels(labels map[string]string, log ...*slog.Logger) (JobS
 			return cfg, false, fmt.Errorf("invalid %s label value %q: %w", docoCDJobLabelNames.JobStopServices, stopRaw, parseErr)
 		}
 
-		// Validate that the job does not list itself.
-		jobProject := strings.TrimSpace(labels[api.ProjectLabel])
-		jobService := strings.TrimSpace(labels[api.ServiceLabel])
-
-		for _, ref := range refs {
-			resolvedProject := ref.Project
-			if resolvedProject == "" {
-				resolvedProject = jobProject
-			}
-
-			if resolvedProject == jobProject && ref.Service == jobService {
-				return cfg, false, fmt.Errorf("%s: a job cannot stop itself (%s/%s)", docoCDJobLabelNames.JobStopServices, resolvedProject, ref.Service)
-			}
-		}
-
 		cfg.StopServices = refs
 	}
 
 	return cfg, true, nil
+}
+
+// ValidateStopServicesSelfReference returns an error if refs contains an entry
+// that resolves to the job's own project/stack and service name, which would
+// cause the scheduler to stop the job's own service right before running it.
+//
+// This cannot be checked inside ParseJobScheduleLabels because it only has
+// access to the raw label map: standalone/compose containers always carry
+// com.docker.compose.project/com.docker.compose.service labels, but Swarm
+// services deployed by doco-cd do not carry those labels on the task spec, so
+// the job's own project/service identity must be resolved by the caller
+// (which knows how to derive it for both compose and Swarm jobs) and passed
+// in explicitly.
+func ValidateStopServicesSelfReference(project, service string, refs []StopServiceRef) error {
+	for _, ref := range refs {
+		resolvedProject := ref.Project
+		if resolvedProject == "" {
+			resolvedProject = project
+		}
+
+		if resolvedProject == project && ref.Service == service {
+			return fmt.Errorf("%s: a job cannot stop itself (%s/%s)", docoCDJobLabelNames.JobStopServices, resolvedProject, ref.Service)
+		}
+	}
+
+	return nil
 }
 
 // parseStopServiceRefs parses a comma-separated list of "project/service" or "service"

--- a/internal/docker/job_schedule.go
+++ b/internal/docker/job_schedule.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/go-co-op/gocron/v2"
 )
 
@@ -39,6 +40,24 @@ type JobScheduleConfig struct {
 	ExecutionMode JobExecutionMode
 	NotifyOn      JobNotifyOn
 	SwarmReplicas uint64
+	StopServices  []StopServiceRef
+}
+
+// StopServiceRef identifies a compose service (or swarm service) to be temporarily
+// stopped before a scheduled job runs and restarted after it completes.
+//
+// In standalone (compose) mode:
+//   - Service is the compose service name as declared in the compose file (the map
+//     key under `services:`). It is always the service name, never the container_name.
+//   - Project identifies the compose project. When empty, the job's own project is used.
+//
+// In swarm mode:
+//   - Service is the short service name as declared in the compose file.
+//   - Project is the stack name. When empty, the job's own stack is used.
+//   - The full swarm service name is resolved as "<project>_<service>".
+type StopServiceRef struct {
+	Project string // empty = same project/stack as the job
+	Service string
 }
 
 func (c JobScheduleConfig) ShouldNotifySuccess() bool {
@@ -152,5 +171,65 @@ func ParseJobScheduleLabels(labels map[string]string, log ...*slog.Logger) (JobS
 		cfg.SwarmReplicas = replicas
 	}
 
+	if stopRaw, ok := labels[docoCDJobLabelNames.JobStopServices]; ok {
+		refs, parseErr := parseStopServiceRefs(stopRaw)
+		if parseErr != nil {
+			return cfg, false, fmt.Errorf("invalid %s label value %q: %w", docoCDJobLabelNames.JobStopServices, stopRaw, parseErr)
+		}
+
+		// Validate that the job does not list itself.
+		jobProject := strings.TrimSpace(labels[api.ProjectLabel])
+		jobService := strings.TrimSpace(labels[api.ServiceLabel])
+
+		for _, ref := range refs {
+			resolvedProject := ref.Project
+			if resolvedProject == "" {
+				resolvedProject = jobProject
+			}
+
+			if resolvedProject == jobProject && ref.Service == jobService {
+				return cfg, false, fmt.Errorf("%s: a job cannot stop itself (%s/%s)", docoCDJobLabelNames.JobStopServices, resolvedProject, ref.Service)
+			}
+		}
+
+		cfg.StopServices = refs
+	}
+
 	return cfg, true, nil
+}
+
+// parseStopServiceRefs parses a comma-separated list of "project/service" or "service"
+// entries into StopServiceRef values. Empty entries are silently skipped.
+func parseStopServiceRefs(raw string) ([]StopServiceRef, error) {
+	var refs []StopServiceRef
+
+	for entry := range strings.SplitSeq(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		project, service, hasDelimiter := strings.Cut(entry, "/")
+		project = strings.TrimSpace(project)
+		service = strings.TrimSpace(service)
+
+		if service == "" {
+			if hasDelimiter {
+				return nil, fmt.Errorf("entry %q has an empty service name", entry)
+			}
+
+			// No "/" found: the whole entry is the service name, same project.
+			refs = append(refs, StopServiceRef{Service: project})
+
+			continue
+		}
+
+		if project == "" {
+			return nil, fmt.Errorf("entry %q has an empty project name", entry)
+		}
+
+		refs = append(refs, StopServiceRef{Project: project, Service: service})
+	}
+
+	return refs, nil
 }

--- a/internal/docker/job_schedule_test.go
+++ b/internal/docker/job_schedule_test.go
@@ -1,6 +1,11 @@
 package docker
 
-import "testing"
+import (
+	"maps"
+	"testing"
+
+	"github.com/docker/compose/v5/pkg/api"
+)
 
 func TestParseJobScheduleExpression(t *testing.T) {
 	t.Parallel()
@@ -147,4 +152,150 @@ func TestParseJobScheduleLabels_Defaults(t *testing.T) {
 	if cfg.SwarmReplicas != 1 {
 		t.Fatalf("expected default swarm replicas=1, got %d", cfg.SwarmReplicas)
 	}
+}
+
+func TestParseStopServiceRefs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    []StopServiceRef
+		wantErr bool
+	}{
+		{
+			name: "single same-project service",
+			raw:  "db",
+			want: []StopServiceRef{{Service: "db"}},
+		},
+		{
+			name: "multiple same-project services",
+			raw:  "db,cache",
+			want: []StopServiceRef{{Service: "db"}, {Service: "cache"}},
+		},
+		{
+			name: "cross-project service",
+			raw:  "other-project/db",
+			want: []StopServiceRef{{Project: "other-project", Service: "db"}},
+		},
+		{
+			name: "mixed same- and cross-project",
+			raw:  "db,other-project/cache",
+			want: []StopServiceRef{{Service: "db"}, {Project: "other-project", Service: "cache"}},
+		},
+		{
+			name: "whitespace around entries is trimmed",
+			raw:  " db , other/cache ",
+			want: []StopServiceRef{{Service: "db"}, {Project: "other", Service: "cache"}},
+		},
+		{
+			name: "empty entries are skipped",
+			raw:  "db,,cache",
+			want: []StopServiceRef{{Service: "db"}, {Service: "cache"}},
+		},
+		{
+			name:    "missing project name is rejected",
+			raw:     "/db",
+			wantErr: true,
+		},
+		{
+			name:    "missing service name is rejected",
+			raw:     "project/",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseStopServiceRefs(tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseStopServiceRefs(%q) err=%v wantErr=%v", tt.raw, err, tt.wantErr)
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d refs, want %d: %+v", len(got), len(tt.want), got)
+			}
+
+			for i, ref := range got {
+				if ref != tt.want[i] {
+					t.Errorf("ref[%d]: got %+v, want %+v", i, ref, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseJobScheduleLabels_StopServices(t *testing.T) {
+	t.Parallel()
+
+	baseLabels := func(extra map[string]string) map[string]string {
+		m := map[string]string{
+			docoCDJobLabelNames.JobEnabled:  "true",
+			docoCDJobLabelNames.JobSchedule: "0 2 * * *",
+			api.ProjectLabel:                "myproject",
+			api.ServiceLabel:                "backup",
+		}
+		maps.Copy(m, extra)
+
+		return m
+	}
+
+	t.Run("valid same-project services", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
+			docoCDJobLabelNames.JobStopServices: "db,cache",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(cfg.StopServices) != 2 {
+			t.Fatalf("expected 2 stop_services, got %d", len(cfg.StopServices))
+		}
+	})
+
+	t.Run("valid cross-project service", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
+			docoCDJobLabelNames.JobStopServices: "other-project/db",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(cfg.StopServices) != 1 || cfg.StopServices[0].Project != "other-project" {
+			t.Fatalf("unexpected stop_services: %+v", cfg.StopServices)
+		}
+	})
+
+	t.Run("self-reference is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Same project + same service name → should fail.
+		_, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
+			docoCDJobLabelNames.JobStopServices: "backup",
+		}))
+		if err == nil {
+			t.Fatal("expected error for self-reference, got nil")
+		}
+	})
+
+	t.Run("explicit self-reference via project prefix is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
+			docoCDJobLabelNames.JobStopServices: "myproject/backup",
+		}))
+		if err == nil {
+			t.Fatal("expected error for explicit self-reference, got nil")
+		}
+	})
 }

--- a/internal/docker/job_schedule_test.go
+++ b/internal/docker/job_schedule_test.go
@@ -275,27 +275,39 @@ func TestParseJobScheduleLabels_StopServices(t *testing.T) {
 			t.Fatalf("unexpected stop_services: %+v", cfg.StopServices)
 		}
 	})
+}
 
-	t.Run("self-reference is rejected", func(t *testing.T) {
-		t.Parallel()
+func TestValidateStopServicesSelfReference(t *testing.T) {
+	t.Parallel()
 
-		// Same project + same service name → should fail.
-		_, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
-			docoCDJobLabelNames.JobStopServices: "backup",
-		}))
-		if err == nil {
-			t.Fatal("expected error for self-reference, got nil")
-		}
-	})
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "same-project bare self-reference is rejected", raw: "backup", wantErr: true},
+		{name: "explicit self-reference via project prefix is rejected", raw: "myproject/backup", wantErr: true},
+		{name: "different service in same project is allowed", raw: "db", wantErr: false},
+		{name: "different project with same service name is allowed", raw: "other-project/backup", wantErr: false},
+	}
 
-	t.Run("explicit self-reference via project prefix is rejected", func(t *testing.T) {
-		t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		_, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
-			docoCDJobLabelNames.JobStopServices: "myproject/backup",
-		}))
-		if err == nil {
-			t.Fatal("expected error for explicit self-reference, got nil")
-		}
-	})
+			refs, err := parseStopServiceRefs(tt.raw)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+
+			err = ValidateStopServicesSelfReference("myproject", "backup", refs)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected self-reference error, got nil")
+			}
+
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
 }

--- a/internal/docker/job_schedule_test.go
+++ b/internal/docker/job_schedule_test.go
@@ -236,10 +236,11 @@ func TestParseJobScheduleLabels_StopServices(t *testing.T) {
 
 	baseLabels := func(extra map[string]string) map[string]string {
 		m := map[string]string{
-			docoCDJobLabelNames.JobEnabled:  "true",
-			docoCDJobLabelNames.JobSchedule: "0 2 * * *",
-			api.ProjectLabel:                "myproject",
-			api.ServiceLabel:                "backup",
+			docoCDJobLabelNames.JobEnabled:       "true",
+			docoCDJobLabelNames.JobSchedule:      "0 2 * * *",
+			docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
+			api.ProjectLabel:                     "myproject",
+			api.ServiceLabel:                     "backup",
 		}
 		maps.Copy(m, extra)
 
@@ -273,6 +274,51 @@ func TestParseJobScheduleLabels_StopServices(t *testing.T) {
 
 		if len(cfg.StopServices) != 1 || cfg.StopServices[0].Project != "other-project" {
 			t.Fatalf("unexpected stop_services: %+v", cfg.StopServices)
+		}
+	})
+
+	// stop_services restores the stopped services as soon as the job execution
+	// call returns, which is only correct when doco-cd waits for the job to
+	// finish. Only one_off does; restart mode returns immediately.
+	t.Run("restart execution mode is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
+			docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeRestart),
+			docoCDJobLabelNames.JobStopServices:  "db",
+		}))
+		if err == nil {
+			t.Fatal("expected error for stop_services with execution_mode=restart, got nil")
+		}
+	})
+
+	t.Run("default (restart) execution mode is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		labels := baseLabels(map[string]string{
+			docoCDJobLabelNames.JobStopServices: "db",
+		})
+		delete(labels, docoCDJobLabelNames.JobExecutionMode)
+
+		_, _, err := ParseJobScheduleLabels(labels)
+		if err == nil {
+			t.Fatal("expected error for stop_services with default execution_mode, got nil")
+		}
+	})
+
+	t.Run("empty stop_services is allowed with any execution mode", func(t *testing.T) {
+		t.Parallel()
+
+		cfg, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
+			docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeRestart),
+			docoCDJobLabelNames.JobStopServices:  "  ,  ",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(cfg.StopServices) != 0 {
+			t.Fatalf("expected no stop_services, got %+v", cfg.StopServices)
 		}
 	})
 }

--- a/internal/docker/job_schedule_test.go
+++ b/internal/docker/job_schedule_test.go
@@ -277,22 +277,23 @@ func TestParseJobScheduleLabels_StopServices(t *testing.T) {
 		}
 	})
 
-	// stop_services restores the stopped services as soon as the job execution
-	// call returns, which is only correct when doco-cd waits for the job to
-	// finish. Only one_off does; restart mode returns immediately.
-	t.Run("restart execution mode is rejected", func(t *testing.T) {
+	t.Run("restart execution mode is allowed", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
+		cfg, _, err := ParseJobScheduleLabels(baseLabels(map[string]string{
 			docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeRestart),
 			docoCDJobLabelNames.JobStopServices:  "db",
 		}))
-		if err == nil {
-			t.Fatal("expected error for stop_services with execution_mode=restart, got nil")
+		if err != nil {
+			t.Fatalf("unexpected error for stop_services with execution_mode=restart: %v", err)
+		}
+
+		if len(cfg.StopServices) != 1 {
+			t.Fatalf("expected 1 stop_service, got %d", len(cfg.StopServices))
 		}
 	})
 
-	t.Run("default (restart) execution mode is rejected", func(t *testing.T) {
+	t.Run("default (restart) execution mode is allowed", func(t *testing.T) {
 		t.Parallel()
 
 		labels := baseLabels(map[string]string{
@@ -300,9 +301,13 @@ func TestParseJobScheduleLabels_StopServices(t *testing.T) {
 		})
 		delete(labels, docoCDJobLabelNames.JobExecutionMode)
 
-		_, _, err := ParseJobScheduleLabels(labels)
-		if err == nil {
-			t.Fatal("expected error for stop_services with default execution_mode, got nil")
+		cfg, _, err := ParseJobScheduleLabels(labels)
+		if err != nil {
+			t.Fatalf("unexpected error for stop_services with default execution_mode: %v", err)
+		}
+
+		if len(cfg.StopServices) != 1 {
+			t.Fatalf("expected 1 stop_service, got %d", len(cfg.StopServices))
 		}
 	})
 

--- a/internal/docker/job_schedule_validation.go
+++ b/internal/docker/job_schedule_validation.go
@@ -9,13 +9,22 @@ import (
 
 func validateScheduledJobPolicies(project *types.Project, swarmMode bool) error {
 	for serviceName, svc := range project.Services {
-		_, enabled, err := ParseJobScheduleLabels(svc.Labels)
+		cfg, enabled, err := ParseJobScheduleLabels(svc.Labels)
 		if err != nil {
 			return fmt.Errorf("service %s: %w", serviceName, err)
 		}
 
 		if !enabled {
 			continue
+		}
+
+		// Catch self-referencing stop_services at deploy time. The scheduler
+		// repeats this check at run time, but only there can it resolve a job's
+		// own identity from runtime labels; here the project and service names
+		// are known directly, so the user gets an immediate, actionable error
+		// instead of the job silently being dropped by the scheduler later.
+		if err := ValidateStopServicesSelfReference(project.Name, serviceName, cfg.StopServices); err != nil {
+			return fmt.Errorf("service %s: %w", serviceName, err)
 		}
 
 		if swarmMode {

--- a/internal/docker/job_schedule_validation_test.go
+++ b/internal/docker/job_schedule_validation_test.go
@@ -205,7 +205,7 @@ func TestValidateScheduledJobPolicies(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "rejects stop_services with restart execution mode",
+			name:      "allows stop_services with restart execution mode (container/standalone)",
 			swarmMode: false,
 			project: &types.Project{
 				Name: "myproject",
@@ -221,7 +221,7 @@ func TestValidateScheduledJobPolicies(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 

--- a/internal/docker/job_schedule_validation_test.go
+++ b/internal/docker/job_schedule_validation_test.go
@@ -147,6 +147,82 @@ func TestValidateScheduledJobPolicies(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:      "rejects stop_services referencing the job itself",
+			swarmMode: false,
+			project: &types.Project{
+				Name: "myproject",
+				Services: types.Services{
+					"backup": {
+						Name: "backup",
+						Labels: map[string]string{
+							docoCDJobLabelNames.JobEnabled:       "true",
+							docoCDJobLabelNames.JobSchedule:      "0 2 * * *",
+							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
+							docoCDJobLabelNames.JobStopServices:  "db,backup",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "rejects stop_services referencing the job itself via project prefix",
+			swarmMode: false,
+			project: &types.Project{
+				Name: "myproject",
+				Services: types.Services{
+					"backup": {
+						Name: "backup",
+						Labels: map[string]string{
+							docoCDJobLabelNames.JobEnabled:       "true",
+							docoCDJobLabelNames.JobSchedule:      "0 2 * * *",
+							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
+							docoCDJobLabelNames.JobStopServices:  "myproject/backup",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "allows stop_services referencing other services",
+			swarmMode: false,
+			project: &types.Project{
+				Name: "myproject",
+				Services: types.Services{
+					"backup": {
+						Name: "backup",
+						Labels: map[string]string{
+							docoCDJobLabelNames.JobEnabled:       "true",
+							docoCDJobLabelNames.JobSchedule:      "0 2 * * *",
+							docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneOff),
+							docoCDJobLabelNames.JobStopServices:  "db,other-project/cache",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "rejects stop_services with restart execution mode",
+			swarmMode: false,
+			project: &types.Project{
+				Name: "myproject",
+				Services: types.Services{
+					"backup": {
+						Name:    "backup",
+						Restart: "no",
+						Labels: map[string]string{
+							docoCDJobLabelNames.JobEnabled:      "true",
+							docoCDJobLabelNames.JobSchedule:     "0 2 * * *",
+							docoCDJobLabelNames.JobStopServices: "db",
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -94,6 +94,7 @@ var docoCDJobLabelNames = struct {
 	JobRestartReplicas string // Intended replica count for swarm restart-mode jobs deployed at 0 replicas
 	JobLastRun         string // Timestamp of the last run in RFC3339 format
 	JobNextRun         string // Timestamp of the next scheduled run in RFC3339 format
+	JobStopServices    string // Comma-separated list of services to stop before the job runs and restart after
 }{
 	JobEnabled:         "cd.doco.job.enabled",
 	JobSchedule:        "cd.doco.job.schedule",
@@ -106,6 +107,7 @@ var docoCDJobLabelNames = struct {
 	JobRestartReplicas: "cd.doco.job.swarm.restart_replicas",
 	JobLastRun:         "cd.doco.job.last_run",
 	JobNextRun:         "cd.doco.job.next_run",
+	JobStopServices:    "cd.doco.job.stop_services",
 }
 
 // DocoCDJobLabels exposes the scheduler/job labels for consumers outside this package.

--- a/internal/docker/swarm.go
+++ b/internal/docker/swarm.go
@@ -35,6 +35,10 @@ import (
 var (
 	ErrNotAJobService                = errors.New("service is not a job-mode service")
 	ErrJobServiceRestartNotSupported = errors.New("restart not supported for job services")
+
+	// ErrGlobalSwarmServiceNotScalable indicates a global/global-job service was
+	// targeted by an operation that scales replicas, which Swarm does not allow.
+	ErrGlobalSwarmServiceNotScalable = errors.New("global-mode swarm service cannot be scaled")
 )
 
 // LoadSwarmStack loads a Docker Swarm stack using the provided project and deploy configuration.
@@ -533,17 +537,29 @@ func RerunJobService(ctx context.Context, cli dockerClient.APIClient, serviceNam
 	return nil
 }
 
-// StopSwarmService temporarily stops a swarm service by scaling it to 0 replicas.
+// ErrSwarmServiceAlreadyStopped indicates a replicated service was already
+// scaled to 0 replicas, so there is nothing to stop or restore.
+var ErrSwarmServiceAlreadyStopped = errors.New("swarm service is already scaled to 0 replicas")
+
+// StopSwarmService temporarily stops a swarm service by scaling it to 0 replicas
+// and waiting until its tasks have actually terminated.
 // It returns the original replica count so the caller can restore it later via
 // StartSwarmService.
 //
-// Global-mode services cannot be scaled to 0; the function logs a warning via the
-// provided logger and returns (0, nil) to allow the caller to skip them gracefully.
+// Waiting matters for the primary use case of this feature (consistent cold
+// backups): ServiceUpdate only records the intent to scale down, so without
+// waiting the scheduled job would start while the target's containers are
+// still shutting down and flushing to disk.
+//
+// Global-mode services cannot be scaled to 0; the function returns
+// (0, ErrGlobalSwarmServiceNotScalable) so the caller can skip them gracefully.
+// A replicated service that is already at 0 replicas returns
+// (0, ErrSwarmServiceAlreadyStopped).
 //
 // The serviceName must be the full swarm-scoped name (e.g. "mystack_myservice").
 // In the cd.doco.job.stop_services label, cross-stack services are expressed as
 // "stack/service" and resolved to "stack_service" before calling this function.
-func StopSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName string) (originalReplicas uint64, err error) {
+func StopSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName string, timeout time.Duration) (originalReplicas uint64, err error) {
 	result, err := dockerCLI.Client().ServiceInspect(ctx, serviceName, dockerClient.ServiceInspectOptions{
 		InsertDefaults: true,
 	})
@@ -555,7 +571,7 @@ func StopSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName st
 
 	// Global and global-job services cannot be scaled to 0.
 	if svc.Spec.Mode.Global != nil || svc.Spec.Mode.GlobalJob != nil {
-		return 0, nil
+		return 0, ErrGlobalSwarmServiceNotScalable
 	}
 
 	// Determine the current (intended) replica count.
@@ -570,12 +586,76 @@ func StopSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName st
 		replicas = 1
 	}
 
+	if replicas == 0 {
+		return 0, ErrSwarmServiceAlreadyStopped
+	}
+
 	// Scale to 0.
 	if err := swarmInternal.ScaleService(ctx, dockerCLI, serviceName, 0, false, false); err != nil {
 		return 0, fmt.Errorf("scale service %s to 0: %w", serviceName, err)
 	}
 
+	if err := waitForSwarmServiceTasksStopped(ctx, dockerCLI, svc.ID, serviceName, timeout); err != nil {
+		return replicas, err
+	}
+
 	return replicas, nil
+}
+
+// waitForSwarmServiceTasksStopped blocks until the given service has no tasks
+// left in a live state, or until timeout elapses.
+//
+// swarm.ScaleService(wait=true) is not sufficient here: it delegates to the
+// Docker CLI progress writer, which short-circuits for a service scaled to 0
+// and therefore returns before the tasks have actually shut down.
+func waitForSwarmServiceTasksStopped(ctx context.Context, dockerCLI command.Cli, serviceID, serviceName string, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		tasks, err := dockerCLI.Client().TaskList(waitCtx, dockerClient.TaskListOptions{
+			Filters: make(dockerClient.Filters).Add("service", serviceID),
+		})
+		if err != nil {
+			if waitCtx.Err() != nil && ctx.Err() == nil {
+				return fmt.Errorf("timed out after %s waiting for task(s) of service %s to stop", timeout, serviceName)
+			}
+
+			return fmt.Errorf("list tasks of service %s: %w", serviceName, err)
+		}
+
+		live := 0
+
+		for _, task := range tasks.Items {
+			// A task still occupies resources (and may still be writing to
+			// volumes) until it reaches a terminal state.
+			switch task.Status.State {
+			case swarmTypes.TaskStateShutdown, swarmTypes.TaskStateComplete,
+				swarmTypes.TaskStateFailed, swarmTypes.TaskStateRejected,
+				swarmTypes.TaskStateOrphaned, swarmTypes.TaskStateRemove:
+				continue
+			default:
+				live++
+			}
+		}
+
+		if live == 0 {
+			return nil
+		}
+
+		select {
+		case <-waitCtx.Done():
+			return fmt.Errorf("timed out after %s waiting for %d task(s) of service %s to stop", timeout, live, serviceName)
+		case <-ticker.C:
+		}
+	}
 }
 
 // StartSwarmService restores a previously stopped swarm service to the given
@@ -583,10 +663,12 @@ func StopSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName st
 // called in a deferred function to guarantee the service is restarted even when
 // the scheduled job fails.
 //
+// A replicas value of 0 means StopSwarmService never actually stopped the
+// service (global-mode, or already scaled to 0), so there is nothing to restore.
+//
 // The serviceName must be the full swarm-scoped name (e.g. "mystack_myservice").
 func StartSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName string, replicas uint64) error {
 	if replicas == 0 {
-		// Service was global-mode or already at 0 — nothing to restore.
 		return nil
 	}
 

--- a/internal/docker/swarm.go
+++ b/internal/docker/swarm.go
@@ -532,3 +532,67 @@ func RerunJobService(ctx context.Context, cli dockerClient.APIClient, serviceNam
 
 	return nil
 }
+
+// StopSwarmService temporarily stops a swarm service by scaling it to 0 replicas.
+// It returns the original replica count so the caller can restore it later via
+// StartSwarmService.
+//
+// Global-mode services cannot be scaled to 0; the function logs a warning via the
+// provided logger and returns (0, nil) to allow the caller to skip them gracefully.
+//
+// The serviceName must be the full swarm-scoped name (e.g. "mystack_myservice").
+// In the cd.doco.job.stop_services label, cross-stack services are expressed as
+// "stack/service" and resolved to "stack_service" before calling this function.
+func StopSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName string) (originalReplicas uint64, err error) {
+	result, err := dockerCLI.Client().ServiceInspect(ctx, serviceName, dockerClient.ServiceInspectOptions{
+		InsertDefaults: true,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("inspect service %s: %w", serviceName, err)
+	}
+
+	svc := result.Service
+
+	// Global and global-job services cannot be scaled to 0.
+	if svc.Spec.Mode.Global != nil || svc.Spec.Mode.GlobalJob != nil {
+		return 0, nil
+	}
+
+	// Determine the current (intended) replica count.
+	var replicas uint64
+
+	switch {
+	case svc.Spec.Mode.Replicated != nil && svc.Spec.Mode.Replicated.Replicas != nil:
+		replicas = *svc.Spec.Mode.Replicated.Replicas
+	case svc.Spec.Mode.ReplicatedJob != nil && svc.Spec.Mode.ReplicatedJob.TotalCompletions != nil:
+		replicas = *svc.Spec.Mode.ReplicatedJob.TotalCompletions
+	default:
+		replicas = 1
+	}
+
+	// Scale to 0.
+	if err := swarmInternal.ScaleService(ctx, dockerCLI, serviceName, 0, false, false); err != nil {
+		return 0, fmt.Errorf("scale service %s to 0: %w", serviceName, err)
+	}
+
+	return replicas, nil
+}
+
+// StartSwarmService restores a previously stopped swarm service to the given
+// replica count. It is the counterpart to StopSwarmService and is typically
+// called in a deferred function to guarantee the service is restarted even when
+// the scheduled job fails.
+//
+// The serviceName must be the full swarm-scoped name (e.g. "mystack_myservice").
+func StartSwarmService(ctx context.Context, dockerCLI command.Cli, serviceName string, replicas uint64) error {
+	if replicas == 0 {
+		// Service was global-mode or already at 0 — nothing to restore.
+		return nil
+	}
+
+	if err := swarmInternal.ScaleService(ctx, dockerCLI, serviceName, replicas, false, false); err != nil {
+		return fmt.Errorf("scale service %s back to %d: %w", serviceName, replicas, err)
+	}
+
+	return nil
+}

--- a/internal/reconciliation/manager.go
+++ b/internal/reconciliation/manager.go
@@ -3,10 +3,12 @@ package reconciliation
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
@@ -84,18 +86,37 @@ func (j *job) close() {
 	close(j.closeChan)
 }
 
+// schedulerHoldEntry tracks how many concurrent scheduled jobs are holding a
+// service stopped. When the last holder releases, the entry stays active for a
+// grace period so that any Docker stop event that was already buffered before the
+// hold was cleared does not slip through and trigger a spurious reconciliation
+// restart.
+type schedulerHoldEntry struct {
+	count     int
+	expiresAt time.Time // non-zero only when count == 0; suppression stays active until then
+}
+
+// schedulerStopHoldGracePeriod is how long the hold remains active after the
+// last job releases it. The Docker event stream is asynchronous: the stop event
+// can be buffered in the reconciliation channel for up to several hundred
+// milliseconds after the scheduler has already restarted the service, so this
+// grace period ensures those stale events are still suppressed.
+const schedulerStopHoldGracePeriod = 10 * time.Second
+
 type reconciliation struct {
 	m sync.Mutex
 
-	repoJobs        map[string]*job
-	deployingStacks map[string]int
+	repoJobs              map[string]*job
+	deployingStacks       map[string]int
+	schedulerHeldServices map[string]schedulerHoldEntry // key = "project/service"
 }
 
 func newReconciliation() *reconciliation {
 	return &reconciliation{
-		repoJobs:        make(map[string]*job),
-		deployingStacks: make(map[string]int),
-		m:               sync.Mutex{},
+		repoJobs:              make(map[string]*job),
+		deployingStacks:       make(map[string]int),
+		schedulerHeldServices: make(map[string]schedulerHoldEntry),
+		m:                     sync.Mutex{},
 	}
 }
 
@@ -109,6 +130,110 @@ func (r *reconciliation) close() {
 
 	r.repoJobs = make(map[string]*job)
 	r.deployingStacks = make(map[string]int)
+	r.schedulerHeldServices = make(map[string]schedulerHoldEntry)
+}
+
+// MarkSchedulerStopHeld records that the scheduler has intentionally stopped the
+// given compose service (identified by its compose project and service name) so
+// that the reconciliation event listener does not try to restart it while the
+// scheduled job is running. The hold is refcounted to handle concurrent jobs
+// that stop the same service.
+func MarkSchedulerStopHeld(project, service string) {
+	reconciliationHandler.markSchedulerStopHeld(project, service)
+}
+
+// UnmarkSchedulerStopHeld releases a hold previously registered via
+// MarkSchedulerStopHeld. When the refcount reaches zero the hold enters a
+// grace period (see schedulerStopHoldGracePeriod) so that any Docker stop
+// event still buffered in the reconciliation channel does not trigger a
+// spurious restart.
+func UnmarkSchedulerStopHeld(project, service string) {
+	reconciliationHandler.unmarkSchedulerStopHeld(project, service)
+}
+
+func schedulerHeldServiceKey(project, service string) string {
+	return project + "/" + service
+}
+
+func (r *reconciliation) markSchedulerStopHeld(project, service string) {
+	if project == "" || service == "" {
+		return
+	}
+
+	key := schedulerHeldServiceKey(project, service)
+
+	r.m.Lock()
+	entry := r.schedulerHeldServices[key]
+	entry.count++
+	entry.expiresAt = time.Time{} // clear any lingering grace period
+	r.schedulerHeldServices[key] = entry
+	r.m.Unlock()
+}
+
+func (r *reconciliation) unmarkSchedulerStopHeld(project, service string) {
+	if project == "" || service == "" {
+		return
+	}
+
+	key := schedulerHeldServiceKey(project, service)
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	entry := r.schedulerHeldServices[key]
+
+	if entry.count <= 1 {
+		// Last holder released. Keep the entry alive for the grace period so
+		// that stop events already buffered in the reconciliation channel are
+		// still suppressed after the service has been restarted.
+		r.schedulerHeldServices[key] = schedulerHoldEntry{
+			count:     0,
+			expiresAt: time.Now().Add(schedulerStopHoldGracePeriod),
+		}
+	} else {
+		entry.count--
+		r.schedulerHeldServices[key] = entry
+	}
+}
+
+// isServiceSchedulerStopHeld reports whether the container described by attrs is
+// currently held stopped by the job scheduler (or within the post-release grace
+// period). It uses the standard Docker Compose labels to identify the service.
+func (r *reconciliation) isServiceSchedulerStopHeld(attrs map[string]string) bool {
+	if attrs == nil {
+		return false
+	}
+
+	project := strings.TrimSpace(attrs[api.ProjectLabel])
+	service := strings.TrimSpace(attrs[api.ServiceLabel])
+
+	if project == "" || service == "" {
+		return false
+	}
+
+	key := schedulerHeldServiceKey(project, service)
+
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	entry, ok := r.schedulerHeldServices[key]
+	if !ok {
+		return false
+	}
+
+	if entry.count > 0 {
+		return true
+	}
+
+	// Grace period: still suppress events shortly after the service was restarted.
+	if !entry.expiresAt.IsZero() && time.Now().Before(entry.expiresAt) {
+		return true
+	}
+
+	// Grace period expired — clean up lazily.
+	delete(r.schedulerHeldServices, key)
+
+	return false
 }
 
 func stackDeploymentKey(repository, stack string) string {

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -392,6 +392,16 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 		return
 	}
 
+	if reconciliationHandler.isServiceSchedulerStopHeld(event.Actor.Attributes) {
+		jobLog.Debug("suppressing reconciliation event for service intentionally held stopped by job scheduler",
+			slog.String("event", action),
+			slog.String("stack", stackName),
+			slog.String("container_name", event.Actor.Attributes["name"]),
+		)
+
+		return
+	}
+
 	if suppress, remaining := j.shouldSuppressRestartFollowupEvent(action, event); suppress {
 		jobLog.Debug("suppressing follow-up event from self-initiated container restart",
 			slog.String("event", action),

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -81,6 +81,12 @@ type scheduler struct {
 
 	runningMu sync.Mutex
 	running   map[string]bool
+
+	// swarmStoppedServices tracks the original replica counts of swarm services
+	// that were scaled to 0 by stopServicesForJob, so startServicesForJob can
+	// restore them. Keyed by full swarm service name (e.g. "mystack_myservice").
+	swarmStoppedServicesMu sync.Mutex
+	swarmStoppedServices   map[string]uint64
 }
 
 // JobInfo describes one scheduler-managed target and its runtime scheduling status.
@@ -94,6 +100,7 @@ type JobInfo struct {
 	SkipRunning    bool                    `json:"skip_running"`
 	NotifyOn       docker.JobNotifyOn      `json:"notify_on,omitempty"`
 	Replicas       uint64                  `json:"replicas,omitempty"`
+	StopServices   []string                `json:"stop_services,omitempty"`
 	Status         string                  `json:"status,omitempty"`
 	LastRunAt      *time.Time              `json:"last_run_at,omitempty"`
 	NextRunAt      *time.Time              `json:"next_run_at,omitempty"`
@@ -109,12 +116,13 @@ func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *syn
 	}
 
 	s := &scheduler{
-		dockerCli: dockerCli,
-		log:       log.With(slog.String("component", "scheduler")),
-		wg:        wg,
-		startedAt: schedulerNow(),
-		states:    map[string]scheduledJobState{},
-		running:   map[string]bool{},
+		dockerCli:            dockerCli,
+		log:                  log.With(slog.String("component", "scheduler")),
+		wg:                   wg,
+		startedAt:            schedulerNow(),
+		states:               map[string]scheduledJobState{},
+		running:              map[string]bool{},
+		swarmStoppedServices: map[string]uint64{},
 	}
 
 	s.run(ctx)
@@ -185,6 +193,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		info.SkipRunning = cfg.SkipRunning
 		info.NotifyOn = cfg.NotifyOn
 		info.Replicas = cfg.SwarmReplicas
+		info.StopServices = formatStopServiceRefs(cfg.StopServices)
 
 		schedule, scheduleErr := docker.ParseJobScheduleExpression(cfg.Schedule)
 		if scheduleErr != nil {
@@ -233,9 +242,10 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 	}
 
 	s := &scheduler{
-		dockerCli: dockerCli,
-		log:       log.With(slog.String("component", "scheduler")),
-		running:   map[string]bool{},
+		dockerCli:            dockerCli,
+		log:                  log.With(slog.String("component", "scheduler")),
+		running:              map[string]bool{},
+		swarmStoppedServices: map[string]uint64{},
 	}
 
 	jobs, err := s.discoverJobs(ctx)
@@ -723,6 +733,27 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 }
 
 func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, cfg docker.JobScheduleConfig) error {
+	// Stop any declared services before executing the job, then restart them
+	// afterwards regardless of whether the job succeeds or fails.
+	if len(cfg.StopServices) > 0 {
+		stackName := getJobStackName(job)
+
+		if err := s.stopServicesForJob(ctx, job.mode, stackName, cfg.StopServices); err != nil {
+			return fmt.Errorf("stopping services before job: %w", err)
+		}
+
+		restoreCtx := context.WithoutCancel(ctx)
+
+		defer func() {
+			if err := s.startServicesForJob(restoreCtx, job.mode, stackName, cfg.StopServices); err != nil {
+				s.log.Error("failed to restart services after scheduled job",
+					slog.String("job", job.name),
+					logger.ErrAttr(err),
+				)
+			}
+		}()
+	}
+
 	switch job.mode {
 	case scheduledJobModeContainer:
 		switch cfg.ExecutionMode {
@@ -753,6 +784,159 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 	default:
 		return fmt.Errorf("unsupported scheduled job mode %q", job.mode)
 	}
+}
+
+const stopServicesTimeout = 30 * time.Second
+
+// stopServicesForJob stops the services listed in StopServices before a job runs.
+// For compose mode, services are grouped by project and stopped via the compose API.
+// For swarm mode, services are scaled to 0 (global-mode services are skipped with a warning).
+// savedSwarmReplicas is populated in swarm mode so startServicesForJob can restore them.
+func (s *scheduler) stopServicesForJob(ctx context.Context, mode scheduledJobMode, jobStack string, refs []docker.StopServiceRef) error {
+	switch mode {
+	case scheduledJobModeContainer:
+		byProject := groupStopRefsByProject(refs, jobStack)
+		for project, services := range byProject {
+			s.log.Info("stopping services before scheduled job",
+				slog.String("project", project),
+				slog.Any("services", services),
+			)
+
+			if err := docker.StopProjectServices(ctx, s.dockerCli, project, services, stopServicesTimeout); err != nil {
+				return fmt.Errorf("project %q services %v: %w", project, services, err)
+			}
+		}
+
+	case scheduledJobModeSwarm:
+		for _, ref := range refs {
+			stack := ref.Project
+			if stack == "" {
+				stack = jobStack
+			}
+
+			fullName := stack + "_" + ref.Service
+
+			replicas, err := docker.StopSwarmService(ctx, s.dockerCli, fullName)
+			if err != nil {
+				return fmt.Errorf("swarm service %q: %w", fullName, err)
+			}
+
+			if replicas == 0 {
+				s.log.Warn("skipping global-mode swarm service in stop_services (cannot scale to 0)",
+					slog.String("service", fullName),
+				)
+
+				continue
+			}
+
+			s.log.Info("stopped swarm service before scheduled job",
+				slog.String("service", fullName),
+				slog.Uint64("original_replicas", replicas),
+			)
+
+			// Store replica count on the scheduler so the deferred start can retrieve it.
+			s.swarmStoppedServicesMu.Lock()
+			s.swarmStoppedServices[fullName] = replicas
+			s.swarmStoppedServicesMu.Unlock()
+		}
+	}
+
+	return nil
+}
+
+// startServicesForJob restarts services that were stopped by stopServicesForJob.
+// It is always called in a deferred block (using context.WithoutCancel) so services
+// are restarted even if the job itself fails.
+func (s *scheduler) startServicesForJob(ctx context.Context, mode scheduledJobMode, jobStack string, refs []docker.StopServiceRef) error {
+	var errs []string
+
+	switch mode {
+	case scheduledJobModeContainer:
+		byProject := groupStopRefsByProject(refs, jobStack)
+		for project, services := range byProject {
+			s.log.Info("restarting services after scheduled job",
+				slog.String("project", project),
+				slog.Any("services", services),
+			)
+
+			if err := docker.StartProjectServices(ctx, s.dockerCli, project, services, stopServicesTimeout); err != nil {
+				errs = append(errs, fmt.Sprintf("project %q services %v: %v", project, services, err))
+			}
+		}
+
+	case scheduledJobModeSwarm:
+		for _, ref := range refs {
+			stack := ref.Project
+			if stack == "" {
+				stack = jobStack
+			}
+
+			fullName := stack + "_" + ref.Service
+
+			s.swarmStoppedServicesMu.Lock()
+
+			replicas, ok := s.swarmStoppedServices[fullName]
+			if ok {
+				delete(s.swarmStoppedServices, fullName)
+			}
+			s.swarmStoppedServicesMu.Unlock()
+
+			if !ok {
+				// Was a global-mode service (skipped during stop) — nothing to restore.
+				continue
+			}
+
+			s.log.Info("restarting swarm service after scheduled job",
+				slog.String("service", fullName),
+				slog.Uint64("replicas", replicas),
+			)
+
+			if err := docker.StartSwarmService(ctx, s.dockerCli, fullName, replicas); err != nil {
+				errs = append(errs, fmt.Sprintf("swarm service %q: %v", fullName, err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to restart %d service(s): %s", len(errs), strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+// groupStopRefsByProject groups StopServiceRef slices by their resolved project name.
+func groupStopRefsByProject(refs []docker.StopServiceRef, defaultProject string) map[string][]string {
+	byProject := make(map[string][]string)
+
+	for _, ref := range refs {
+		project := ref.Project
+		if project == "" {
+			project = defaultProject
+		}
+
+		byProject[project] = append(byProject[project], ref.Service)
+	}
+
+	return byProject
+}
+
+// formatStopServiceRefs serialises StopServiceRef values into the canonical
+// "project/service" or "service" strings used in labels and JobInfo.
+func formatStopServiceRefs(refs []docker.StopServiceRef) []string {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		if r.Project != "" {
+			out = append(out, r.Project+"/"+r.Service)
+		} else {
+			out = append(out, r.Service)
+		}
+	}
+
+	return out
 }
 
 func (s *scheduler) sendRunNotification(job scheduledJob, cfg docker.JobScheduleConfig, runID string, success bool, title, msg string) {
@@ -816,6 +1000,7 @@ func getScheduleFingerprint(cfg docker.JobScheduleConfig) string {
 		strconv.FormatBool(cfg.SkipRunning),
 		string(cfg.NotifyOn),
 		strconv.FormatUint(cfg.SwarmReplicas, 10),
+		strings.Join(formatStopServiceRefs(cfg.StopServices), ","),
 	}, "|")
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -82,11 +83,32 @@ type scheduler struct {
 	runningMu sync.Mutex
 	running   map[string]bool
 
-	// swarmStoppedServices tracks the original replica counts of swarm services
-	// that were scaled to 0 by stopServicesForJob, so startServicesForJob can
-	// restore them. Keyed by full swarm service name (e.g. "mystack_myservice").
-	swarmStoppedServicesMu sync.Mutex
-	swarmStoppedServices   map[string]uint64
+	// stopHolds reference-counts services currently held stopped by
+	// stopServicesForJob/startServicesForJob. It is keyed by (mode, resolved
+	// project/stack, service) so that if two concurrent scheduled runs both
+	// declare the same target in stop_services, the target is only actually
+	// stopped by the first holder and only actually restarted once the last
+	// holder releases it — this prevents one run from prematurely restarting
+	// a service another concurrent run still needs stopped. For swarm mode,
+	// the held state also records the original replica count so it can be
+	// restored when the last holder releases it.
+	stopHoldsMu sync.Mutex
+	stopHolds   map[stopHoldKey]*stopHoldState
+}
+
+// stopHoldKey identifies a service that may be concurrently held stopped by
+// more than one scheduled job run.
+type stopHoldKey struct {
+	mode    scheduledJobMode
+	project string
+	service string
+}
+
+// stopHoldState tracks how many concurrent job runs currently hold a service
+// stopped, and (for swarm mode) the replica count it should be restored to.
+type stopHoldState struct {
+	refCount int
+	replicas uint64
 }
 
 // JobInfo describes one scheduler-managed target and its runtime scheduling status.
@@ -116,13 +138,13 @@ func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *syn
 	}
 
 	s := &scheduler{
-		dockerCli:            dockerCli,
-		log:                  log.With(slog.String("component", "scheduler")),
-		wg:                   wg,
-		startedAt:            schedulerNow(),
-		states:               map[string]scheduledJobState{},
-		running:              map[string]bool{},
-		swarmStoppedServices: map[string]uint64{},
+		dockerCli: dockerCli,
+		log:       log.With(slog.String("component", "scheduler")),
+		wg:        wg,
+		startedAt: schedulerNow(),
+		states:    map[string]scheduledJobState{},
+		running:   map[string]bool{},
+		stopHolds: map[stopHoldKey]*stopHoldState{},
 	}
 
 	s.run(ctx)
@@ -170,7 +192,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		// mid-run for this job.
 		running := job.running || runningStates[job.key]
 
-		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels, s.log)
+		cfg, enabled, parseErr := parseJobConfig(job, s.log)
 		if parseErr != nil {
 			info.Valid = false
 			info.ScheduleError = parseErr.Error()
@@ -242,10 +264,10 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 	}
 
 	s := &scheduler{
-		dockerCli:            dockerCli,
-		log:                  log.With(slog.String("component", "scheduler")),
-		running:              map[string]bool{},
-		swarmStoppedServices: map[string]uint64{},
+		dockerCli: dockerCli,
+		log:       log.With(slog.String("component", "scheduler")),
+		running:   map[string]bool{},
+		stopHolds: map[stopHoldKey]*stopHoldState{},
 	}
 
 	jobs, err := s.discoverJobs(ctx)
@@ -287,9 +309,11 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 		}
 	}()
 
-	lock.LockStack(stack)
+	// Lock the job's own stack plus any stacks referenced by stop_services (see lockStacks).
+	lockedStacks := append([]string{stack}, resolveStopServiceStacks(cfg.StopServices, stack)...)
+	unlockStacks := lockStacks(lockedStacks...)
 
-	defer lock.UnlockStack(stack)
+	defer unlockStacks()
 
 	setRuntimeRunInProgress(job.key, true)
 	defer setRuntimeRunInProgress(job.key, false)
@@ -329,7 +353,7 @@ func findRunnableJob(jobs []scheduledJob, jobName, stackName string) (scheduledJ
 			continue
 		}
 
-		cfg, enabled, err := docker.ParseJobScheduleLabels(job.labels)
+		cfg, enabled, err := parseJobConfig(job)
 		if err != nil {
 			return scheduledJob{}, docker.JobScheduleConfig{}, fmt.Errorf("job %q has invalid schedule labels: %w", jobName, err)
 		}
@@ -404,7 +428,7 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 	for _, job := range jobs {
 		discoveredByKey[job.key] = job
 
-		cfg, enabled, parseErr := docker.ParseJobScheduleLabels(job.labels, s.log)
+		cfg, enabled, parseErr := parseJobConfig(job, s.log)
 		if parseErr != nil {
 			s.log.Warn("ignoring job with invalid schedule labels",
 				slog.String("job", job.name),
@@ -706,12 +730,17 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 			slog.String("scheduled_at", now.Format(time.RFC3339)),
 		)
 
-		runLog.Debug("waiting for scheduler/deploy lock")
-		lock.LockStack(stackName)
+		// Lock the job's own stack plus any stacks referenced by stop_services,
+		// so a concurrent deployment to a target stack cannot race with it
+		// being stopped/restarted around this run (see lockStacks).
+		lockedStacks := append([]string{stackName}, resolveStopServiceStacks(cfg.StopServices, stackName)...)
 
-		defer lock.UnlockStack(stackName)
+		runLog.Debug("waiting for scheduler/deploy lock(s)", slog.Any("stacks", lockedStacks))
+		unlockStacks := lockStacks(lockedStacks...)
 
-		runLog.Debug("acquired scheduler/deploy lock")
+		defer unlockStacks()
+
+		runLog.Debug("acquired scheduler/deploy lock(s)")
 
 		runLog.Debug("triggering scheduled run")
 
@@ -735,13 +764,14 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, cfg docker.JobScheduleConfig) error {
 	// Stop any declared services before executing the job, then restart them
 	// afterwards regardless of whether the job succeeds or fails.
+	//
+	// The restart is deferred unconditionally, before attempting the stop and
+	// regardless of whether it fully succeeds, so that any services which
+	// *were* successfully stopped are never left stranded (e.g. if stopping
+	// service 2 of 3 fails, service 1 must still be restarted). Restarting an
+	// already-running service/container is a harmless no-op.
 	if len(cfg.StopServices) > 0 {
 		stackName := getJobStackName(job)
-
-		if err := s.stopServicesForJob(ctx, job.mode, stackName, cfg.StopServices); err != nil {
-			return fmt.Errorf("stopping services before job: %w", err)
-		}
-
 		restoreCtx := context.WithoutCancel(ctx)
 
 		defer func() {
@@ -752,6 +782,10 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 				)
 			}
 		}()
+
+		if err := s.stopServicesForJob(ctx, job.mode, stackName, cfg.StopServices); err != nil {
+			return fmt.Errorf("stopping services before job: %w", err)
+		}
 	}
 
 	switch job.mode {
@@ -788,22 +822,114 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 
 const stopServicesTimeout = 30 * time.Second
 
+// acquireStopHold registers this run as one of the (possibly several)
+// concurrent holders of project/service being stopped, for the given mode.
+// It returns true if this is the first holder (i.e. the caller must actually
+// perform the stop); subsequent concurrent holders are told the target is
+// already held stopped and must not stop it again or restore it until they
+// are the last holder to release it.
+func (s *scheduler) acquireStopHold(mode scheduledJobMode, project, service string) bool {
+	key := stopHoldKey{mode: mode, project: project, service: service}
+
+	s.stopHoldsMu.Lock()
+	defer s.stopHoldsMu.Unlock()
+
+	st, ok := s.stopHolds[key]
+	if !ok {
+		st = &stopHoldState{}
+		s.stopHolds[key] = st
+	}
+
+	st.refCount++
+
+	return st.refCount == 1
+}
+
+// setStopHoldReplicas records the original swarm replica count for a held
+// service, so the last holder to release it can restore it.
+func (s *scheduler) setStopHoldReplicas(mode scheduledJobMode, project, service string, replicas uint64) {
+	key := stopHoldKey{mode: mode, project: project, service: service}
+
+	s.stopHoldsMu.Lock()
+	defer s.stopHoldsMu.Unlock()
+
+	if st, ok := s.stopHolds[key]; ok {
+		st.replicas = replicas
+	}
+}
+
+// releaseStopHold releases this run's hold on project/service. It returns
+// true (and the recorded replica count, for swarm mode) if this was the last
+// holder, meaning the caller must actually perform the restart; otherwise
+// another concurrent run still needs the target held stopped.
+func (s *scheduler) releaseStopHold(mode scheduledJobMode, project, service string) (isLast bool, replicas uint64) {
+	key := stopHoldKey{mode: mode, project: project, service: service}
+
+	s.stopHoldsMu.Lock()
+	defer s.stopHoldsMu.Unlock()
+
+	st, ok := s.stopHolds[key]
+	if !ok {
+		// No recorded hold (shouldn't normally happen) — nothing to restore.
+		return false, 0
+	}
+
+	st.refCount--
+	replicas = st.replicas
+
+	if st.refCount <= 0 {
+		delete(s.stopHolds, key)
+		return true, replicas
+	}
+
+	return false, replicas
+}
+
 // stopServicesForJob stops the services listed in StopServices before a job runs.
 // For compose mode, services are grouped by project and stopped via the compose API.
 // For swarm mode, services are scaled to 0 (global-mode services are skipped with a warning).
-// savedSwarmReplicas is populated in swarm mode so startServicesForJob can restore them.
+//
+// If another concurrent scheduled run already holds a given project/service
+// stopped (e.g. two jobs both list the same shared dependency), this run
+// records an additional hold on it but does not stop it again — see
+// acquireStopHold. This prevents the first run's restart from prematurely
+// bringing the service back up while the second run still needs it stopped.
+//
+// This is best-effort: a failure to stop one project/service does not abort
+// attempts to stop the others, so as many of the declared services as
+// possible are quiesced before the job runs. All failures are aggregated and
+// returned together so the job is still not executed if any stop failed.
 func (s *scheduler) stopServicesForJob(ctx context.Context, mode scheduledJobMode, jobStack string, refs []docker.StopServiceRef) error {
+	var errs []string
+
 	switch mode {
 	case scheduledJobModeContainer:
 		byProject := groupStopRefsByProject(refs, jobStack)
 		for project, services := range byProject {
+			var toStop []string
+
+			for _, svc := range services {
+				if s.acquireStopHold(mode, project, svc) {
+					toStop = append(toStop, svc)
+				} else {
+					s.log.Debug("service already held stopped by another concurrent job, skipping duplicate stop",
+						slog.String("project", project),
+						slog.String("service", svc),
+					)
+				}
+			}
+
+			if len(toStop) == 0 {
+				continue
+			}
+
 			s.log.Info("stopping services before scheduled job",
 				slog.String("project", project),
-				slog.Any("services", services),
+				slog.Any("services", toStop),
 			)
 
-			if err := docker.StopProjectServices(ctx, s.dockerCli, project, services, stopServicesTimeout); err != nil {
-				return fmt.Errorf("project %q services %v: %w", project, services, err)
+			if err := docker.StopProjectServices(ctx, s.dockerCli, project, toStop, stopServicesTimeout); err != nil {
+				errs = append(errs, fmt.Sprintf("project %q services %v: %v", project, toStop, err))
 			}
 		}
 
@@ -816,9 +942,18 @@ func (s *scheduler) stopServicesForJob(ctx context.Context, mode scheduledJobMod
 
 			fullName := stack + "_" + ref.Service
 
+			if !s.acquireStopHold(mode, stack, ref.Service) {
+				s.log.Debug("swarm service already held stopped by another concurrent job, skipping duplicate stop",
+					slog.String("service", fullName),
+				)
+
+				continue
+			}
+
 			replicas, err := docker.StopSwarmService(ctx, s.dockerCli, fullName)
 			if err != nil {
-				return fmt.Errorf("swarm service %q: %w", fullName, err)
+				errs = append(errs, fmt.Sprintf("swarm service %q: %v", fullName, err))
+				continue
 			}
 
 			if replicas == 0 {
@@ -834,11 +969,13 @@ func (s *scheduler) stopServicesForJob(ctx context.Context, mode scheduledJobMod
 				slog.Uint64("original_replicas", replicas),
 			)
 
-			// Store replica count on the scheduler so the deferred start can retrieve it.
-			s.swarmStoppedServicesMu.Lock()
-			s.swarmStoppedServices[fullName] = replicas
-			s.swarmStoppedServicesMu.Unlock()
+			// Record the replica count so the last holder to release it can restore it.
+			s.setStopHoldReplicas(mode, stack, ref.Service, replicas)
 		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to stop %d service group(s): %s", len(errs), strings.Join(errs, "; "))
 	}
 
 	return nil
@@ -847,6 +984,10 @@ func (s *scheduler) stopServicesForJob(ctx context.Context, mode scheduledJobMod
 // startServicesForJob restarts services that were stopped by stopServicesForJob.
 // It is always called in a deferred block (using context.WithoutCancel) so services
 // are restarted even if the job itself fails.
+//
+// A service is only actually restarted once every concurrent holder of it has
+// released their hold (see releaseStopHold) — if another concurrent run is
+// still relying on the service being stopped, this run's release is a no-op.
 func (s *scheduler) startServicesForJob(ctx context.Context, mode scheduledJobMode, jobStack string, refs []docker.StopServiceRef) error {
 	var errs []string
 
@@ -854,13 +995,30 @@ func (s *scheduler) startServicesForJob(ctx context.Context, mode scheduledJobMo
 	case scheduledJobModeContainer:
 		byProject := groupStopRefsByProject(refs, jobStack)
 		for project, services := range byProject {
+			var toStart []string
+
+			for _, svc := range services {
+				if isLast, _ := s.releaseStopHold(mode, project, svc); isLast {
+					toStart = append(toStart, svc)
+				} else {
+					s.log.Debug("service still held stopped by another concurrent job, deferring restart",
+						slog.String("project", project),
+						slog.String("service", svc),
+					)
+				}
+			}
+
+			if len(toStart) == 0 {
+				continue
+			}
+
 			s.log.Info("restarting services after scheduled job",
 				slog.String("project", project),
-				slog.Any("services", services),
+				slog.Any("services", toStart),
 			)
 
-			if err := docker.StartProjectServices(ctx, s.dockerCli, project, services, stopServicesTimeout); err != nil {
-				errs = append(errs, fmt.Sprintf("project %q services %v: %v", project, services, err))
+			if err := docker.StartProjectServices(ctx, s.dockerCli, project, toStart); err != nil {
+				errs = append(errs, fmt.Sprintf("project %q services %v: %v", project, toStart, err))
 			}
 		}
 
@@ -873,16 +1031,18 @@ func (s *scheduler) startServicesForJob(ctx context.Context, mode scheduledJobMo
 
 			fullName := stack + "_" + ref.Service
 
-			s.swarmStoppedServicesMu.Lock()
+			isLast, replicas := s.releaseStopHold(mode, stack, ref.Service)
+			if !isLast {
+				s.log.Debug("swarm service still held stopped by another concurrent job, deferring restart",
+					slog.String("service", fullName),
+				)
 
-			replicas, ok := s.swarmStoppedServices[fullName]
-			if ok {
-				delete(s.swarmStoppedServices, fullName)
+				continue
 			}
-			s.swarmStoppedServicesMu.Unlock()
 
-			if !ok {
-				// Was a global-mode service (skipped during stop) — nothing to restore.
+			if replicas == 0 {
+				// Was a global-mode service (skipped during stop), or was never
+				// actually stopped by us in the first place — nothing to restore.
 				continue
 			}
 
@@ -902,6 +1062,65 @@ func (s *scheduler) startServicesForJob(ctx context.Context, mode scheduledJobMo
 	}
 
 	return nil
+}
+
+// lockStacks acquires the per-stack scheduler/deploy lock (see lock.LockStack)
+// for every distinct, non-empty stack name given, in a deterministic (sorted)
+// order. Locking multiple stacks in a fixed global order — rather than in
+// caller-supplied order — prevents ABBA deadlocks when two scheduled runs
+// need to lock an overlapping set of stacks concurrently (e.g. a job's own
+// stack plus stacks referenced by its stop_services, which another run might
+// need to lock in the opposite order). It returns an unlock function that
+// releases all acquired locks; callers must call it exactly once.
+func lockStacks(stacks ...string) (unlock func()) {
+	seen := make(map[string]struct{}, len(stacks))
+	unique := make([]string, 0, len(stacks))
+
+	for _, stack := range stacks {
+		stack = strings.TrimSpace(stack)
+		if stack == "" {
+			continue
+		}
+
+		if _, ok := seen[stack]; ok {
+			continue
+		}
+
+		seen[stack] = struct{}{}
+		unique = append(unique, stack)
+	}
+
+	sort.Strings(unique)
+
+	for _, stack := range unique {
+		lock.LockStack(stack)
+	}
+
+	return func() {
+		for i := len(unique) - 1; i >= 0; i-- {
+			lock.UnlockStack(unique[i])
+		}
+	}
+}
+
+// resolveStopServiceStacks returns the distinct resolved stack/project names
+// referenced by refs, using defaultStack for entries with no explicit project.
+// Used to also lock any stacks targeted by stop_services (in addition to the
+// job's own stack) so a concurrent deployment to a target stack cannot race
+// with it being stopped/restarted around the scheduled run.
+func resolveStopServiceStacks(refs []docker.StopServiceRef, defaultStack string) []string {
+	stacks := make([]string, 0, len(refs))
+
+	for _, ref := range refs {
+		stack := ref.Project
+		if stack == "" {
+			stack = defaultStack
+		}
+
+		stacks = append(stacks, stack)
+	}
+
+	return stacks
 }
 
 // groupStopRefsByProject groups StopServiceRef slices by their resolved project name.
@@ -1102,6 +1321,45 @@ func getJobStackName(job scheduledJob) string {
 	}
 
 	return ""
+}
+
+// jobOwnIdentity resolves the project/stack and service name that identify
+// job itself, used to detect stop_services self-references for both compose
+// and Swarm jobs.
+//
+// Compose containers always carry com.docker.compose.project/.service labels
+// (Docker injects them at container-create time), so those are used directly.
+// Swarm services deployed by doco-cd do not carry those labels on the task
+// spec, so the service name is derived from the full Swarm service name
+// (e.g. "mystack_myservice"), stripping the resolved stack prefix.
+func jobOwnIdentity(job scheduledJob) (project, service string) {
+	project = getJobStackName(job)
+
+	if job.mode == scheduledJobModeSwarm {
+		service = strings.TrimPrefix(job.name, project+"_")
+		return project, service
+	}
+
+	return project, strings.TrimSpace(job.labels[api.ServiceLabel])
+}
+
+// parseJobConfig parses a job's schedule labels and, if stop_services is set,
+// validates that the job does not reference itself. Centralising this here
+// (rather than in docker.ParseJobScheduleLabels) lets the self-reference
+// check use the correct own-identity resolution for both compose and Swarm
+// jobs; see jobOwnIdentity.
+func parseJobConfig(job scheduledJob, log ...*slog.Logger) (docker.JobScheduleConfig, bool, error) {
+	cfg, enabled, err := docker.ParseJobScheduleLabels(job.labels, log...)
+	if err != nil || !enabled || len(cfg.StopServices) == 0 {
+		return cfg, enabled, err
+	}
+
+	project, service := jobOwnIdentity(job)
+	if err := docker.ValidateStopServicesSelfReference(project, service, cfg.StopServices); err != nil {
+		return cfg, false, err
+	}
+
+	return cfg, enabled, nil
 }
 
 func firstContainerName(names []string) string {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/prometheus"
+	"github.com/kimdre/doco-cd/internal/reconciliation"
 )
 
 const (
@@ -923,6 +924,12 @@ func (s *scheduler) stopServicesForJob(ctx context.Context, mode scheduledJobMod
 				continue
 			}
 
+			// Mark each service as scheduler-held so that the reconciliation
+			// event listener does not restart it while the job is running.
+			for _, svc := range toStop {
+				reconciliation.MarkSchedulerStopHeld(project, svc)
+			}
+
 			s.log.Info("stopping services before scheduled job",
 				slog.String("project", project),
 				slog.Any("services", toStop),
@@ -1027,6 +1034,12 @@ func (s *scheduler) startServicesForJob(ctx context.Context, mode scheduledJobMo
 
 			if len(toStart) == 0 {
 				continue
+			}
+
+			// Unmark the scheduler hold before starting — if our start fails,
+			// reconciliation can step in and recover the service.
+			for _, svc := range toStart {
+				reconciliation.UnmarkSchedulerStopHeld(project, svc)
 			}
 
 			s.log.Info("restarting services after scheduled job",

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -795,6 +795,13 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 		case docker.JobExecutionModeOneOff:
 			return docker.RunContainerOneOffFromExisting(ctx, s.dockerCli.Client(), job.id)
 		default:
+			if len(cfg.StopServices) > 0 {
+				// stop_services requires knowing when the job has finished.
+				// Use the blocking variant so services are not restarted while
+				// the job container is still running.
+				return docker.RestartContainerAndWait(ctx, s.dockerCli.Client(), job.id)
+			}
+
 			return docker.RestartContainer(ctx, s.dockerCli.Client(), job.id)
 		}
 	case scheduledJobModeSwarm:
@@ -1382,6 +1389,17 @@ func parseJobConfig(job scheduledJob, log ...*slog.Logger) (docker.JobScheduleCo
 	cfg, enabled, err := docker.ParseJobScheduleLabels(job.labels, log...)
 	if err != nil || !enabled || len(cfg.StopServices) == 0 {
 		return cfg, enabled, err
+	}
+
+	// In Swarm mode, stop_services requires one_off because there is no
+	// reliable completion signal for restart-mode services (ScaleService /
+	// ServiceUpdate only record intent and return immediately).
+	if job.mode == scheduledJobModeSwarm && cfg.ExecutionMode != docker.JobExecutionModeOneOff {
+		return cfg, false, fmt.Errorf(
+			"%s requires %s=%q in Swarm mode (got %q): doco-cd cannot detect job completion for Swarm services in %q mode",
+			docker.DocoCDJobLabels.JobStopServices, docker.DocoCDJobLabels.JobExecutionMode,
+			docker.JobExecutionModeOneOff, cfg.ExecutionMode, cfg.ExecutionMode,
+		)
 	}
 
 	project, service := jobOwnIdentity(job)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -950,16 +950,33 @@ func (s *scheduler) stopServicesForJob(ctx context.Context, mode scheduledJobMod
 				continue
 			}
 
-			replicas, err := docker.StopSwarmService(ctx, s.dockerCli, fullName)
-			if err != nil {
-				errs = append(errs, fmt.Sprintf("swarm service %q: %v", fullName, err))
-				continue
-			}
+			replicas, err := docker.StopSwarmService(ctx, s.dockerCli, fullName, stopServicesTimeout)
 
-			if replicas == 0 {
+			switch {
+			case errors.Is(err, docker.ErrGlobalSwarmServiceNotScalable):
 				s.log.Warn("skipping global-mode swarm service in stop_services (cannot scale to 0)",
 					slog.String("service", fullName),
 				)
+
+				continue
+
+			case errors.Is(err, docker.ErrSwarmServiceAlreadyStopped):
+				s.log.Info("swarm service in stop_services is already scaled to 0, nothing to stop",
+					slog.String("service", fullName),
+				)
+
+				continue
+
+			case err != nil:
+				// The scale-down may have been applied even though the call failed
+				// (e.g. waiting for tasks to terminate timed out). Whenever a
+				// replica count was reported, record it so the service is still
+				// restored afterwards instead of being stranded at 0 replicas.
+				if replicas > 0 {
+					s.setStopHoldReplicas(mode, stack, ref.Service, replicas)
+				}
+
+				errs = append(errs, fmt.Sprintf("swarm service %q: %v", fullName, err))
 
 				continue
 			}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -472,3 +472,170 @@ func TestContainerJobKey_FallsBackToContainerID(t *testing.T) {
 		t.Fatalf("containerJobKey()=%q want=%q", got, want)
 	}
 }
+
+func TestJobOwnIdentity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("compose job uses compose project/service labels", func(t *testing.T) {
+		t.Parallel()
+
+		job := scheduledJob{
+			mode: scheduledJobModeContainer,
+			name: "irrelevant-container-name",
+			labels: map[string]string{
+				api.ProjectLabel: "myproject",
+				api.ServiceLabel: "backup",
+			},
+		}
+
+		project, service := jobOwnIdentity(job)
+		if project != "myproject" || service != "backup" {
+			t.Fatalf("jobOwnIdentity() = (%q, %q), want (\"myproject\", \"backup\")", project, service)
+		}
+	})
+
+	t.Run("swarm job derives service from full service name", func(t *testing.T) {
+		t.Parallel()
+
+		job := scheduledJob{
+			mode: scheduledJobModeSwarm,
+			name: "mystack_backup",
+			labels: map[string]string{
+				swarm.StackNamespaceLabel: "mystack",
+			},
+		}
+
+		project, service := jobOwnIdentity(job)
+		if project != "mystack" || service != "backup" {
+			t.Fatalf("jobOwnIdentity() = (%q, %q), want (\"mystack\", \"backup\")", project, service)
+		}
+	})
+}
+
+func TestValidateStopServicesSelfReference_SwarmIdentity(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: swarm task labels never carry com.docker.compose.project
+	// or com.docker.compose.service, so self-reference detection must use the
+	// resolved stack name and the service name derived from the full swarm
+	// service name (see jobOwnIdentity), not raw compose labels.
+	job := scheduledJob{
+		mode: scheduledJobModeSwarm,
+		name: "mystack_backup",
+		labels: map[string]string{
+			swarm.StackNamespaceLabel:              "mystack",
+			docker.DocoCDJobLabels.JobEnabled:      "true",
+			docker.DocoCDJobLabels.JobSchedule:     "0 2 * * *",
+			docker.DocoCDJobLabels.JobStopServices: "backup",
+		},
+	}
+
+	cfg, enabled, err := parseJobConfig(job)
+	if err == nil {
+		t.Fatalf("expected self-reference error for swarm job, got nil (enabled=%v cfg=%+v)", enabled, cfg)
+	}
+}
+
+func TestResolveStopServiceStacks(t *testing.T) {
+	t.Parallel()
+
+	refs := []docker.StopServiceRef{
+		{Service: "db"},
+		{Project: "other-project", Service: "cache"},
+		{Project: "other-project", Service: "search"},
+	}
+
+	got := resolveStopServiceStacks(refs, "own-project")
+
+	want := []string{"own-project", "other-project", "other-project"}
+	if len(got) != len(want) {
+		t.Fatalf("resolveStopServiceStacks() = %v, want %v", got, want)
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resolveStopServiceStacks()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestLockStacks_DeduplicatesAndLocksSortedOrder(t *testing.T) {
+	t.Parallel()
+
+	// Repeated/empty entries must not cause a self-deadlock (locking the same
+	// stack twice) and must not be double-unlocked.
+	unlock := lockStacks("zeta", "alpha", "alpha", "", "zeta")
+	unlock()
+
+	// If dedup/unlock bookkeeping were broken, acquiring the same stacks again
+	// would deadlock (this call would hang forever), so a normal test timeout
+	// failure would catch it.
+	unlock2 := lockStacks("alpha", "zeta")
+	unlock2()
+}
+
+func TestStopHold_RefCounting(t *testing.T) {
+	t.Parallel()
+
+	s := &scheduler{stopHolds: map[stopHoldKey]*stopHoldState{}}
+
+	// First holder must actually perform the stop.
+	if isFirst := s.acquireStopHold(scheduledJobModeContainer, "proj", "db"); !isFirst {
+		t.Fatal("expected first acquireStopHold() to report isFirst=true")
+	}
+
+	// A second concurrent holder of the same target must not stop it again.
+	if isFirst := s.acquireStopHold(scheduledJobModeContainer, "proj", "db"); isFirst {
+		t.Fatal("expected second acquireStopHold() to report isFirst=false")
+	}
+
+	// Releasing while another holder remains must not trigger a restart.
+	if isLast, _ := s.releaseStopHold(scheduledJobModeContainer, "proj", "db"); isLast {
+		t.Fatal("expected first releaseStopHold() to report isLast=false while a holder remains")
+	}
+
+	// The last holder releasing must trigger the actual restart.
+	if isLast, _ := s.releaseStopHold(scheduledJobModeContainer, "proj", "db"); !isLast {
+		t.Fatal("expected final releaseStopHold() to report isLast=true")
+	}
+
+	// The hold must be fully removed once released by the last holder.
+	if _, ok := s.stopHolds[stopHoldKey{mode: scheduledJobModeContainer, project: "proj", service: "db"}]; ok {
+		t.Fatal("expected stop hold to be removed after last release")
+	}
+}
+
+func TestStopHold_SwarmReplicasSurviveUntilLastRelease(t *testing.T) {
+	t.Parallel()
+
+	s := &scheduler{stopHolds: map[stopHoldKey]*stopHoldState{}}
+
+	// Two concurrent jobs both stop the same shared swarm service.
+	if isFirst := s.acquireStopHold(scheduledJobModeSwarm, "stack", "shared"); !isFirst {
+		t.Fatal("expected first acquireStopHold() to report isFirst=true")
+	}
+
+	// Only the first holder actually observes/records the original replica count.
+	s.setStopHoldReplicas(scheduledJobModeSwarm, "stack", "shared", 3)
+
+	if isFirst := s.acquireStopHold(scheduledJobModeSwarm, "stack", "shared"); isFirst {
+		t.Fatal("expected second acquireStopHold() to report isFirst=false")
+	}
+
+	// The second job finishes first and releases its hold: since the first
+	// job is still holding it, this must NOT restore the service yet.
+	if isLast, _ := s.releaseStopHold(scheduledJobModeSwarm, "stack", "shared"); isLast {
+		t.Fatal("expected release while a holder remains to report isLast=false")
+	}
+
+	// The first job finishes and releases its hold: now it must restore, and
+	// the originally recorded replica count must still be intact.
+	isLast, replicas := s.releaseStopHold(scheduledJobModeSwarm, "stack", "shared")
+	if !isLast {
+		t.Fatal("expected final release to report isLast=true")
+	}
+
+	if replicas != 3 {
+		t.Fatalf("replicas = %d, want 3", replicas)
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -523,16 +524,21 @@ func TestValidateStopServicesSelfReference_SwarmIdentity(t *testing.T) {
 		mode: scheduledJobModeSwarm,
 		name: "mystack_backup",
 		labels: map[string]string{
-			swarm.StackNamespaceLabel:              "mystack",
-			docker.DocoCDJobLabels.JobEnabled:      "true",
-			docker.DocoCDJobLabels.JobSchedule:     "0 2 * * *",
-			docker.DocoCDJobLabels.JobStopServices: "backup",
+			swarm.StackNamespaceLabel:               "mystack",
+			docker.DocoCDJobLabels.JobEnabled:       "true",
+			docker.DocoCDJobLabels.JobSchedule:      "0 2 * * *",
+			docker.DocoCDJobLabels.JobExecutionMode: "one_off",
+			docker.DocoCDJobLabels.JobStopServices:  "backup",
 		},
 	}
 
 	cfg, enabled, err := parseJobConfig(job)
 	if err == nil {
 		t.Fatalf("expected self-reference error for swarm job, got nil (enabled=%v cfg=%+v)", enabled, cfg)
+	}
+
+	if !strings.Contains(err.Error(), "cannot stop itself") {
+		t.Fatalf("expected self-reference error, got: %v", err)
 	}
 }
 

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -217,6 +217,14 @@ Behavior:
     Only explicitly listed services are stopped/started.
     If dependent services should also be paused, include them explicitly in `cd.doco.job.stop_services`.
 
+!!! note "A job cannot stop itself"
+    If `cd.doco.job.stop_services` resolves to the job's own project/service, the label is rejected and the job is treated as invalid.
+
+!!! info "Concurrency and shared targets"
+    While services are held stopped, doco-cd locks the job's own stack **and** every stack referenced by `cd.doco.job.stop_services`, so a concurrent deployment or another scheduled run cannot race with the reconciliation of those stacks.
+
+    If two scheduled jobs happen to list the same target service (e.g. two backup jobs sharing a cache), the target is only actually restarted once every job that stopped it has finished — it will not be brought back up prematurely while another job still needs it stopped.
+
 ## Examples
 
 === "Prune swarm nodes"

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -170,6 +170,7 @@ Use the following service labels to configure scheduled jobs:
 | `cd.doco.job.skip_running`      | boolean | Do not run the job if a previous scheduled run is still active/running                                                                                                      | `false`   |
 | `cd.doco.job.notify_on`         | string  | [Notification](Notifications.md) behavior for scheduled runs: `none`, `success`, `failure`, `all`                                                                           | `all`     |
 | `cd.doco.job.swarm.replicas`    | integer | Number of completions/concurrency for swarm one-off jobs in `replicated` [deploy mode](#swarm-deploymode)                                                                   | `1`       |
+| `cd.doco.job.stop_services`     | string  | Comma-separated services to [temporarily stop during a job run](#temporarily-stop-services-during-a-job-run) (supports `service` and `project/service`)                     |           |
 
 !!! note "Using scheduled jobs with multiple doco-cd instances"
     `cd.doco.job.skip_running` only prevents overlapping runs within the same doco-cd process.
@@ -185,6 +186,36 @@ The following mapping applies to scheduled runs in `one_off` mode:
 
 - If the service uses `#!yaml deploy.mode: global`, the job run is created as `global-job`
 - If the service uses `#!yaml deploy.mode: replicated` or does not specify a deploy mode, the job run is created as `replicated-job` with the number of completions/concurrency determined by the `cd.doco.job.swarm.replicas` label.
+
+### Temporarily stop services during a job run
+
+Use `cd.doco.job.stop_services` when a scheduled job needs a quiet window (for example, cold backups):
+
+```yaml title="docker-compose.yml"
+services:
+  backup:
+    image: ghcr.io/my-org/backup:1.2.3
+    command: ["/backup.sh"]
+    labels:
+      cd.doco.job.enabled: "true"
+      cd.doco.job.schedule: "0 2 * * *"
+      cd.doco.job.execution_mode: "one_off"
+      cd.doco.job.stop_services: "app,other-project/other-app"
+```
+
+Behavior:
+
+- Before the job starts, listed services are stopped.
+- After the job finishes (success or failure), listed services are started again.
+- `service` targets the same project/stack as the job.
+- `project/service` targets another compose project (standalone) or stack (swarm).
+
+!!! warning "Use service names, not container names"
+    Values must reference the **compose service name** (the key under `services:`), **not** `container_name`.
+
+!!! note "`depends_on` is not traversed automatically"
+    Only explicitly listed services are stopped/started.
+    If dependent services should also be paused, include them explicitly in `cd.doco.job.stop_services`.
 
 ## Examples
 

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -161,16 +161,16 @@ be created for each scheduled run and removed after completion.
 
 Use the following service labels to configure scheduled jobs:
 
-| Label                           | Type    | Description                                                                                                                                                                 | Default   |
-|---------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
-| `cd.doco.job.enabled`           | boolean | Enable scheduling for this service/container                                                                                                                                | `false`   |
-| `cd.doco.job.schedule`          | string  | [Schedule format](#schedule-formats) to use                                                                                                                                 |           |
-| `cd.doco.job.wait_running_jobs` | boolean | Override deploy-config-wide [`wait_running_jobs`](../Deploy-Settings.md#wait-for-running-scheduled-jobs-before-deployment) behavior for this job service during deployments | (inherit) |
-| `cd.doco.job.execution_mode`    | string  | [`restart`](#restart) (default behavior) or [`one_off`](#one_off) (ephemeral execution)                                                                                     | `restart` |
-| `cd.doco.job.skip_running`      | boolean | Do not run the job if a previous scheduled run is still active/running                                                                                                      | `false`   |
-| `cd.doco.job.notify_on`         | string  | [Notification](Notifications.md) behavior for scheduled runs: `none`, `success`, `failure`, `all`                                                                           | `all`     |
-| `cd.doco.job.swarm.replicas`    | integer | Number of completions/concurrency for swarm one-off jobs in `replicated` [deploy mode](#swarm-deploymode)                                                                   | `1`       |
-| `cd.doco.job.stop_services`     | string  | Comma-separated services to [temporarily stop during a job run](#temporarily-stop-services-during-a-job-run) (supports `service` and `project/service`)                     |           |
+| Label                           | Type    | Description                                                                                                                                                                                 | Default   |
+|---------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| `cd.doco.job.enabled`           | boolean | Enable scheduling for this service/container                                                                                                                                                | `false`   |
+| `cd.doco.job.schedule`          | string  | [Schedule format](#schedule-formats) to use                                                                                                                                                 |           |
+| `cd.doco.job.wait_running_jobs` | boolean | Override deploy-config-wide [`wait_running_jobs`](../Deploy-Settings.md#wait-for-running-scheduled-jobs-before-deployment) behavior for this job service during deployments                 | (inherit) |
+| `cd.doco.job.execution_mode`    | string  | [`restart`](#restart) (default behavior) or [`one_off`](#one_off) (ephemeral execution)                                                                                                     | `restart` |
+| `cd.doco.job.skip_running`      | boolean | Do not run the job if a previous scheduled run is still active/running                                                                                                                      | `false`   |
+| `cd.doco.job.notify_on`         | string  | [Notification](Notifications.md) behavior for scheduled runs: `none`, `success`, `failure`, `all`                                                                                           | `all`     |
+| `cd.doco.job.swarm.replicas`    | integer | Number of completions/concurrency for swarm one-off jobs in `replicated` [deploy mode](#swarm-deploymode)                                                                                   | `1`       |
+| `cd.doco.job.stop_services`     | string  | Comma-separated services to [temporarily stop during a job run](#temporarily-stop-services-during-a-job-run) (supports `service` and `project/service`, requires `execution_mode: one_off`) |           |
 
 !!! note "Using scheduled jobs with multiple doco-cd instances"
     `cd.doco.job.skip_running` only prevents overlapping runs within the same doco-cd process.
@@ -205,22 +205,28 @@ services:
 
 Behavior:
 
-- Before the job starts, listed services are stopped.
+- Before the job starts, listed services are stopped, and doco-cd waits until their containers/tasks have actually terminated.
 - After the job finishes (success or failure), listed services are started again.
 - `service` targets the same project/stack as the job.
 - `project/service` targets another compose project (standalone) or stack (swarm).
 
+!!! warning "Requires `execution_mode: one_off`"
+    `cd.doco.job.stop_services` is only valid together with `#!yaml cd.doco.job.execution_mode: "one_off"`, and the deployment is rejected otherwise.
+
+    ??? question "Why?"
+        Stopped services are restored as soon as the job finishes, so doco-cd must be able to detect job completion. It only does so in `one_off` mode, where it waits for the one-off container/task to exit. In `restart` mode (the default) the run returns as soon as the restart has been issued, which would bring the stopped services back up while the job is still running.
+
 !!! warning "Use service names, not container names"
     Values must reference the **compose service name** (the key under `services:`), **not** `container_name`.
 
-!!! note "`depends_on` is not traversed automatically"
+!!! info "`depends_on` is not traversed automatically"
     Only explicitly listed services are stopped/started.
     If dependent services should also be paused, include them explicitly in `cd.doco.job.stop_services`.
 
-!!! note "A job cannot stop itself"
-    If `cd.doco.job.stop_services` resolves to the job's own project/service, the label is rejected and the job is treated as invalid.
+!!! info "Swarm: global-mode services are skipped"
+    Services deployed with `#!yaml deploy.mode: global` (or `global-job`) cannot be scaled to 0 replicas, so they are skipped with a warning instead of being stopped.
 
-!!! info "Concurrency and shared targets"
+??? note "Concurrency and shared targets"
     While services are held stopped, doco-cd locks the job's own stack **and** every stack referenced by `cd.doco.job.stop_services`, so a concurrent deployment or another scheduled run cannot race with the reconciliation of those stacks.
 
     If two scheduled jobs happen to list the same target service (e.g. two backup jobs sharing a cache), the target is only actually restarted once every job that stopped it has finished — it will not be brought back up prematurely while another job still needs it stopped.

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -170,7 +170,7 @@ Use the following service labels to configure scheduled jobs:
 | `cd.doco.job.skip_running`      | boolean | Do not run the job if a previous scheduled run is still active/running                                                                                                                      | `false`   |
 | `cd.doco.job.notify_on`         | string  | [Notification](Notifications.md) behavior for scheduled runs: `none`, `success`, `failure`, `all`                                                                                           | `all`     |
 | `cd.doco.job.swarm.replicas`    | integer | Number of completions/concurrency for swarm one-off jobs in `replicated` [deploy mode](#swarm-deploymode)                                                                                   | `1`       |
-| `cd.doco.job.stop_services`     | string  | Comma-separated services to [temporarily stop during a job run](#temporarily-stop-services-during-a-job-run) (supports `service` and `project/service`, requires `execution_mode: one_off`) |           |
+| `cd.doco.job.stop_services`     | string  | Comma-separated services to [temporarily stop during a job run](#temporarily-stop-services-during-a-job-run) (supports `service` and `project/service`; Swarm requires `execution_mode: one_off`) |           |
 
 !!! note "Using scheduled jobs with multiple doco-cd instances"
     `cd.doco.job.skip_running` only prevents overlapping runs within the same doco-cd process.
@@ -210,11 +210,15 @@ Behavior:
 - `service` targets the same project/stack as the job.
 - `project/service` targets another compose project (standalone) or stack (swarm).
 
-!!! warning "Requires `execution_mode: one_off`"
-    `cd.doco.job.stop_services` is only valid together with `#!yaml cd.doco.job.execution_mode: "one_off"`, and the deployment is rejected otherwise.
+!!! info "Execution mode support"
+    `cd.doco.job.stop_services` is supported in both execution modes for **standalone compose**:
 
-    ??? question "Why?"
-        Stopped services are restored as soon as the job finishes, so doco-cd must be able to detect job completion. It only does so in `one_off` mode, where it waits for the one-off container/task to exit. In `restart` mode (the default) the run returns as soon as the restart has been issued, which would bring the stopped services back up while the job is still running.
+    | Mode | Standalone | Swarm |
+    |---|---|---|
+    | `one_off` | ✅ | ✅ |
+    | `restart` (default) | ✅ | ❌ |
+
+    In Swarm mode, `restart` is not supported because doco-cd cannot detect when the job has finished.
 
 !!! warning "Use service names, not container names"
     Values must reference the **compose service name** (the key under `services:`), **not** `container_name`.


### PR DESCRIPTION
This pull request introduces support for scheduled jobs to temporarily stop and restart other services within a Docker Compose project, controlled via a new `cd.doco.job.stop_services` label. It adds robust parsing, validation, and runtime logic for this feature, along with comprehensive tests to ensure correctness and prevent misconfiguration (such as a job stopping itself). The changes also ensure that only jobs in "one_off" execution mode can use this feature, as only then can job completion be reliably detected.

**New service stop/start feature for scheduled jobs:**

* Added a new label `cd.doco.job.stop_services` allowing jobs to specify a comma-separated list of services (within the same or other projects) to be stopped before the job runs and restarted after completion. [[1]](diffhunk://#diff-36889ffc0132096110fcf8672f861548d9bd3032939aa6f65f4bfcc90ea6fd55R97) [[2]](diffhunk://#diff-36889ffc0132096110fcf8672f861548d9bd3032939aa6f65f4bfcc90ea6fd55R110)
* Introduced the `StopServiceRef` struct and related parsing/validation logic to robustly handle service references, including cross-project support and whitespace handling. [[1]](diffhunk://#diff-964cea39e21ed8f8ffd70325af5dab07e3746c9c97be0622fa4caa612702d01bR42-R59) [[2]](diffhunk://#diff-964cea39e21ed8f8ffd70325af5dab07e3746c9c97be0622fa4caa612702d01bR173-R259)

**Compose project runtime logic:**

* Implemented `StopProjectServices` and `StartProjectServices` functions to stop/start only the specified services in a project, ensuring no unintended dependency traversal and aggregating errors for best-effort operation.
* Added tests to verify correct stopping/starting of services, including scenarios with service dependencies (`depends_on`).

**Validation and safety checks:**

* Enforced that jobs cannot stop themselves (either by name or explicit project/service reference) with both deploy-time and runtime validation, improving user feedback and preventing scheduler errors. [[1]](diffhunk://#diff-964cea39e21ed8f8ffd70325af5dab07e3746c9c97be0622fa4caa612702d01bR173-R259) [[2]](diffhunk://#diff-f33115673b6cb509509ddcc95fce83ec30033c2a072c853197f4e1e9125a3f06L12-R12) [[3]](diffhunk://#diff-f33115673b6cb509509ddcc95fce83ec30033c2a072c853197f4e1e9125a3f06R21-R29) [[4]](diffhunk://#diff-4e3eb705c92f6a0e4862b26403222aed6c106b80e6e0dd924ed28c604de0e55fR150-R225)
* Restricted use of `stop_services` to jobs with `one_off` execution mode, as this is the only mode where job completion can be reliably observed and stopped services safely restarted. [[1]](diffhunk://#diff-964cea39e21ed8f8ffd70325af5dab07e3746c9c97be0622fa4caa612702d01bR173-R259) [[2]](diffhunk://#diff-5e0503b94c4432cca6b7720573a29ba4c7299d69fe5aeb99365ca2d606dfb5d4R156-R359)

**Testing and coverage:**

* Added comprehensive unit and integration tests covering parsing, validation, and runtime behavior for the new `stop_services` functionality, including edge cases and error scenarios. [[1]](diffhunk://#diff-5e0503b94c4432cca6b7720573a29ba4c7299d69fe5aeb99365ca2d606dfb5d4L3-R8) [[2]](diffhunk://#diff-5e0503b94c4432cca6b7720573a29ba4c7299d69fe5aeb99365ca2d606dfb5d4R156-R359) [[3]](diffhunk://#diff-4e3eb705c92f6a0e4862b26403222aed6c106b80e6e0dd924ed28c604de0e55fR150-R225) [[4]](diffhunk://#diff-2ef14ea74d1b196daa1d2c7656f5101457c50ac6ca9f246767308a21dfb34331R1993-R2158)