### PR TITLE
docs: document the Docker API permissions required for each feature

### DIFF
--- a/wiki/docs/Advanced/Docker-API-Permissions.md
+++ b/wiki/docs/Advanced/Docker-API-Permissions.md
@@ -93,9 +93,20 @@ These endpoints are only needed when the corresponding setting is enabled.
 | [`destroy.remove_volumes`](../Deploy-Settings.md)                     | `true`  | `GET /volumes/{name}`, `DELETE /volumes/{name}`                                         | destructive |
 | [`destroy.remove_images`](../Deploy-Settings.md)                      | `true`  | `DELETE /images/{name}`                                                                 | destructive |
 | [`reconciliation.enabled`](../Deploy-Settings.md)                     | `true`  | `GET /events`, `POST /containers/{id}/restart`                                          | read/write  |
-| `SCHEDULER_ENABLED`                                                   | `true`  | `POST /containers/create`, `POST /containers/{id}/wait`, `POST /containers/{id}/start`, Swarm: `POST /services/create`, `DELETE /services/{id}`, `GET /tasks` | read/write  |
+| `SCHEDULER_ENABLED`                                                   | `true`  | See [below](#scheduler_enabled-endpoint-details)                                 | read/write  |
 | [`wait_running_jobs`](../Deploy-Settings.md)                          | `true`  | `GET /tasks` (Swarm), `GET /containers/json` (Compose)                                  | read        |
-| [REST API](../Endpoints/REST-API.md) (`API_SECRET` set)               | off     | `GET /info`, `GET /containers/json`, `POST /containers/{id}/start|stop|restart`, Swarm: `GET /services`, `POST /services/{id}/update` | read/write  |
+| [REST API](../Endpoints/REST-API.md) (`API_SECRET` set)               | off     | See [below](#rest-api-endpoint-details)                                         | destructive |
+
+#### `SCHEDULER_ENABLED` endpoint details
+
+- Default (`execution_mode: restart`): `POST /containers/{id}/restart`; Swarm: `GET /services/{id}`, `POST /services/{id}/update`
+- `execution_mode: one_off`: `POST /containers/create`, `POST /containers/{id}/wait`, `POST /containers/{id}/start`; Swarm: `POST /services/create`, `DELETE /services/{id}`, `GET /tasks`
+- `stop_services`: `POST /containers/{id}/stop|start`; Swarm: `POST /services/{id}/update`, `GET /tasks`
+
+#### REST API endpoint details
+
+- Compose project management: `GET /containers/json`, `POST /containers/{id}/start|stop|restart`, `DELETE /containers/{id}`, `DELETE /networks/{id}`, `DELETE /volumes/{name}`, `DELETE /images/{name}`
+- Swarm stack/service management: `GET /services`, `POST /services/{id}/update`, `DELETE /services/{id}`, `DELETE /configs/{id}`, `DELETE /secrets/{id}`
 
 !!! danger "Image pruning in Swarm mode bypasses the proxy"
     In Swarm mode, `prune_images` runs `docker image prune` inside a global job service that
@@ -112,7 +123,7 @@ you additionally need `POST /build` (and `POST /session` when BuildKit is used).
 
 Doco-CD does not call these endpoints, so you can safely deny them:
 
-`POST /auth`, `POST /build`, `POST /commit`, `POST /containers/{id}/exec`, `POST /exec/{id}/start`,
+`POST /auth`, `POST /commit`, `POST /containers/{id}/exec`, `POST /exec/{id}/start`,
 `GET /containers/{id}/logs`, `GET /containers/{id}/top`, `POST /containers/{id}/pause`,
 `GET /plugins`, `GET /system/df`, `POST /swarm/init`, `POST /swarm/join`
 

--- a/wiki/docs/Advanced/Docker-API-Permissions.md
+++ b/wiki/docs/Advanced/Docker-API-Permissions.md
@@ -103,17 +103,18 @@ These endpoints are only needed when the corresponding setting is enabled.
     daemon directly, so your socket proxy does not apply to it, and every node needs the raw
     socket available. Set `prune_images: false` if this is unacceptable in your environment.
 
+### Building images
+
+If any of your services use `build:` in their compose file,
+you additionally need `POST /build` (and `POST /session` when BuildKit is used).
+
 ### Never used
 
 Doco-CD does not call these endpoints, so you can safely deny them:
 
 `POST /auth`, `POST /build`, `POST /commit`, `POST /containers/{id}/exec`, `POST /exec/{id}/start`,
 `GET /containers/{id}/logs`, `GET /containers/{id}/top`, `POST /containers/{id}/pause`,
-`GET /plugins`, `POST /session`, `GET /system/df`, `POST /swarm/init`, `POST /swarm/join`
-
-!!! note "Building images"
-    Doco-CD does not build images by default. If any of your services use `build:` in their
-    compose file, you additionally need `POST /build` (and `POST /session` when BuildKit is used).
+`GET /plugins`, `GET /system/df`, `POST /swarm/init`, `POST /swarm/join`
 
 ## Example socket proxy configuration
 

--- a/wiki/docs/Advanced/Docker-API-Permissions.md
+++ b/wiki/docs/Advanced/Docker-API-Permissions.md
@@ -1,0 +1,238 @@
+---
+tags:
+  - Advanced
+  - Docker
+  - Security
+---
+
+# Docker API Permissions
+
+Doco-CD needs access to the Docker API to deploy your stacks.
+By default this is the mounted Docker socket, which grants unrestricted control over the host.
+
+If you would rather place a [Docker socket proxy](#example-socket-proxy-configuration) in front of the daemon, this page documents
+which Docker API endpoints doco-cd actually uses, so you can grant only what your setup needs.
+
+!!! warning "A socket proxy limits the blast radius, it does not make access read-only"
+    Doco-CD is a deployment tool. It has to create, update and delete containers, images,
+    networks and volumes (plus services, configs and secrets in Swarm mode) to do its job.
+    A socket proxy is still worth it: it lets you deny endpoints doco-cd never uses, such as
+    `/build`, `/exec` and `/plugins`, and it keeps the raw socket out of the container.
+
+## Required endpoints per feature
+
+The tables below list the Docker Engine API endpoints doco-cd calls, grouped by feature.
+Paths are shown without the `/v1.x` API version prefix that the client prepends to every request.
+
+### Always required
+
+Every doco-cd installation needs these, regardless of the deployment mode.
+
+| Feature                | Docker API endpoints                                                                     | Access |
+|------------------------|------------------------------------------------------------------------------------------|--------|
+| Client handshake       | `HEAD /_ping`, `GET /version`                                                            | read   |
+| Startup verification   | `GET /info`                                                                              | read   |
+| Swarm mode detection   | `GET /info`                                                                              | read   |
+| Own container lookup   | `GET /containers/{id}/json`                                                              | read   |
+| [Scheduled jobs](Job-Scheduling.md) discovery | `GET /containers/json`, `GET /services` (Swarm), `GET /events`         | read   |
+| [Reconciliation](../Core-Concepts.md) watcher | `GET /events`, `GET /containers/json`, `GET /containers/{id}/json`     | read   |
+
+!!! info "`GET /events` is needed by default"
+    Both the scheduler (`SCHEDULER_ENABLED`) and reconciliation (`reconciliation.enabled`) are
+    enabled by default and subscribe to the Docker event stream. Denying `/events` disables
+    automatic drift recovery and scheduled jobs.
+
+### Docker Compose deployments
+
+| Feature              | Docker API endpoints                                                                                                   | Access      |
+|----------------------|------------------------------------------------------------------------------------------------------------------------|-------------|
+| Project discovery    | `GET /containers/json`, `GET /containers/{id}/json`, `GET /networks`, `GET /volumes`                                    | read        |
+| Image pull           | `POST /images/create`, `GET /images/json`, `GET /images/{name}/json`                                                    | read/write  |
+| Image drift check    | `GET /distribution/{name}/json`, `GET /images/{name}/json`, `GET /containers/{id}/json`                                 | read        |
+| Network creation     | `GET /networks`, `GET /networks/{id}`, `POST /networks/create`                                                          | read/write  |
+| Volume creation      | `GET /volumes`, `GET /volumes/{name}`, `POST /volumes/create`                                                           | read/write  |
+| Container lifecycle  | `POST /containers/create`, `POST /containers/{id}/start`, `POST /containers/{id}/stop`, `POST /containers/{id}/restart` | read/write  |
+| Container recreation | `POST /containers/{id}/rename`, `DELETE /containers/{id}`                                                               | destructive |
+| Network attachment   | `POST /networks/{id}/connect`, `POST /networks/{id}/disconnect`                                                         | read/write  |
+
+### Docker Swarm deployments
+
+Used instead of most Compose endpoints when the daemon is a [Swarm manager](Swarm-Mode.md).
+
+| Feature                    | Docker API endpoints                                                                              | Access      |
+|----------------------------|----------------------------------------------------------------------------------------------------|-------------|
+| Stack discovery            | `GET /services`, `GET /services/{id}`, `GET /tasks`                                                | read        |
+| Convergence monitoring     | `GET /services/{id}`, `GET /tasks`, **`GET /nodes`**                                               | read        |
+| Overlay networks           | `GET /networks`, `GET /networks/{id}`, `POST /networks/create`                                     | read/write  |
+| Service deployment         | `POST /services/create`, `POST /services/{id}/update`                                              | read/write  |
+| Configs                    | `GET /configs`, `GET /configs/{id}`, `POST /configs/create`, `POST /configs/{id}/update`           | read/write  |
+| Secrets                    | `GET /secrets`, `GET /secrets/{id}`, `POST /secrets/create`, `POST /secrets/{id}/update`           | read/write  |
+| Config / secret rotation   | `DELETE /configs/{id}`, `DELETE /secrets/{id}`                                                     | destructive |
+
+!!! warning "`GET /nodes` is easy to miss"
+    Doco-CD waits for services to converge, which reads the list of active Swarm nodes.
+    Most socket proxies gate this behind a separate `NODES` permission that is **off by default**.
+    Without it, every Swarm deployment fails with `403 Forbidden`.
+
+!!! info "Why `POST /configs/{id}/update` is needed"
+    Doco-CD appends a content hash to config and secret names (see [Swarm Mode](Swarm-Mode.md#configs-and-secrets)).
+    A **new or changed** config is created with `POST /configs/create`.
+    Redeploying an **unchanged** config finds the existing hashed name and refreshes it with
+    `POST /configs/{id}/update`. Both are required. The same applies to secrets.
+
+### Optional features
+
+These endpoints are only needed when the corresponding setting is enabled.
+
+| Setting                                                              | Default | Additional endpoints                                                                   | Access      |
+|----------------------------------------------------------------------|---------|-----------------------------------------------------------------------------------------|-------------|
+| [`prune_images`](../Deploy-Settings.md) (Compose)                     | `true`  | `DELETE /images/{name}`                                                                 | destructive |
+| [`prune_images`](../Deploy-Settings.md) (Swarm)                       | `true`  | `POST /services/create`, `GET /services`, `POST /services/{id}/update`                  | destructive |
+| [`remove_orphans`](../Deploy-Settings.md)                             | `true`  | `DELETE /containers/{id}`, `DELETE /networks/{id}`, `DELETE /services/{id}` (Swarm)     | destructive |
+| [`destroy.enabled`](../Deploy-Settings.md)                            | `false` | `POST /containers/{id}/stop`, `DELETE /containers/{id}`, `DELETE /networks/{id}`, Swarm: `DELETE /services/{id}`, `DELETE /configs/{id}`, `DELETE /secrets/{id}` | destructive |
+| [`destroy.remove_volumes`](../Deploy-Settings.md)                     | `true`  | `GET /volumes/{name}`, `DELETE /volumes/{name}`                                         | destructive |
+| [`destroy.remove_images`](../Deploy-Settings.md)                      | `true`  | `DELETE /images/{name}`                                                                 | destructive |
+| [`reconciliation.enabled`](../Deploy-Settings.md)                     | `true`  | `GET /events`, `POST /containers/{id}/restart`                                          | read/write  |
+| `SCHEDULER_ENABLED`                                                   | `true`  | `POST /containers/create`, `POST /containers/{id}/wait`, `POST /containers/{id}/start`, Swarm: `POST /services/create`, `DELETE /services/{id}`, `GET /tasks` | read/write  |
+| [`wait_running_jobs`](../Deploy-Settings.md)                          | `true`  | `GET /tasks` (Swarm), `GET /containers/json` (Compose)                                  | read        |
+| [REST API](../Endpoints/REST-API.md) (`API_SECRET` set)               | off     | `GET /info`, `GET /containers/json`, `POST /containers/{id}/start|stop|restart`, Swarm: `GET /services`, `POST /services/{id}/update` | read/write  |
+
+!!! danger "Image pruning in Swarm mode bypasses the proxy"
+    In Swarm mode, `prune_images` runs `docker image prune` inside a global job service that
+    **bind-mounts `/var/run/docker.sock` on every node**. That container talks to the local
+    daemon directly, so your socket proxy does not apply to it, and every node needs the raw
+    socket available. Set `prune_images: false` if this is unacceptable in your environment.
+
+### Never used
+
+Doco-CD does not call these endpoints, so you can safely deny them:
+
+`POST /auth`, `POST /build`, `POST /commit`, `POST /containers/{id}/exec`, `POST /exec/{id}/start`,
+`GET /containers/{id}/logs`, `GET /containers/{id}/top`, `POST /containers/{id}/pause`,
+`GET /plugins`, `POST /session`, `GET /system/df`, `POST /swarm/init`, `POST /swarm/join`
+
+!!! note "Building images"
+    Doco-CD does not build images by default. If any of your services use `build:` in their
+    compose file, you additionally need `POST /build` (and `POST /session` when BuildKit is used).
+
+## Example socket proxy configuration
+
+The following example uses [tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy),
+which maps Docker API resources to environment variables.
+
+!!! info "Other proxies use different variable names"
+    Environment variable names differ between socket proxy implementations.
+    The **Docker API endpoint tables above are the source of truth** — map them to whatever
+    your proxy of choice expects.
+
+```yaml title="docker-compose.yml"
+services:
+  dockerproxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:latest
+    environment:
+      # Required by every installation
+      PING: 1
+      VERSION: 1
+      INFO: 1
+      EVENTS: 1
+      CONTAINERS: 1
+      IMAGES: 1
+      NETWORKS: 1
+      VOLUMES: 1
+      DISTRIBUTION: 1
+      # Docker Swarm only, omit these on a standalone daemon
+      SERVICES: 1
+      TASKS: 1
+      NODES: 1 # (1)!
+      SECRETS: 1
+      CONFIGS: 1
+      # Required to deploy anything
+      POST: 1
+      DELETE: 1 # (2)!
+      # Endpoints doco-cd never uses
+      AUTH: 0
+      BUILD: 0
+      COMMIT: 0
+      EXEC: 0
+      PLUGINS: 0
+      SESSION: 0
+      SWARM: 0
+      SYSTEM: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+
+  doco-cd:
+    image: ghcr.io/kimdre/doco-cd:latest
+    container_name: doco-cd
+    depends_on:
+      - dockerproxy
+    environment:
+      DOCKER_HOST: tcp://dockerproxy:2375 # (3)!
+      WEBHOOK_SECRET: xxx
+    ports:
+      - "80:80"
+    volumes:
+      - data:/data # (4)!
+    cap_drop:
+      - ALL
+    restart: unless-stopped
+
+volumes:
+  data:
+```
+
+1. Needed to wait for Swarm services to converge. Without it every Swarm deployment fails with `403 Forbidden`.
+2. Required for recreating containers, rotating configs/secrets and `remove_orphans`. Set to `0` only if you accept that redeployments will fail.
+3. Point doco-cd at the proxy instead of mounting the socket. See [Docker Settings](../Docker-Settings.md).
+4. The Docker socket is no longer mounted here — only the data volume remains.
+
+### Minimal standalone (Compose only) configuration
+
+If you do not use Docker Swarm, drop the Swarm resources:
+
+```yaml title="docker-compose.yml"
+services:
+  dockerproxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:latest
+    environment:
+      PING: 1
+      VERSION: 1
+      INFO: 1
+      EVENTS: 1
+      CONTAINERS: 1
+      IMAGES: 1
+      NETWORKS: 1
+      VOLUMES: 1
+      DISTRIBUTION: 1
+      POST: 1
+      DELETE: 1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+```
+
+## Troubleshooting
+
+If a deployment fails with a `403 Forbidden` error such as:
+
+```text
+failed to deploy stack myapp: Error response from daemon:
+<html><body><h1>403 Forbidden</h1>
+Request forbidden by administrative rules.
+</body></html>
+```
+
+your proxy is blocking an endpoint that doco-cd needs.
+Most socket proxies log the rejected request, so check the proxy logs to find the exact
+method and path, then look it up in the [tables above](#required-endpoints-per-feature).
+
+The most common causes are:
+
+| Missing permission | Symptom                                                                |
+|--------------------|------------------------------------------------------------------------|
+| `NODES`            | Swarm deployments fail while waiting for services to converge          |
+| `CONFIGS`          | Swarm stacks using `configs:` fail to deploy                           |
+| `SECRETS`          | Swarm stacks using `secrets:` fail to deploy                           |
+| `DISTRIBUTION`     | Image update detection falls back or fails                             |
+| `POST`             | Nothing can be created; deployments fail immediately                   |
+| `DELETE`           | Container recreation, config/secret rotation and `destroy` fail        |

--- a/wiki/docs/Advanced/Swarm-Mode.md
+++ b/wiki/docs/Advanced/Swarm-Mode.md
@@ -23,3 +23,10 @@ After rotating, doco-cd will also clean up old versions of the configs or secret
 For example, if you deploy a stack named `myapp` with a config named `db-settings` and the content of the config is `hello world`, doco-cd will create a config named `myapp_db-settings_a948904f` in the Swarm cluster.
 
 If you later change the content of the config to `hello universe`, doco-cd will create a new config named `myapp_db-settings_0b5c6934`, redeploy the service/container with the new config and remove the old config `myapp_db-settings_a948904f` from the Swarm cluster.
+
+## Docker API Permissions
+
+Swarm deployments need access to more Docker API resources than Compose deployments, namely
+services, tasks, nodes, configs and secrets.
+
+See [Docker API Permissions](Docker-API-Permissions.md) if you run doco-cd behind a Docker socket proxy.

--- a/wiki/docs/Docker-Settings.md
+++ b/wiki/docs/Docker-Settings.md
@@ -27,3 +27,8 @@ Most users can leave them at the defaults, and you can set them with [environmen
 ## Docker Contexts
 
 See [Docker Contexts](Advanced/Docker-Contexts.md) for information on how to use Docker contexts with Doco-CD.
+
+## Docker API Permissions
+
+See [Docker API Permissions](Advanced/Docker-API-Permissions.md) for the list of Docker API endpoints Doco-CD uses
+and how to run it behind a Docker socket proxy.

--- a/wiki/docs/Getting-Started.md
+++ b/wiki/docs/Getting-Started.md
@@ -79,6 +79,12 @@ docker compose logs -f
 To be able to reach the application from external Git providers like GitHub or Gitlab, you need to expose the http endpoint of the application to the internet.
 You can use a reverse proxy like [NGINX](https://www.nginx.com/), [Traefik](https://traefik.io) or [Caddy](https://caddyserver.com) for this purpose.
 
+### Restricting Docker access
+
+Mounting the Docker socket grants doco-cd full control over the Docker host.
+If you prefer to restrict this, see [Docker API Permissions](Advanced/Docker-API-Permissions.md)
+for the endpoints doco-cd uses and an example Docker socket proxy setup.
+
 ### Notes for Podman users
 
 If you are using Podman instead of Docker, you may need to adjust the `docker-compose.yml` file to use the Podman socket instead of the Docker socket:

--- a/wiki/zensical.toml
+++ b/wiki/zensical.toml
@@ -35,6 +35,7 @@ nav = [
     { "Poll Settings" = "Poll-Settings.md" },
   ] },
   { Advanced = [
+    { "Docker API Permissions" = "Advanced/Docker-API-Permissions.md" },
     { "Docker Contexts" = "Advanced/Docker-Contexts.md" },
     { Encryption = "Advanced/Encryption.md" },
     { "External Secrets" = [


### PR DESCRIPTION
## Description

Adds a documentation page listing the Docker Engine API endpoints doco-cd uses, grouped by feature, so operators running doco-cd behind a Docker socket proxy can configure least-privilege access instead of discovering the required permissions through failed deployments and proxy logs.

Closes #1624

## How the endpoint list was produced

Rather than deriving the list from the source alone, I ran a doco-cd instance with its Docker socket replaced by a transparent logging proxy and recorded every API request made during real deployments:

| Scenario | Result |
|---|---|
| Startup / swarm detection | captured |
| Compose deployment | 3 containers deployed |
| Compose destroy | stack removed |
| REST API (`restart`, `stop`, `start`) | captured |
| Swarm stack deployment | services + configs + secrets + overlay networks |
| Swarm redeployment | config/secret/service updates |
| Swarm stack destroy | stack removed |

The observed calls were then cross-checked against a static analysis of the call sites in `internal/docker/`, `internal/docker/swarm/`, `internal/reconciliation/`, `internal/scheduler/` and the `docker/compose/v5` operations doco-cd invokes.

## Answers to the specific questions in the issue

**`POST /networks/create`** comes from `internal/docker/swarm/deploy_composefile.go:231` (`createNetworks`), which defaults the driver to `overlay`.

**`POST /configs/{id}/update`** comes from `internal/docker/swarm/deploy_composefile.go:188` (`createConfigs`). It is only reached when redeploying an **unchanged** config: doco-cd appends a content hash to config names, so a new or changed config is created via `POST /configs/create`, while an unchanged one already exists under its hashed name and is refreshed via update. Both endpoints are therefore required. The same applies to secrets.

## Findings worth highlighting

The example table in the issue is a good starting point, but a few endpoints are easy to miss:

- **`GET /nodes`** is required in Swarm mode. doco-cd waits for services to converge, which reads the list of active nodes. Most socket proxies gate this behind a separate `NODES` permission that is **off by default**, which makes every Swarm deployment fail with `403 Forbidden`.
- **`GET /events`** is needed by default, since both reconciliation and the scheduler are enabled out of the box.
- **`GET /distribution/{name}/json`** is used for image update detection.
- **`prune_images` in Swarm mode bypasses the proxy entirely.** It runs `docker image prune` inside a global job service that bind-mounts `/var/run/docker.sock` on every node (`internal/docker/swarm_job.go`), so the raw socket must be available on the workers. This is documented as a caveat.

The page also states plainly that a socket proxy limits the blast radius but cannot make access read-only: doco-cd is a deployment tool and needs write access to containers, images, networks and volumes (plus services, configs and secrets in Swarm mode). In practice only `/build`, `/exec`, `/auth`, `/plugins`, `/session` and `/system/df` can be denied outright, and those are listed explicitly.

## Verification of the example configuration

The example was tested end to end against `tecnativa/docker-socket-proxy` on a single-node Swarm:

- With the documented permissions, a full Swarm deployment (services, configs, secrets, overlay networks) completes with **0 × 403**.
- Removing `CONFIGS`, `SECRETS` and `NODES` reproduces exactly the failure reported in the issue:

  ```text
  failed to deploy swarm stack probe-stack: Error response from daemon:
  <html><body><h1>403 Forbidden</h1>
  Request forbidden by administrative rules.
  </body></html>
  ```

A troubleshooting section maps the most common missing permissions to their symptoms.

## Changes

- `wiki/docs/Advanced/Docker-API-Permissions.md` — new page
- `wiki/zensical.toml` — nav entry under **Advanced**
- Cross-links added from `Docker-Settings.md`, `Advanced/Swarm-Mode.md` and `Getting-Started.md`

## Checks

- `zensical build` — `No issues found` (all internal links and anchors resolve)
- `codespell` with the CI settings — clean
- Documentation only; no code changes

## Note

My commit is unsigned, contrary to the guidance in `CONTRIBUTING.md` — I do not have a signing key set up on this machine. Happy to re-sign or squash if you would prefer that before merging.
