### PR TITLE
feat(notification): duration in default body, document the .Message pitfall

### DIFF
--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -309,6 +309,10 @@ func (d TemplateData) DefaultBody() string {
 		fields["job_id"] = m.JobID
 	}
 
+	if m.Duration > 0 {
+		fields["duration"] = m.Duration.String()
+	}
+
 	if m.ReconciliationEvent != "" {
 		reconciliationFields["event"] = m.ReconciliationEvent
 	}

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -157,6 +157,27 @@ func TestDefaultBody(t *testing.T) {
 		}
 	})
 
+	t.Run("duration is a metadata line when set, omitted when zero", func(t *testing.T) {
+		t.Parallel()
+
+		message := defaultBody("Deployment completed", Metadata{
+			Repository: "acme/api",
+			Duration:   12483 * time.Millisecond,
+		})
+		expected := "Deployment completed\n\nduration: 12.483s\nrepository: acme/api"
+
+		if message != expected {
+			t.Errorf("expected %q, got %q", expected, message)
+		}
+
+		message = defaultBody("Deployment completed", Metadata{Repository: "acme/api"})
+		expected = "Deployment completed\n\nrepository: acme/api"
+
+		if message != expected {
+			t.Errorf("expected %q, got %q", expected, message)
+		}
+	})
+
 	t.Run("reconciliation metadata includes event and affected actor", func(t *testing.T) {
 		t.Parallel()
 

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -60,6 +60,7 @@ When a notification is sent, the following metadata fields are included in the n
 
 | Field name   | Description                                                                                                                                      | Example                            |
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| `duration`   | Time the deployment took (omitted when no deployment ran, e.g. for [reconciliation notifications](#reconciliation-notifications))                 | `12.483s`                          |
 | `job_id`     | Unique ID of the deployment job that triggered the notification (not included for [reconciliation notifications](#reconciliation-notifications)) |                                    |
 | `repository` | Repository name                                                                                                                                  | `github.com/my/repo`               |
 | `revision`   | Branch/tag and Commit SHA that was deployed                                                                                                      | `main (abc123)`, `v1.0.0 (def456)` |
@@ -70,6 +71,14 @@ When a notification is sent, the following metadata fields are included in the n
 By default the notification body is the message followed by the [metadata fields](#metadata-fields) as `key: value` lines. Set `APPRISE_NOTIFY_BODY_TEMPLATE` (or `APPRISE_NOTIFY_BODY_TEMPLATE_FILE`) to a [Go `text/template`](https://pkg.go.dev/text/template) to render the body yourself — useful to drop noisy fields, add a host label, or produce a one-liner when several stacks report into one channel.
 
 The template is validated at startup: a syntax error or a reference to an unknown field stops doco-cd from starting. The title (emoji + optional `[R]` marker + title text) is not affected by the template.
+
+!!! warning "Don't swallow failure reasons"
+
+    The template replaces the default body for **every** notification level, and on `failure` the error text is only carried by `{{ .Message }}` — a template that never references it produces failure notifications with no failure reason at all (the title only says `Deployment failed`; the details then live only in the logs). On `success`, `.Message` is largely redundant with the title, so compact templates should include it guarded by level:
+
+    ```
+    {{ if ne .Level "success" }} — {{ .Message }}{{ end }}
+    ```
 
 The following fields are available:
 


### PR DESCRIPTION
Follow-ups from the #1591 discussion:

- Default body gets a `duration: 12.483s` metadata line. Only when a deployment actually ran: zero duration is omitted, so reconciliation restarts, scheduled jobs and the version ping keep their current bodies byte-for-byte. 

- Updated docs with `.Message` ting
```
{{ if ne .Level "success" }} — {{ .Message }}{{ end }}
```

Test covers the new line and the omitted-when-zero case; existing DefaultBody expectations untouched.