### PR TITLE
feat: add option to rewrite source URLs in deployments

### DIFF
--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -162,6 +162,14 @@ func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config,
 	sourceType := config.NormalizeSourceType(pollConfig.Source)
 	sourceRef := pollConfig.SourceUrl
 	entity := logEntityForSourceType(sourceType)
+	sourceURLRewriteApplied := false
+
+	if sourceType == config.SourceTypeGit && appConfig != nil {
+		var rewritten string
+
+		rewritten, sourceURLRewriteApplied = rewriteSourceURL(sourceRef, appConfig.SourceURLRewrites)
+		sourceRef = rewritten
+	}
 
 	repoName := git.GetRepoName(sourceRef)
 	if sourceType == config.SourceTypeOCI {
@@ -171,6 +179,10 @@ func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config,
 	jobLog := logger.With(
 		slog.String("job_id", metadata.JobID),
 	)
+
+	if sourceURLRewriteApplied {
+		jobLog.Debug("using configured source URL rewrite", slog.String("source_url", sourceRef))
+	}
 
 	if pollConfig.CustomTarget != "" {
 		jobLog = jobLog.With(slog.String("target", pollConfig.CustomTarget))

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -295,7 +295,8 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 
 	sourceType := config.SourceTypeGit
 
-	sourceRef := payload.CloneURL
+	var sourceRef string
+
 	cloneURLOverrideApplied := false
 
 	if payload.Source == webhook.PayloadSourceOCI {

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -31,6 +33,180 @@ import (
 
 var ErrInvalidHTTPMethod = errors.New("invalid http method")
 
+// normalizeSourceURLRewriteKey normalizes the source URL rewrite key
+// by trimming whitespace and converting it to lowercase.
+func normalizeSourceURLRewriteKey(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+// resolveWebhookGitCloneURL checks if there is a configured clone URL override for the given webhook payload and
+// returns the resolved clone URL along with a boolean indicating whether an override was applied.
+func resolveWebhookGitCloneURL(payload webhook.ParsedPayload, appConfig *app.Config) (string, bool) {
+	defaultURL := strings.TrimSpace(payload.CloneURL)
+	if appConfig == nil || len(appConfig.SourceURLRewrites) == 0 {
+		return defaultURL, false
+	}
+
+	return rewriteSourceURL(defaultURL, appConfig.SourceURLRewrites)
+}
+
+// rewriteSourceURL applies the configured source URL rewrites to the given source URL and
+// returns the rewritten URL along with a boolean indicating whether a rewrite was applied.
+func rewriteSourceURL(sourceURL string, rewrites map[string]string) (string, bool) {
+	sourceURL = strings.TrimSpace(sourceURL)
+	if sourceURL == "" || len(rewrites) == 0 {
+		return sourceURL, false
+	}
+
+	keys := make([]string, 0, len(rewrites))
+	for key := range rewrites {
+		normalizedKey := normalizeSourceURLRewriteKey(key)
+		if normalizedKey == "" {
+			continue
+		}
+
+		keys = append(keys, normalizedKey)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return len(keys[i]) > len(keys[j])
+	})
+
+	for _, key := range keys {
+		target := strings.TrimSpace(rewrites[key])
+		if target == "" {
+			continue
+		}
+
+		if strings.HasPrefix(sourceURL, key) {
+			return target + sourceURL[len(key):], true
+		}
+
+		if rewrittenURL, ok := rewriteGitURLHost(sourceURL, key, target); ok {
+			return rewrittenURL, true
+		}
+	}
+
+	return sourceURL, false
+}
+
+// rewriteGitURLHost rewrites the host in the given Git URL if it matches the specified matchHost,
+// replacing it with the target host.
+func rewriteGitURLHost(sourceURL, matchHost, target string) (string, bool) {
+	if rewrittenURL, ok := rewriteHostInStandardURL(sourceURL, matchHost, target); ok {
+		return rewrittenURL, true
+	}
+
+	return rewriteHostInSCPURL(sourceURL, matchHost, target)
+}
+
+// rewriteHostInStandardURL rewrites the host in a standard URL (e.g., "https://example.com/repo.git")
+// if it matches the specified matchHost,.
+func rewriteHostInStandardURL(sourceURL, matchHost, target string) (string, bool) {
+	u, err := url.Parse(sourceURL)
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+
+	if !hostsMatch(u.Hostname(), u.Host, matchHost) {
+		return "", false
+	}
+
+	if replacementURL, repErr := url.Parse(target); repErr == nil && replacementURL.Host != "" {
+		if replacementURL.Scheme != "" {
+			u.Scheme = replacementURL.Scheme
+		}
+
+		if replacementURL.User != nil {
+			u.User = replacementURL.User
+		}
+
+		u.Host = replacementURL.Host
+
+		return u.String(), true
+	}
+
+	u.Host = target
+
+	return u.String(), true
+}
+
+// rewriteHostInSCPURL rewrites the host in an SCP-style Git URL (e.g., "git@github.com:user/repo.git")
+// if it matches the specified matchHost, replacing it with the target host.
+func rewriteHostInSCPURL(sourceURL, matchHost, target string) (string, bool) {
+	if strings.Contains(sourceURL, "://") {
+		return "", false
+	}
+
+	at := strings.Index(sourceURL, "@")
+
+	colon := strings.Index(sourceURL, ":")
+	if at <= 0 || colon <= at+1 {
+		return "", false
+	}
+
+	user := sourceURL[:at]
+	host := sourceURL[at+1 : colon]
+
+	repoPath := sourceURL[colon+1:]
+	if repoPath == "" || !hostsMatch(host, host, matchHost) {
+		return "", false
+	}
+
+	targetHost := target
+	targetUser := user
+
+	if replacementURL, err := url.Parse(target); err == nil && replacementURL.Host != "" {
+		targetHost = replacementURL.Host
+		if replacementURL.User != nil {
+			targetUser = replacementURL.User.Username()
+		}
+	} else if strings.Contains(target, "@") {
+		parts := strings.SplitN(target, "@", 2)
+		if strings.TrimSpace(parts[0]) != "" {
+			targetUser = strings.TrimSpace(parts[0])
+		}
+
+		targetHost = strings.TrimSpace(parts[1])
+	}
+
+	if targetHost == "" {
+		return "", false
+	}
+
+	return fmt.Sprintf("%s@%s:%s", targetUser, targetHost, repoPath), true
+}
+
+// hostsMatch checks if the given hostname or host with port matches the specified rule,
+// considering normalization and potential port differences.
+func hostsMatch(hostname, hostWithPort, rule string) bool {
+	rule = normalizeSourceURLRewriteKey(rule)
+	if rule == "" || strings.ContainsAny(rule, "/@") {
+		return false
+	}
+
+	normalizedHostname := normalizeSourceURLRewriteKey(hostname)
+	normalizedHostWithPort := normalizeSourceURLRewriteKey(hostWithPort)
+
+	if strings.Contains(rule, ":") {
+		return normalizedHostWithPort == rule
+	}
+
+	return normalizedHostname == rule
+}
+
+// shouldUsePayloadSSHURL determines whether to use the SSH URL from the webhook payload for cloning,
+// based on whether a clone URL override was applied and the presence of an SSH private key in the resolved auth config.
+func shouldUsePayloadSSHURL(overrideApplied bool, payloadSSHURL string, resolved git.ResolvedAuthConfig) bool {
+	if overrideApplied {
+		return false
+	}
+
+	return strings.TrimSpace(payloadSSHURL) != "" && resolved.SSHPrivateKey != ""
+}
+
+// repositoryNameFromWebhookPayload extracts the repository name from the webhook payload,
+// prioritizing the full name, then the clone URL, and finally the artifact. If none are available, it returns "unknown".
 func repositoryNameFromWebhookPayload(payload webhook.ParsedPayload) string {
 	if payload.FullName != "" {
 		return payload.FullName
@@ -120,9 +296,16 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	sourceType := config.SourceTypeGit
 
 	sourceRef := payload.CloneURL
+	cloneURLOverrideApplied := false
+
 	if payload.Source == webhook.PayloadSourceOCI {
 		sourceType = config.SourceTypeOCI
 		sourceRef = payload.Artifact
+	} else {
+		sourceRef, cloneURLOverrideApplied = resolveWebhookGitCloneURL(payload, appConfig)
+		if cloneURLOverrideApplied {
+			jobLog.Debug("using configured webhook clone URL override", slog.String("clone_url", sourceRef))
+		}
 	}
 
 	entity := logEntityForSourceType(sourceType)
@@ -157,8 +340,9 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	)
 
 	// Only attempt SSH clone when URL-specific credentials include an SSH private key.
+	// If a clone URL override is configured, do not switch back to the payload SSH URL.
 	resolvedSSH := git.ResolveAuthConfig(payload.SSHUrl, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken)
-	if sourceType == config.SourceTypeGit && payload.SSHUrl != "" && resolvedSSH.SSHPrivateKey != "" {
+	if sourceType == config.SourceTypeGit && shouldUsePayloadSSHURL(cloneURLOverrideApplied, payload.SSHUrl, resolvedSSH) {
 		sshAuth, authErr := git.GetAuthMethod(payload.SSHUrl, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken)
 		if authErr != nil {
 			onError(w, jobLog.With(logger.ErrAttr(authErr)), "failed to resolve SSH auth method", authErr.Error(), http.StatusInternalServerError, metadata)

--- a/cmd/doco-cd/handler_webhook_source_test.go
+++ b/cmd/doco-cd/handler_webhook_source_test.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/kimdre/doco-cd/internal/config/app"
+	"github.com/kimdre/doco-cd/internal/git"
+	"github.com/kimdre/doco-cd/internal/webhook"
+)
+
+func TestResolveWebhookGitCloneURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		payload         webhook.ParsedPayload
+		rewrites        map[string]string
+		expectedURL     string
+		expectedApplied bool
+	}{
+		{
+			name: "rewrites by URL prefix",
+			payload: webhook.ParsedPayload{
+				CloneURL: "https://forgejo.example.com/org/repo.git",
+			},
+			rewrites: map[string]string{
+				"https://forgejo.example.com/": "http://forgejo:3000/",
+			},
+			expectedURL:     "http://forgejo:3000/org/repo.git",
+			expectedApplied: true,
+		},
+		{
+			name: "rewrites by domain host",
+			payload: webhook.ParsedPayload{
+				CloneURL: "https://forgejo.example.com/org/repo.git",
+			},
+			rewrites: map[string]string{
+				"forgejo.example.com": "forgejo:3000",
+			},
+			expectedURL:     "https://forgejo:3000/org/repo.git",
+			expectedApplied: true,
+		},
+		{
+			name: "rewrites scp URL by URI prefix",
+			payload: webhook.ParsedPayload{
+				CloneURL: "git@forgejo.example.com:org/repo.git",
+			},
+			rewrites: map[string]string{
+				"git@forgejo.example.com:": "git@forgejo.internal:",
+			},
+			expectedURL:     "git@forgejo.internal:org/repo.git",
+			expectedApplied: true,
+		},
+		{
+			name: "more specific rule wins",
+			payload: webhook.ParsedPayload{
+				CloneURL: "https://forgejo.example.com/org/repo.git",
+			},
+			rewrites: map[string]string{
+				"forgejo.example.com":          "forgejo:3000",
+				"https://forgejo.example.com/": "http://forgejo:3000/",
+			},
+			expectedURL:     "http://forgejo:3000/org/repo.git",
+			expectedApplied: true,
+		},
+		{
+			name: "no rewrite keeps original clone url",
+			payload: webhook.ParsedPayload{
+				CloneURL: "https://github.com/org/repo.git",
+			},
+			rewrites: map[string]string{
+				"forgejo.example.com": "forgejo:3000",
+			},
+			expectedURL:     "https://github.com/org/repo.git",
+			expectedApplied: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &app.Config{
+				SourceURLRewrites: tc.rewrites,
+			}
+
+			url, applied := resolveWebhookGitCloneURL(tc.payload, cfg)
+
+			if url != tc.expectedURL {
+				t.Fatalf("expected url %q, got %q", tc.expectedURL, url)
+			}
+
+			if applied != tc.expectedApplied {
+				t.Fatalf("expected applied=%v, got %v", tc.expectedApplied, applied)
+			}
+		})
+	}
+}
+
+func TestRewriteSourceURL_UsedByPollAndWebhook(t *testing.T) {
+	t.Parallel()
+
+	cfg := &app.Config{
+		SourceURLRewrites: map[string]string{
+			"https://forgejo.example.com/": "http://forgejo:3000/",
+		},
+	}
+
+	webhookURL, webhookApplied := resolveWebhookGitCloneURL(webhook.ParsedPayload{
+		CloneURL: "https://forgejo.example.com/org/repo.git",
+	}, cfg)
+	if !webhookApplied || webhookURL != "http://forgejo:3000/org/repo.git" {
+		t.Fatalf("expected webhook URL rewrite to apply, got applied=%v url=%q", webhookApplied, webhookURL)
+	}
+
+	pollURL, pollApplied := rewriteSourceURL("https://forgejo.example.com/org/repo.git", cfg.SourceURLRewrites)
+	if !pollApplied || pollURL != "http://forgejo:3000/org/repo.git" {
+		t.Fatalf("expected poll URL rewrite to apply, got applied=%v url=%q", pollApplied, pollURL)
+	}
+}
+
+func TestShouldUsePayloadSSHURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		overrideApplied bool
+		payloadSSHURL   string
+		resolved        git.ResolvedAuthConfig
+		expected        bool
+	}{
+		{
+			name:            "uses payload ssh url when no rewrite and ssh key exists",
+			overrideApplied: false,
+			payloadSSHURL:   "git@forgejo.example.com:org/repo.git",
+			resolved: git.ResolvedAuthConfig{
+				SSHPrivateKey: "private-key",
+			},
+			expected: true,
+		},
+		{
+			name:            "does not use payload ssh url when rewrite is active",
+			overrideApplied: true,
+			payloadSSHURL:   "git@forgejo.example.com:org/repo.git",
+			resolved: git.ResolvedAuthConfig{
+				SSHPrivateKey: "private-key",
+			},
+			expected: false,
+		},
+		{
+			name:            "does not use payload ssh url when no ssh key exists",
+			overrideApplied: false,
+			payloadSSHURL:   "git@forgejo.example.com:org/repo.git",
+			resolved:        git.ResolvedAuthConfig{},
+			expected:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			usePayloadSSH := shouldUsePayloadSSHURL(tc.overrideApplied, tc.payloadSSHURL, tc.resolved)
+			if usePayloadSSH != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, usePayloadSSH)
+			}
+		})
+	}
+}

