### PR TITLE
fix: skip/ignore services with scale 0

### DIFF
--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -515,7 +515,7 @@ func HaveDeployedServiceImageDigestsChanged(ctx context.Context, dockerCli comma
 	uniqueRefs := set.New[string]()
 
 	for _, svc := range project.Services {
-		if svc.Image == "" {
+		if svc.Image == "" || svc.GetScale() == 0 {
 			continue
 		}
 

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -515,6 +515,7 @@ func HaveDeployedServiceImageDigestsChanged(ctx context.Context, dockerCli comma
 	uniqueRefs := set.New[string]()
 
 	for _, svc := range project.Services {
+		// Scale-0 (parked) services never produce a container, so they have no deployed digest to compare.
 		if svc.Image == "" || svc.GetScale() == 0 {
 			continue
 		}

--- a/internal/docker/images_test.go
+++ b/internal/docker/images_test.go
@@ -177,6 +177,21 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 			wantRegistryCalls: 0,
 		},
 		{
+			name: "skips parked services",
+			project: &types.Project{
+				Name: "test",
+				Services: types.Services{
+					"web":        {Name: "web", Image: "nginx:latest"},
+					"extra-tool": {Name: "extra-tool", Image: "busybox:latest", Scale: new(0)},
+				},
+			},
+			registryDigest:       "sha256:same",
+			deployedDigests:      map[string]string{"web": "sha256:same"},
+			wantChanged:          false,
+			wantRegistryCalls:    1,
+			wantRegistryCallRefs: []string{"nginx:latest"},
+		},
+		{
 			name: "returns true when deployed digest missing",
 			project: &types.Project{
 				Name: "test",

--- a/internal/docker/project.go
+++ b/internal/docker/project.go
@@ -99,6 +99,13 @@ func shouldIgnoreLabelInProjectHash(label string) bool {
 func ProjectHash(p *types.Project) (string, error) {
 	pCopy := copyProject(p)
 
+	// Parked services never create containers, so they must not affect restart-time hash checks.
+	for name, svc := range pCopy.Services {
+		if svc.GetScale() == 0 {
+			delete(pCopy.Services, name)
+		}
+	}
+
 	// Only behavior-configuring labels should impact redeploy decisions.
 	for name := range pCopy.Services {
 		svc := pCopy.Services[name]

--- a/internal/docker/project_test.go
+++ b/internal/docker/project_test.go
@@ -169,3 +169,44 @@ func TestProjectHash_IgnoresComposeGeneratedLabels(t *testing.T) {
 		t.Fatalf("expected compose-generated label to be ignored, got %q and %q", baseHash, withComposeRuntimeLabelHash)
 	}
 }
+
+func TestProjectHash_IgnoresScaleZeroServices(t *testing.T) {
+	t.Parallel()
+
+	base := &types.Project{
+		Services: types.Services{
+			"api": {
+				Name:  "api",
+				Image: "nginx:latest",
+			},
+		},
+	}
+
+	withParkedService := &types.Project{
+		Services: types.Services{
+			"api": {
+				Name:  "api",
+				Image: "nginx:latest",
+			},
+			"extra-tool": {
+				Name:  "extra-tool",
+				Image: "busybox:latest",
+				Scale: new(0),
+			},
+		},
+	}
+
+	baseHash, err := ProjectHash(base)
+	if err != nil {
+		t.Fatalf("ProjectHash(base) error: %v", err)
+	}
+
+	withParkedServiceHash, err := ProjectHash(withParkedService)
+	if err != nil {
+		t.Fatalf("ProjectHash(withParkedService) error: %v", err)
+	}
+
+	if baseHash != withParkedServiceHash {
+		t.Fatalf("expected parked services to be ignored, got %q and %q", baseHash, withParkedServiceHash)
+	}
+}


### PR DESCRIPTION
Fix `scale: 0` handling in deploy change detection.

- Skip parked services when comparing deployed vs. registry image digests, preventing infinite redeploys with `force_image_pull`.
- Exclude parked services from `ProjectHash` so restart-time and warm-cache compose hashes match.
- Add regression tests for both behaviors.