### PR TITLE
fix(autodiscovery): change default value of delete option to false

### DIFF
--- a/internal/config/deploy/auto_discovery.go
+++ b/internal/config/deploy/auto_discovery.go
@@ -25,7 +25,7 @@ import (
 type AutoDiscoveryConfig struct {
 	Enabled       bool `yaml:"enabled" json:"enabled" default:"false"`               // Enabled enables autodiscovery of services to deploy in the working directory
 	ScanDepth     int  `yaml:"depth" json:"depth" default:"0"`                       // ScanDepth is the maximum depth of subdirectories to scan for docker-compose files
-	Delete        bool `yaml:"delete" json:"delete" default:"true"`                  // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
+	Delete        bool `yaml:"delete" json:"delete" default:"false"`                 // Delete removes obsolete auto-discovered deployments that are no longer present in the repository
 	RemoveVolumes bool `yaml:"remove_volumes" json:"remove_volumes" default:"false"` // RemoveVolumes removes the volumes of an auto-discovered deployment when it is deleted
 	RemoveImages  bool `yaml:"remove_images" json:"remove_images" default:"true"`    // RemoveImages removes the images of an auto-discovered deployment when it is deleted
 }

--- a/internal/config/deploy/auto_discovery_test.go
+++ b/internal/config/deploy/auto_discovery_test.go
@@ -44,8 +44,8 @@ auto_discovery: true
 			t.Fatalf("expected default auto_discovery.depth 0, got %d", configs[0].AutoDiscovery.ScanDepth)
 		}
 
-		if !configs[0].AutoDiscovery.Delete {
-			t.Fatal("expected default auto_discovery.delete to be true")
+		if configs[0].AutoDiscovery.Delete {
+			t.Fatal("expected default auto_discovery.delete to be false")
 		}
 	})
 
@@ -99,8 +99,8 @@ auto_discovery:
 			t.Fatalf("expected default auto_discovery.depth 0, got %d", cfg.AutoDiscovery.ScanDepth)
 		}
 
-		if !cfg.AutoDiscovery.Delete {
-			t.Fatal("expected default auto_discovery.delete to be true")
+		if cfg.AutoDiscovery.Delete {
+			t.Fatal("expected default auto_discovery.delete to be false")
 		}
 	})
 }

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -148,8 +148,8 @@ If `auto_discovery` is enabled, doco-cd will try to find projects/stacks to depl
 Doco-cd will internally generate new deploy configs based on the directory name and inherits all other settings from the 
 base deploy config inside the `.doco-cd.yml` file or the inline deployment config inside the poll config.
 
-When an app is no longer available in the `working_dir` (e.g. deleted or moved to another directory outside the working dir), 
-doco-cd will automatically remove the deployed project/stack from the docker host.
+When `auto_discovery.delete` is set to `true` and an app is no longer available in the `working_dir` (e.g. deleted or
+moved to another directory outside the working dir), doco-cd will remove the deployed project/stack from the docker host.
 
 #### Auto-Discovery settings
 
@@ -160,7 +160,7 @@ Use `auto_discovery: true` to enable it with defaults, or use the object form be
 |------------------|---------|------------------------------------------------------------------------------------------------------|---------------|
 | `enabled`        | boolean | Enables auto-discovery of services to deploy in the working directory                                | `false`       |
 | `depth`          | number  | Maximum depth of subdirectories to scan for docker-compose files, set to `0` for no limit            | `0`           |
-| `delete`         | boolean | Auto-remove obsolete auto-discovered deployments that are no longer present in the working directory | `true`        |
+| `delete`         | boolean | Auto-remove obsolete auto-discovered deployments that are no longer present in the working directory | `false`       |
 | `remove_volumes` | boolean | Remove volumes of auto-discovered deployments when they are deleted                                  | `false`       |
 | `remove_images`  | boolean | Remove images of auto-discovered deployments when they are deleted                                   | `true`        |
 


### PR DESCRIPTION
This pull request updates the default behavior for the `auto_discovery.delete` setting, making it more conservative by not automatically removing obsolete deployments unless explicitly enabled. Related documentation and tests have been updated to reflect this change.

**Default behavior change:**
- Changed the default value of the `Delete` field in the `AutoDiscoveryConfig` struct from `true` to `false`, so obsolete auto-discovered deployments are no longer removed by default (`internal/config/deploy/auto_discovery.go`).

**Test updates:**
- Updated tests to expect the new default (`false`) for `auto_discovery.delete` instead of the previous default (`true`) (`internal/config/deploy/auto_discovery_test.go`). [[1]](diffhunk://#diff-1ad549c144ad351fa9dad538547e2fc306ab2a850a5f5da1ca20c28a0350bf57L47-R48) [[2]](diffhunk://#diff-1ad549c144ad351fa9dad538547e2fc306ab2a850a5f5da1ca20c28a0350bf57L102-R103)

**Documentation updates:**
- Clarified in the documentation that deployments are only removed when `auto_discovery.delete` is set to `true`, and updated the default value in the settings table to `false` (`wiki/docs/Deploy-Settings.md`). [[1]](diffhunk://#diff-5fa91545f2dd7ad8adff66ddd6ab22ccd9d7700d4d6e45c2cf4e63cca13ce204L151-R152) [[2]](diffhunk://#diff-5fa91545f2dd7ad8adff66ddd6ab22ccd9d7700d4d6e45c2cf4e63cca13ce204L163-R163)