### PR TITLE
feat(notification): expose deploy duration and changed services in body templates

### DIFF
--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+	"time"
 
 	"github.com/kimdre/doco-cd/internal/git"
 )
@@ -79,6 +80,8 @@ type Metadata struct {
 	AffectedActorID     string
 	AffectedActorName   string
 	Commits             []git.CommitInfo // commits deployed since the last deploy; empty on first deploy/failure/OCI
+	Duration            time.Duration    // time from job start to the notification; zero when no deploy/destroy ran
+	ChangedServices     []string         // services force-recreated by this deploy; empty when the whole stack is (re)deployed
 }
 
 // TemplateData is the data exposed to a user-configured notification body template.
@@ -116,6 +119,8 @@ func validateTemplate(tmpl string) (*template.Template, error) {
 			Commits: []git.CommitInfo{
 				{Hash: "abc123", ShortHash: "abc123", Subject: "sample commit", Author: "Jane Doe"},
 			},
+			Duration:        42 * time.Second,
+			ChangedServices: []string{"app"},
 		},
 	}
 	if err := t.Execute(io.Discard, sample); err != nil {

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/kimdre/doco-cd/internal/common/id"
 	"github.com/kimdre/doco-cd/internal/test"
@@ -323,6 +324,26 @@ func TestRenderTemplate(t *testing.T) {
 			JobID:      "job-99",
 		})
 		expected := "Deploy done\n\njob_id: job-99\nrepository: acme/repo"
