### PR TITLE
fix: do not require a C compiler for the test-nobitwarden target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,11 @@ test:
 	@echo "Running tests..."
 	@WEBHOOK_SECRET="test_Secret1" API_SECRET="test_apiSecret1" ${COMPILER} go test ${BUILD_FLAGS} -cover ./... -timeout 10m
 
+# The nobitwarden build tag excludes the Bitwarden SDK, which is the only
+# dependency that requires cgo, so this target builds without a C compiler.
 test-nobitwarden:
 	@echo "Running tests without bitwarden integration..."
-	@WEBHOOK_SECRET="test_Secret1" API_SECRET="test_apiSecret1" ${COMPILER} go test -ldflags="-X main.Version=dev" -tags nobitwarden -cover ./... -timeout 10m
+	@WEBHOOK_SECRET="test_Secret1" API_SECRET="test_apiSecret1" CGO_ENABLED=0 go test -ldflags="-X main.Version=dev" -tags nobitwarden -cover ./... -timeout 10m
 
 test-verbose:
 	@echo "Running tests..."


### PR DESCRIPTION
## Description

`make test-nobitwarden` currently fails on any machine without `musl-gcc` installed, which defeats the purpose of the target.

## Problem

The `nobitwarden` build tag excludes the Bitwarden SDK, which is the only dependency in the project that requires cgo. However, the target still inherited `${COMPILER}`, which expands to `CGO_ENABLED=1 CC=musl-gcc` on Linux (and `CC=clang` on Darwin):

```make
test-nobitwarden:
	@... ${COMPILER} go test -ldflags="-X main.Version=dev" -tags nobitwarden -cover ./... -timeout 10m
```

Running it without `musl-gcc` present:

```text
# runtime/cgo
cgo: C compiler "musl-gcc" not found: exec: "musl-gcc": executable file not found in $PATH
```

This is exactly the situation the target is meant to support — `CONTRIBUTING.md` describes the `nobitwarden` tag as the option for environments where the Bitwarden SDK is unavailable (for example armv7).

## Fix

Use `CGO_ENABLED=0` for this target instead of `${COMPILER}`.

This matches the guidance already documented elsewhere in the repo:

- `CONTRIBUTING.md`: `CGO_ENABLED=0 go build -tags nobitwarden -o doco-cd ./cmd/doco-cd`
- `Dockerfile`: notes that CGO is not needed for builds without Bitwarden

The static link flags (`-linkmode external -extldflags ...`) had already been dropped from this target, so `${COMPILER}` was the only remaining cgo requirement. All other targets keep using `${COMPILER}` and are unaffected.

## Verification

Confirmed on a machine **without** `musl-gcc`:

- The only cgo dependency is the Bitwarden SDK; there are no `import "C"` statements in `internal/` or `cmd/`, and the provider is split by build tag into `client_bitwarden.go` (`//go:build !nobitwarden`) and `client_nobitwarden.go` (`//go:build nobitwarden`).
- Before: the old command fails with `cgo: C compiler "musl-gcc" not found`.
- After: `CGO_ENABLED=0 go test -tags nobitwarden ./...` compiles every package and test binary successfully, and unit tests pass.
- `CGO_ENABLED=0 go build -tags nobitwarden ./cmd/doco-cd` succeeds.

Note that the full `./...` test run still requires a live Docker daemon, since the suite is integration-based — this change only removes the C toolchain requirement.

## Note

My commit is unsigned, contrary to the guidance in `CONTRIBUTING.md` — I do not have a signing key set up on this machine. Happy to re-sign or squash if you would prefer that before merging.
