### PR TITLE
feat(notification): expose deployed commits in body templates

### DIFF
--- a/internal/git/commits_test.go
+++ b/internal/git/commits_test.go
@@ -18,7 +18,7 @@ func commitN(t *testing.T, wt *gogit.Worktree, n int) []plumbing.Hash {
 	hashes := make([]plumbing.Hash, 0, n)
 	when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		sig := &object.Signature{Name: "Jane Doe", Email: "jane@example.com", When: when.Add(time.Duration(i) * time.Minute)}
 
 		h, err := wt.Commit("commit "+string(rune('a'+i)), &gogit.CommitOptions{

--- a/internal/git/commits_test.go
+++ b/internal/git/commits_test.go
@@ -1,0 +1,126 @@
+package git
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+// commitN creates n empty commits and returns their hashes oldest-first.
+func commitN(t *testing.T, wt *gogit.Worktree, n int) []plumbing.Hash {
+	t.Helper()
+
+	hashes := make([]plumbing.Hash, 0, n)
+	when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for i := 0; i < n; i++ {
+		sig := &object.Signature{Name: "Jane Doe", Email: "jane@example.com", When: when.Add(time.Duration(i) * time.Minute)}
+
+		h, err := wt.Commit("commit "+string(rune('a'+i)), &gogit.CommitOptions{
+			AllowEmptyCommits: true,
+			Author:            sig,
+			Committer:         sig,
+		})
+		if err != nil {
+			t.Fatalf("commit %d: %v", i, err)
+		}
+
+		hashes = append(hashes, h)
+	}
+
+	return hashes
+}
+
+func TestGetCommitsBetween(t *testing.T) {
+	repo, err := gogit.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	h := commitN(t, wt, 4) // h[0] oldest .. h[3] newest
+
+	// commits after h[0] up to h[3]: h[3], h[2], h[1] (newest first)
+	got, err := GetCommitsBetween(repo, h[0], h[3], 50)
+	if err != nil {
+		t.Fatalf("GetCommitsBetween: %v", err)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 commits, got %d: %+v", len(got), got)
+	}
+
+	if got[0].Hash != h[3].String() || got[2].Hash != h[1].String() {
+		t.Fatalf("wrong order: %+v", got)
+	}
+
+	if got[0].Author != "Jane Doe" || got[0].ShortHash != h[3].String()[:DefaultShortSHALength] {
+		t.Fatalf("unexpected fields: %+v", got[0])
+	}
+
+	// same old==new -> empty
+	empty, err := GetCommitsBetween(repo, h[3], h[3], 50)
+	if err != nil {
+		t.Fatalf("GetCommitsBetween equal: %v", err)
+	}
+
+	if len(empty) != 0 {
+		t.Fatalf("expected 0 commits, got %d", len(empty))
+	}
+
+	// cap is honoured
+	capped, err := GetCommitsBetween(repo, plumbing.ZeroHash, h[3], 2)
+	if err != nil {
+		t.Fatalf("GetCommitsBetween capped: %v", err)
+	}
+
+	if len(capped) != 2 {
+		t.Fatalf("expected 2 commits (capped), got %d", len(capped))
+	}
+}
+
+// A force-push/rebase makes the old tip no longer an ancestor of the new tip.
+// The walk must stop at the merge-base and return only the diverged commits,
+// not the whole new branch.
+func TestGetCommitsBetween_DivergedHistory(t *testing.T) {
+	repo, err := gogit.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	h := commitN(t, wt, 3) // a, b(h[1]), oldTip=c(h[2])
+
+	// rewind to b and build a divergent history: d, e
+	if err := wt.Checkout(&gogit.CheckoutOptions{Hash: h[1]}); err != nil {
+		t.Fatalf("checkout: %v", err)
+	}
+
+	d := commitN(t, wt, 2) // d, newTip=e(d[1]) — both parented on b
+
+	got, err := GetCommitsBetween(repo, h[2], d[1], 50)
+	if err != nil {
+		t.Fatalf("GetCommitsBetween: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 diverged commits, got %d: %+v", len(got), got)
+	}
+
+	if got[0].Hash != d[1].String() || got[1].Hash != d[0].String() {
+		t.Fatalf("expected [e, d], got %+v", got)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -915,6 +915,88 @@ func GetChangedFilesBetweenCommits(repo *git.Repository, commitHash1, commitHash
 	return changedFiles, nil
 }
 
+// CommitInfo is a single commit exposed to notification templates.
+type CommitInfo struct {
+	Hash      string
+	ShortHash string
+	Subject   string
+	Author    string
+}
+
+// String renders "shortHash subject", the default when a template prints a commit directly.
+func (c CommitInfo) String() string {
+	return c.ShortHash + " " + c.Subject
+}
+
+// commitBoundary returns the hashes at which GetCommitsBetween should stop walking:
+// oldHash plus the merge-base of old and new. On a normal fast-forward the merge-base
+// is oldHash itself; after a rebase/force-push it is the point where the histories
+// diverged, so only the genuinely new commits are returned instead of the whole branch.
+func commitBoundary(repo *git.Repository, oldHash, newHash plumbing.Hash) map[plumbing.Hash]struct{} {
+	boundary := map[plumbing.Hash]struct{}{oldHash: {}}
+
+	newCommit, err := repo.CommitObject(newHash)
+	if err != nil {
+		return boundary
+	}
+
+	oldCommit, err := repo.CommitObject(oldHash)
+	if err != nil {
+		return boundary
+	}
+
+	bases, err := newCommit.MergeBase(oldCommit)
+	if err != nil {
+		return boundary
+	}
+
+	for _, b := range bases {
+		boundary[b.Hash] = struct{}{}
+	}
+
+	return boundary
+}
+
+// GetCommitsBetween returns commits reachable from newHash but not from oldHash,
+// newest first, capped at maxCommits.
+func GetCommitsBetween(repo *git.Repository, oldHash, newHash plumbing.Hash, maxCommits int) ([]CommitInfo, error) {
+	iter, err := repo.Log(&git.LogOptions{From: newHash, Order: git.LogOrderCommitterTime})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read commit log from %s: %w", newHash, err)
+	}
+	defer iter.Close()
+
+	boundary := commitBoundary(repo, oldHash, newHash)
+	commits := make([]CommitInfo, 0, maxCommits)
+
+	stop := errors.New("stop")
+
+	err = iter.ForEach(func(c *object.Commit) error {
+		if _, atBoundary := boundary[c.Hash]; atBoundary || len(commits) >= maxCommits {
+			return stop
+		}
+
+		subject := c.Message
+		if i := strings.IndexByte(subject, '\n'); i >= 0 {
+			subject = subject[:i]
+		}
+
+		commits = append(commits, CommitInfo{
+			Hash:      c.Hash.String(),
+			ShortHash: c.Hash.String()[:DefaultShortSHALength],
+			Subject:   strings.TrimSpace(subject),
+			Author:    c.Author.Name,
+		})
+
+		return nil
+	})
+	if err != nil && !errors.Is(err, stop) {
+		return nil, fmt.Errorf("failed to walk commit log: %w", err)
+	}
+
+	return commits, nil
+}
+
 // shouldResetDecryptedFile determines whether a file should be reset based on its decrypted content.
 func shouldResetDecryptedFile(repo *git.Repository, repoRoot, file string) bool {
 	headRef, err := repo.Head()

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+
+	"github.com/kimdre/doco-cd/internal/git"
 )
 
 type level int
@@ -76,6 +78,7 @@ type Metadata struct {
 	AffectedActorKind   string
 	AffectedActorID     string
 	AffectedActorName   string
+	Commits             []git.CommitInfo // commits deployed since the last deploy; empty on first deploy/failure/OCI
 }
 
 // TemplateData is the data exposed to a user-configured notification body template.
@@ -110,6 +113,9 @@ func validateTemplate(tmpl string) (*template.Template, error) {
 		Metadata: Metadata{
 			Repository: "github.com/acme/app", Stack: "app", Context: "default",
 			Revision: "refs/heads/main (abc123)", JobID: "sample",
+			Commits: []git.CommitInfo{
+				{Hash: "abc123", ShortHash: "abc123", Subject: "sample commit", Author: "Jane Doe"},
+			},
 		},
 	}
 	if err := t.Execute(io.Discard, sample); err != nil {

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -179,6 +179,8 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 	}
 
 	if deployedCommit := deployedState.GetDeploymentCommitSHA(); deployedCommit != "" {
+		s.DeployState.DeployedCommit = deployedCommit
+
 		latestCommit, err := git.GetLatestCommit(s.Repository.Git, s.DeployConfig.Reference)
 		if err != nil {
 			return fmt.Errorf("failed to get latest commit: %w", err)

--- a/internal/stages/stage_4_post-deploy.go
+++ b/internal/stages/stage_4_post-deploy.go
@@ -7,11 +7,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing"
+
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
 )
+
+const maxChangelogCommits = 50
 
 func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logger) error {
 	s.Stages.PostDeploy.StartedAt = time.Now()
@@ -23,8 +27,11 @@ func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logg
 	var err error
 
 	shortCommit := strings.TrimSpace(s.Repository.Revision)
+
+	var latestCommit string
+
 	if s.Repository.Source != config.SourceTypeOCI {
-		latestCommit, err := git.GetLatestCommit(s.Repository.Git, s.DeployConfig.Reference)
+		latestCommit, err = git.GetLatestCommit(s.Repository.Git, s.DeployConfig.Reference)
 		if err != nil {
 			return fmt.Errorf("failed to get latest commit: %w", err)
 		}
@@ -42,6 +49,19 @@ func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logg
 	metadata.Target = s.DeployConfig.Internal.ConfigTarget
 	metadata.Revision = notification.GetRevision(s.DeployConfig.Reference, shortCommit)
 	metadata.JobID = s.JobID
+
+	if s.DeployState.DeployedCommit != "" && latestCommit != "" {
+		metadata.Commits, err = git.GetCommitsBetween(
+			s.Repository.Git,
+			plumbing.NewHash(s.DeployState.DeployedCommit),
+			plumbing.NewHash(latestCommit),
+			maxChangelogCommits,
+		)
+		if err != nil {
+			// changelog is best-effort, never block the notification
+			stageLog.Warn("failed to build commit changelog", logger.ErrAttr(err))
+		}
+	}
 
 	err = notification.Send(notification.Success, "Deployment completed", "Successfully deployed stack "+s.DeployConfig.Name, metadata)
 	if err != nil {

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -134,6 +134,7 @@ type Docker struct {
 type DeploymentState struct {
 	changedServices []docker.Change
 	ignoredInfo     docker.IgnoredInfo
+	DeployedCommit  string // previously-deployed commit SHA, carried to post-deploy for the changelog
 }
 
 // StageManager is the main structure that holds the logger and stage data.

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -91,6 +91,7 @@ The following fields are available:
 | `.AffectedActorKind`  | `container` or `service`                                                 |
 | `.AffectedActorID`    | Affected container/service ID                                            |
 | `.AffectedActorName`  | Affected container/service name                                          |
+| `.Commits`            | Commits deployed since the last deploy (see [Commit changelog](#commit-changelog)) |
 
 `{{ .DefaultBody }}` renders the built-in body (message + metadata), so you can extend the default format instead of replacing it, e.g. `{{ .DefaultBody }}\nhost: my-vm`.
 
@@ -102,6 +103,32 @@ The following fields are available:
     ```
 
     renders e.g. `✅ prod-vm/app — Successfully deployed stack app (main (abc123))` for target `prod-vm`, or `✅ app — Successfully deployed stack app (main (abc123))` without a custom target.
+
+### Commit changelog
+
+`.Commits` is the list of commits that got deployed since the previously deployed commit, newest first. It is only populated on successful deploy notifications of Git sources; on the first deploy, on failures and for OCI sources it stays empty (a `range` over it just renders nothing). Each entry has:
+
+| Field         | Description                          |
+|---------------|--------------------------------------|
+| `.ShortHash`  | Shortened commit SHA                  |
+| `.Subject`    | First line of the commit message     |
+| `.Author`     | Commit author name                    |
+
+Printing an entry directly (`{{ . }}`) gives `shortHash subject`.
+
+!!! example "Body with changelog"
+
+    ```yaml
+    environment:
+      APPRISE_NOTIFY_BODY_TEMPLATE: |
+        {{ .DefaultBody }}
+        {{ range .Commits }}- {{ .ShortHash }} {{ .Subject }} ({{ .Author }})
+        {{ end }}
+    ```
+
+Up to 50 commits are listed. After a rebase or force-push the list starts from the point where the histories diverged.
+
+The changelog is best-effort: with a small `GIT_CLONE_DEPTH` the previously deployed commit may sit beyond the shallow boundary, in which case the list is truncated or omitted. It never blocks the notification.
 
 ## Reconciliation notifications
 

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -110,6 +110,7 @@ The following fields are available:
 
 | Field         | Description                          |
 |---------------|--------------------------------------|
+| `.Hash`       | Full commit SHA                       |
 | `.ShortHash`  | Shortened commit SHA                  |
 | `.Subject`    | First line of the commit message     |
 | `.Author`     | Commit author name                    |


### PR DESCRIPTION
Notification body templates could show only the single `{{ .Revision }}` string. This adds `{{ .Commits }}` - the list of commits deployed since the previously deployed commit - so a new pull can render a changelog in the notification.

Each entry exposes `.ShortHash`, `.Subject`, `.Author`. Printing an entry directly (`{{ . }}`) gives `shortHash subject`. Example:

```yaml
environment:
  APPRISE_NOTIFY_BODY_TEMPLATE: |
    {{ .DefaultBody }}
    {{ range .Commits }}- {{ .ShortHash }} {{ .Subject }} ({{ .Author }})
    {{ end }}
```

How it works:

- Previously deployed SHA is read from the container label in pre-deploy (stage_2) and carried on `DeploymentState` to `post-deploy` (stage_4).
- `git.GetCommitsBetween` walks the log from the new commit back to the merge-base with the old one, so after a rebase or force-push only the diverged commits are listed, not the whole branch. Ordered by committer time.
- `Metadata.Commits` is the new template field. The default body is untouched - nothing shows unless a template ranges over `.Commits`.

Edge cases:

- First deploy, OCI sources, or a redeploy with no new commits give an empty list.
- Capped at 50 commits.
- Best-effort: any walk error is logged and the notification still sends with an empty list.
- Shallow clones (`GIT_CLONE_DEPTH > 0`): if the old commit is beyond the shallow boundary the list may be truncated or empty. Documented in the notifications page.

Tests in internal/git/commits_test.go cover ordering, empty when old==new, the cap, and a diverged (force-push) history stopping at the merge-base.