--- a/internal/config/app/app_config.go
+++ b/internal/config/app/app_config.go
@@ -35,6 +35,9 @@ type Config struct {
 	ApiSecretFile                 string                 `env:"API_SECRET_FILE,file"`                                                   // ApiSecretFile is the file containing the ApiSecret
 	WebhookSecret                 string                 `env:"WEBHOOK_SECRET"`                                                         // WebhookSecret is the secret token used to authenticate the webhook
 	WebhookSecretFile             string                 `env:"WEBHOOK_SECRET_FILE,file"`                                               // WebhookSecretFile is the file containing the WebhookSecret
+	SourceURLRewritesYAML         string                 `env:"SOURCE_URL_REWRITES"`                                                    // SourceURLRewritesYAML maps URL/domain/URI match rules to rewrite targets for git source URLs.
+	SourceURLRewritesFile         string                 `env:"SOURCE_URL_REWRITES_FILE,file"`                                          // SourceURLRewritesFile is the file containing SourceURLRewritesYAML.
+	SourceURLRewrites             map[string]string      `yaml:"-"`                                                                     // SourceURLRewrites holds normalized source URL rewrite rules used by webhook and poll git sources.
 	GitAccessToken                string                 `env:"GIT_ACCESS_TOKEN"`                                                       // GitAccessToken is the access token used to authenticate with the Git server (e.g. GitHub) for private repositories
 	GitAccessTokenUser            string                 `env:"GIT_ACCESS_TOKEN_USER,notEmpty" envDefault:"oauth2"`                     // GitAccessTokenUser is the username paired with GitAccessToken for HTTP(S) clone/fetch. Needed by providers whose tokens have a fixed username (e.g. GitLab deploy tokens). Defaults to oauth2.
 	GitCommitStatus               bool                   `env:"GIT_COMMIT_STATUS,notEmpty" envDefault:"false"`                          // GitCommitStatus controls whether doco-cd reports deployment outcomes as commit statuses to the source Git provider (requires GIT_ACCESS_TOKEN)
@@ -98,6 +101,7 @@ func GetConfig() (*Config, error) {
 		{EnvName: "SSH_PRIVATE_KEY", EnvValue: &cfg.SSHPrivateKey, FileValue: &cfg.SSHPrivateKeyFile, AllowUnset: true},
 		{EnvName: "SSH_PRIVATE_KEY_PASSPHRASE", EnvValue: &cfg.SSHPrivateKeyPassphrase, FileValue: &cfg.SSHPrivateKeyPassphraseFile, AllowUnset: true},
 		{EnvName: "WEBHOOK_SECRET", EnvValue: &cfg.WebhookSecret, FileValue: &cfg.WebhookSecretFile, AllowUnset: true},
+		{EnvName: "SOURCE_URL_REWRITES", EnvValue: &cfg.SourceURLRewritesYAML, FileValue: &cfg.SourceURLRewritesFile, AllowUnset: true},
 	}
 
 	err := config.ParseConfigFromEnv(&cfg, &mappings)
@@ -113,6 +117,11 @@ func GetConfig() (*Config, error) {
 	err = cfg.parseGitAuthDomains()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse GIT_AUTH_DOMAINS: %w", err)
+	}
+
+	err = cfg.parseSourceURLRewrites()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SOURCE_URL_REWRITES: %w", err)
 	}
 
 	err = cfg.validateGitAuthConfig()