+
+		if got != expected {
+			t.Errorf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("renders duration and changed services", func(t *testing.T) {
+		t.Parallel()
+
+		tmpl, err := validateTemplate("{{.Stack}} in {{.Duration}}{{range .ChangedServices}} {{.}}{{end}}")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := renderTemplate(tmpl, Success, "Deployment completed", "", Metadata{
+			Stack:           "app",
+			Duration:        1500 * time.Millisecond,
+			ChangedServices: []string{"web", "worker"},
+		})
+		expected := "app in 1.5s web worker"
 
 		if got != expected {
 			t.Errorf("expected %q, got %q", expected, got)

--- a/internal/stages/stage_4_post-deploy.go
+++ b/internal/stages/stage_4_post-deploy.go
@@ -49,6 +49,8 @@ func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logg
 	metadata.Target = s.DeployConfig.Internal.ConfigTarget
 	metadata.Revision = notification.GetRevision(s.DeployConfig.Reference, shortCommit)
 	metadata.JobID = s.JobID
+	metadata.Duration = time.Since(s.Stages.Init.StartedAt).Truncate(time.Millisecond)
+	metadata.ChangedServices = s.DeployState.changedServiceNames()
 
 	if s.DeployState.DeployedCommit != "" && latestCommit != "" {
 		metadata.Commits, err = git.GetCommitsBetween(

--- a/internal/stages/stage_4_post-destroy.go
+++ b/internal/stages/stage_4_post-destroy.go
@@ -22,6 +22,7 @@ func (s *StageManager) RunPostDestroyStage(_ context.Context, stageLog *slog.Log
 	metadata.Context = s.DeployConfig.Context
 	metadata.Target = s.DeployConfig.Internal.ConfigTarget
 	metadata.JobID = s.JobID
+	metadata.Duration = time.Since(s.Stages.Init.StartedAt).Truncate(time.Millisecond)
 
 	err := notification.Send(notification.Success, "Stack destroyed", "successfully destroyed stack "+s.DeployConfig.Name, metadata)
 	if err != nil {

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	types2 "github.com/kimdre/doco-cd/internal/config"
 
 	"github.com/kimdre/doco-cd/internal/commitstatus"
+	"github.com/kimdre/doco-cd/internal/common/types/slice"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker"
@@ -135,6 +137,23 @@ type DeploymentState struct {
 	changedServices []docker.Change
 	ignoredInfo     docker.IgnoredInfo
 	DeployedCommit  string // previously-deployed commit SHA, carried to post-deploy for the changelog
+}
+
+// changedServiceNames flattens the detected changes into a unique list of service names.
+func (d *DeploymentState) changedServiceNames() []string {
+	if d == nil {
+		return nil
+	}
+
+	var names []string
+	for _, change := range d.changedServices {
+		names = append(names, change.Services...)
+	}
+
+	names = slice.Unique(names)
+	slices.Sort(names)
+
+	return names
 }
 
 // StageManager is the main structure that holds the logger and stage data.
@@ -259,6 +278,11 @@ func (s *StageManager) NotifyFailure(notifyErr error) {
 		metadata.Target = s.DeployConfig.Internal.ConfigTarget
 		metadata.Revision = revision
 		metadata.JobID = s.JobID
+		metadata.ChangedServices = s.DeployState.changedServiceNames()
+
+		if !s.Stages.Init.StartedAt.IsZero() {
+			metadata.Duration = time.Since(s.Stages.Init.StartedAt).Truncate(time.Millisecond)
+		}
 
 		s.NotifyFailureFunc(s.Log, notifyErr, metadata)
 	}

--- a/internal/stages/types_test.go
+++ b/internal/stages/types_test.go
@@ -1,0 +1,43 @@
+package stages
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/kimdre/doco-cd/internal/docker"
+)
+
+func TestChangedServiceNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil state returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		var d *DeploymentState
+		if got := d.changedServiceNames(); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("empty state returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		if got := (&DeploymentState{}).changedServiceNames(); len(got) != 0 {
+			t.Errorf("expected no names, got %v", got)
+		}
+	})
+
+	t.Run("flattens, dedupes and sorts", func(t *testing.T) {
+		t.Parallel()
+
+		d := &DeploymentState{changedServices: []docker.Change{
+			{Type: "mounts", Services: []string{"worker", "web"}},
+			{Type: "mismatch", Services: []string{"web", "caddy"}},
+		}}
+
+		expected := []string{"caddy", "web", "worker"}
+		if got := d.changedServiceNames(); !slices.Equal(got, expected) {
+			t.Errorf("expected %v, got %v", expected, got)
+		}
+	})
+}

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -92,6 +92,8 @@ The following fields are available:
 | `.AffectedActorID`    | Affected container/service ID                                            |
 | `.AffectedActorName`  | Affected container/service name                                          |
 | `.Commits`            | Commits deployed since the last deploy (see [Commit changelog](#commit-changelog)) |
+| `.Duration`           | Time the deployment (or destroy) took, from job start to the notification, e.g. `12.483s`. Zero where no deployment ran (reconciliation restarts, scheduled jobs) — hide it with `{{if .Duration}}...{{end}}` |
+| `.ChangedServices`    | Sorted names of the services force-recreated by this deploy (changed mounted/referenced files or a changed auto-discovery label). Empty when the whole stack is (re)deployed for other reasons, e.g. a compose config change, an image update, state drift or `force_recreate` |
 
 `{{ .DefaultBody }}` renders the built-in body (message + metadata), so you can extend the default format instead of replacing it, e.g. `{{ .DefaultBody }}\nhost: my-vm`.
 


### PR DESCRIPTION
Two more template fields for the notification body, following the same pattern as `{{ .Commits }}`

`{{ .Duration }}` - time from job start to the notification. Useful to spot a slowly creeping deploy time right in the ping. Set on deploy, destroy and failure notifications; stays zero where no deployment ran (reconciliation restarts, scheduled jobs), so `{{ if .Duration }}` hides it there. Truncated to milliseconds, renders via `time.Duration.String()` (`12.483s`).

`{{ .ChangedServices }}` - sorted unique names of the services this deploy force-recreated (changed mounted/referenced files or a changed auto-discovery label). Answers exactly which service in the stack was deployed. Empty when the whole stack is (re)deployed for other reasons - compose config change, image update, drift, `force_recreate`.

Example:

```yaml
environment:
  APPRISE_NOTIFY_BODY_TEMPLATE: |
    {{ .Stack }} @ {{ .Revision }}{{ if .Duration }} in {{ .Duration }}{{ end }}
    {{- range .ChangedServices }}
    recreated: {{ . }}
    {{- end }}
```

How it works:

- `Metadata.Duration` / `Metadata.ChangedServices` are the new fields; both are in the startup validation sample, so templates referencing them fail fast on config errors as before. Default body is untouched.
- Duration is `time.Since(Stages.Init.StartedAt)` in post-deploy/post-destroy; in `NotifyFailure` it is guarded by `IsZero` for failures that happen before init.
- Changed services flatten `DeploymentState.changedServices` (the list stage_3 force-recreates), deduped and sorted for stable output - `slice.Unique` is map-backed, order was random otherwise.
- Hand-built metadata paths (reconciliation restarts, scheduler, version ping) simply leave both at zero values.

Edge cases: first deploy and OCI sources give an empty `ChangedServices`; a drift-only or config-only redeploy too (nothing was file-triggered). Tests cover template render of both fields plus the flatten/dedupe/sort helper.

Docs row added to the notifications page.