@@ -210,6 +219,36 @@ func (cfg *Config) parseGitAuthDomains() error {
 
 	if err := yaml.Unmarshal([]byte(cfg.GitAuthDomainsYAML), &cfg.GitAuthDomains); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (cfg *Config) parseSourceURLRewrites() error {
+	cfg.SourceURLRewrites = map[string]string{}
+
+	if strings.TrimSpace(cfg.SourceURLRewritesYAML) == "" {
+		return nil
+	}
+
+	raw := map[string]string{}
+	if err := yaml.Unmarshal([]byte(cfg.SourceURLRewritesYAML), &raw); err != nil {
+		return err
+	}
+
+	for key, value := range raw {
+		normalizedKey := strings.ToLower(strings.TrimSpace(key))
+		normalizedURL := strings.TrimSpace(value)
+
+		if normalizedKey == "" {
+			return errors.New("rewrite key in SOURCE_URL_REWRITES must not be empty")
+		}
+
+		if normalizedURL == "" {
+			return fmt.Errorf("rewrite key %q in SOURCE_URL_REWRITES must have a non-empty target", key)
+		}
+
+		cfg.SourceURLRewrites[normalizedKey] = normalizedURL
 	}
 
 	return nil

--- a/internal/config/app/app_config_test.go
+++ b/internal/config/app/app_config_test.go
@@ -403,3 +403,79 @@ func TestGetConfig_GitScmApiUrlRejectsNonHTTP(t *testing.T) {
 		t.Fatal("expected non-http GIT_SCM_API_URL to be rejected")
 	}
 }
+
+func TestGetConfig_SourceURLRewrites(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("HTTP_PORT", "8080")
+	t.Setenv("WEBHOOK_SECRET", "secret")
+	t.Setenv("SOURCE_URL_REWRITES", "HTTPS://Forgejo.Example.Com/: http://forgejo:3000/")
+
+	cfg, err := GetConfig()
+	if err != nil {
+		t.Fatalf("expected config to load, got %v", err)
+	}
+
+	overrideURL, ok := cfg.SourceURLRewrites["https://forgejo.example.com/"]
+	if !ok {
+		t.Fatalf("expected normalized override key %q to exist", "https://forgejo.example.com/")
+	}
+
+	if overrideURL != "http://forgejo:3000/" {
+		t.Fatalf("expected override URL to be %q, got %q", "http://forgejo:3000/", overrideURL)
+	}
+}
+
+func TestGetConfig_SourceURLRewritesFromFile(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("HTTP_PORT", "8080")
+	t.Setenv("WEBHOOK_SECRET", "secret")
+	t.Setenv("SOURCE_URL_REWRITES", "")
+
+	overridesFile := path.Join(t.TempDir(), "webhook-repository-overrides.yaml")
+	overridesYAML := "forgejo.example.com: forgejo:3000\n"
+
+	if err := os.WriteFile(overridesFile, []byte(overridesYAML), filesystem.PermOwner); err != nil {
+		t.Fatalf("failed to write overrides file: %v", err)
+	}
+
+	t.Setenv("SOURCE_URL_REWRITES_FILE", overridesFile)
+
+	cfg, err := GetConfig()
+	if err != nil {
+		t.Fatalf("expected config to load, got %v", err)
+	}
+
+	overrideURL, ok := cfg.SourceURLRewrites["forgejo.example.com"]
+	if !ok || overrideURL != "forgejo:3000" {
+		t.Fatalf("expected file-based rewrite to be loaded, got %+v", cfg.SourceURLRewrites)
+	}
+}
+
+func TestGetConfig_SourceURLRewritesRejectsEmptyTarget(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("HTTP_PORT", "8080")
+	t.Setenv("WEBHOOK_SECRET", "secret")
+	t.Setenv("SOURCE_URL_REWRITES", "forgejo.example.com: ''")
+
+	if _, err := GetConfig(); err == nil {
+		t.Fatal("expected empty source URL rewrite target to be rejected")
+	}
+}
+
+func TestGetConfig_SourceURLRewritesRejectsEnvAndFileTogether(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("HTTP_PORT", "8080")
+	t.Setenv("WEBHOOK_SECRET", "secret")
+	t.Setenv("SOURCE_URL_REWRITES", "forgejo.example.com: forgejo:3000")
+
+	overridesFile := path.Join(t.TempDir(), "webhook-repository-overrides.yaml")
+	if err := os.WriteFile(overridesFile, []byte("https://forgejo.example.com/: http://forgejo:3000/\n"), filesystem.PermOwner); err != nil {
+		t.Fatalf("failed to write overrides file: %v", err)
+	}
+
+	t.Setenv("SOURCE_URL_REWRITES_FILE", overridesFile)
+
+	if _, err := GetConfig(); err == nil {
+		t.Fatal("expected config error when both SOURCE_URL_REWRITES and _FILE are set")
+	}
+}

--- a/wiki/docs/App-Settings.md
+++ b/wiki/docs/App-Settings.md
@@ -30,6 +30,8 @@ The application can be configured using the following environment variables:
 | `TZ`                         | string  | The [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) used in the container.                                                                                                                                                   | `UTC`                                           |
 | `WEBHOOK_SECRET`             | string  | Secret that is used by webhooks for authentication to the application                                                                                                                                                                                 | Webhook endpoint is disabled when not specified |
 | `WEBHOOK_SECRET_FILE`        | string  | Path to the file containing the webhook secret (mutually exclusive with `WEBHOOK_SECRET`).                                                                                                                                                           |                                                 |
+| `SOURCE_URL_REWRITES` | map of strings | YAML map of git source URL rewrite rules, applied to both webhook and poll deployments. See [Source URL Rewrites](#source-url-rewrites). | Ignored when not specified |
+| `SOURCE_URL_REWRITES_FILE` | string | Path to a file containing `SOURCE_URL_REWRITES` YAML (mutually exclusive with `SOURCE_URL_REWRITES`). | |
 
 ## Notification Settings
 
@@ -156,3 +158,48 @@ docker service ps doco-cd_app
 ## Pulling images from a private registry
 
 If you want to pull images from a private registry, see [Private Container Registries](Advanced/Private-Container-Registries.md) in the wiki.
+
+## Source URL Rewrites
+
+`SOURCE_URL_REWRITES` (and `SOURCE_URL_REWRITES_FILE`) let you rewrite git source URLs before doco-cd clones them. Rules apply to both webhook- and poll-triggered deployments.
+
+This is useful when your Git provider advertises a public URL (in webhook payloads or poll configs) but doco-cd should clone through an internal network path instead — for example when your Forgejo instance is behind a reverse proxy with a public domain, but is reachable directly over a Docker network.
+
+Two match strategies are supported:
+
+- **URL/URI prefix** — e.g. `https://forgejo.example.com/` or `git@forgejo.example.com:`.
+  The matched prefix in the source URL is replaced with the configured target, and the repository path is appended as-is.
+    - HTTPS URLs should end with `/` to avoid partial host matches.
+    - SCP-style SSH URLs (e.g. `git@host:`) **must** end with `:` — it is the mandatory separator between host and repository path in SCP syntax (`user@host:path/repo.git`).
+    - SCP syntax cannot express a port number. Use `ssh://` syntax when targeting a non-standard port (e.g. `"ssh://git@forgejo.internal:2222/"`).
+- **Host/domain** — e.g. `forgejo.example.com`. Only the host (and optional port) is replaced; scheme, credentials, and path are preserved.
+
+Rules are matched in order of specificity (longest key first).
+
+!!! example
+
+    ```yaml title="Some possible examples"
+    SOURCE_URL_REWRITES:
+      # HTTPS → internal HTTP (key ends with / to avoid partial-host matches)
+      "https://forgejo.example.com/": "http://forgejo:3000/"
+      # Host-only match (replaces host+port, keeps scheme/path)
+      "forgejo.example.com": "forgejo:3000"
+      # SCP-style SSH → SCP-style SSH (the trailing : is required — it is the SCP host/path separator)
+      # OR: SCP-style SSH → ssh:// with non-standard port (SCP syntax cannot carry a port number)
+      # Pick one of these two, not both (YAML map keys must be unique):
+      # "git@forgejo.example.com:": "git@forgejo.internal:"
+      # "git@forgejo.example.com:": "ssh://git@forgejo.internal:2222/"
+    ```
+
+    In your doco-cd `docker-compose.yml`, you can set this as follows:
+
+    ```yaml title="docker-compose.yml"
+    services:
+      app:
+        environment:
+          SOURCE_URL_REWRITES: |
+            # HTTP variant:
+            "forgejo.example.com": "forgejo:3000"
+            # SSH variant with explicit port:
+            "git@forgejo.example.com:": "ssh://git@forgejo:2222/"
+    ```

--- a/wiki/docs/Endpoints/Webhook-Listener.md
+++ b/wiki/docs/Endpoints/Webhook-Listener.md
@@ -11,6 +11,9 @@ The webhook payload is expected to be in JSON format and must contain the payloa
 
 The application listens for incoming webhooks on the `/v1/webhook` endpoint with the port specified by the `HTTP_PORT` environment variable, see [App Settings](../App-Settings.md#general-settings).
 
+!!! info "Source URL Rewrites"
+    Webhook deployments support rewriting git clone URLs to internal addresses via [`SOURCE_URL_REWRITES`](../App-Settings.md#source-url-rewrites). This is useful when the Git provider advertises a public URL in webhooks but doco-cd should clone via an internal network path.
+
 ## Allow/deny trigger events
 
 By default, all incoming webhooks are accepted and trigger deployments if they match a deployment configuration.

--- a/wiki/docs/Poll-Settings.md
+++ b/wiki/docs/Poll-Settings.md
@@ -13,6 +13,8 @@ tags:
 
 Poll configurations can be set using the `POLL_CONFIG` environment variable or by providing a file with the `POLL_CONFIG_FILE` environment variable.
 
+For Git sources, poll jobs also honor global source URL rewrites from [`SOURCE_URL_REWRITES`](App-Settings.md#source-url-rewrites). This is useful when polling should clone through an internal host/port instead of the public URL.
+
 They must be in the format of a YAML list/array (also called YAML Sequence) and can contain the following settings:
 
 !!! note "Settings without a default value are required."


### PR DESCRIPTION
`SOURCE_URL_REWRITES` (and `SOURCE_URL_REWRITES_FILE`) let you rewrite git source URLs before doco-cd clones them. Rules apply to both webhook- and poll-triggered deployments.

This is useful when your Git provider advertises a public URL (in webhook payloads or poll configs) but doco-cd should clone through an internal network path instead — for example when your Forgejo instance is behind a reverse proxy with a public domain, but is reachable directly over a Docker network.
