### PR TITLE
fix(metrics): include deployment names in repository metrics labels

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -588,6 +588,38 @@ func logDeploymentHeartbeat(log *slog.Logger, phase string) {
 	log.Info("deployment in progress", slog.String("phase", normalizeDeploymentPhase(phase)))
 }
 
+func deploymentRepositoryKey(payload *webhook.ParsedPayload) string {
+	if payload == nil {
+		return ""
+	}
+
+	for _, candidate := range []string{payload.CloneURL, payload.FullName, payload.Artifact} {
+		if value := strings.TrimSpace(candidate); value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func resolveDeploymentMetricsRepositoryLabel(payload *webhook.ParsedPayload) string {
+	repository := normalizeRepositoryForLabelMatch(deploymentRepositoryKey(payload))
+	if repository == "" {
+		return "unknown"
+	}
+
+	return repository
+}
+
+func resolveDeploymentMetricsDeploymentLabel(deployName string) string {
+	deployment := strings.TrimSpace(deployName)
+	if deployment == "" {
+		return "unknown"
+	}
+
+	return deployment
+}
+
 // DeployStack deploys the stack using the provided deployment configuration.
 func DeployStack(
 	jobLog *slog.Logger, externalRepoPath string, ctx *context.Context,
@@ -596,6 +628,8 @@ func DeployStack(
 	swarmMode bool,
 ) error {
 	startTime := time.Now()
+	repositoryLabel := resolveDeploymentMetricsRepositoryLabel(payload)
+	deploymentLabel := resolveDeploymentMetricsDeploymentLabel(deployConfig.Name)
 
 	stackLog := jobLog.
 		With(slog.String("stack", deployConfig.Name))
@@ -683,13 +717,13 @@ func DeployStack(
 		addSwarmSecretLabels(cfg, deployConfig, payload, externalWorkingDir, appVersion, timestamp, latestCommit)
 
 		if err = removeMismatchedRecreatableVolumes(*ctx, dockerCli.Client(), deployConfig.Name, project); err != nil {
-			prometheus.DeploymentErrorsTotal.WithLabelValues(deployConfig.Name).Inc()
+			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
 			return fmt.Errorf("failed to remove mismatched recreatable volumes: %w", err)
 		}
 
 		err = DeploySwarmStack(*ctx, dockerCli, cfg, opts)
 		if err != nil {
-			prometheus.DeploymentErrorsTotal.WithLabelValues(deployConfig.Name).Inc()
+			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
 
 			errMsg := "failed to deploy swarm stack " + deployConfig.Name
 
@@ -700,7 +734,7 @@ func DeployStack(
 
 		err = PruneStackConfigs(*ctx, dockerCli.Client(), deployConfig.Name)
 		if err != nil {
-			prometheus.DeploymentErrorsTotal.WithLabelValues(deployConfig.Name).Inc()
+			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
 
 			errMsg := "failed to prune stack configs"
 
@@ -711,7 +745,7 @@ func DeployStack(
 
 		err = PruneStackSecrets(*ctx, dockerCli.Client(), deployConfig.Name)
 		if err != nil {
-			prometheus.DeploymentErrorsTotal.WithLabelValues(deployConfig.Name).Inc()
+			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
 
 			errMsg := "failed to prune stack secrets"
 
@@ -725,7 +759,7 @@ func DeployStack(
 
 			err = RunImagePruneJob(*ctx, dockerCli)
 			if err != nil {
-				prometheus.DeploymentErrorsTotal.WithLabelValues(deployConfig.Name).Inc()
+				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
 
 				errMsg := "failed to run image prune job"
 
@@ -790,7 +824,7 @@ func DeployStack(
 		err = deployCompose(*ctx, dockerCli, project, deployConfig, recreateMode,
 			forcedServices.ToSlice(), needSignal, deploymentPhase.Set)
 		if err != nil {
-			prometheus.DeploymentErrorsTotal.WithLabelValues(deployConfig.Name).Inc()
+			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
 			return fmt.Errorf("failed to deploy stack: %w", err)
 		}
 	}
@@ -798,14 +832,7 @@ func DeployStack(
 	deploymentPhase.Set("finalizing deployment status")
 
 	// cache the deployment status after successful deployment
-	repositoryKey := strings.TrimSpace(payload.CloneURL)
-	if repositoryKey == "" {
-		repositoryKey = strings.TrimSpace(payload.FullName)
-	}
-
-	if repositoryKey == "" {
-		repositoryKey = strings.TrimSpace(payload.Artifact)
-	}
+	repositoryKey := deploymentRepositoryKey(payload)
 
 	setDeployStatusToCache(gitInternal.GetRepoName(repositoryKey), deployConfig.Name,
 		deployStatus{
@@ -814,8 +841,8 @@ func DeployStack(
 		},
 	)
 
-	prometheus.DeploymentsTotal.WithLabelValues(deployConfig.Name).Inc()
-	prometheus.DeploymentDuration.WithLabelValues(deployConfig.Name).Observe(time.Since(startTime).Seconds())
+	prometheus.DeploymentsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
+	prometheus.DeploymentDuration.WithLabelValues(repositoryLabel, deploymentLabel).Observe(time.Since(startTime).Seconds())
 
 	return nil
 }

--- a/internal/prometheus/collectors.go
+++ b/internal/prometheus/collectors.go
@@ -75,18 +75,18 @@ var (
 		Namespace: MetricsNamespace,
 		Name:      "deployments_total",
 		Help:      "Total number of deployments processed",
-	}, []string{"repository"})
+	}, []string{"repository", "deployment"})
 	DeploymentErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "deployment_errors_total",
 		Help:      "Total number of errors during deployments",
-	}, []string{"repository"})
+	}, []string{"repository", "deployment"})
 	DeploymentDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: MetricsNamespace,
 		Name:      "deployment_duration_seconds",
 		Help:      "Duration of deployment operations in seconds",
 		Buckets:   prometheus.DefBuckets,
-	}, []string{"repository"})
+	}, []string{"repository", "deployment"})
 	DeploymentsActive = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "deployments_active",

--- a/internal/prometheus/metrics_test.go
+++ b/internal/prometheus/metrics_test.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -57,5 +58,24 @@ func TestServe(t *testing.T) {
 
 	if !strings.Contains(rr.Body.String(), "doco_cd_scheduled_runs_total") {
 		t.Error("Expected response body to contain 'doco_cd_scheduled_runs_total' metric, but it does not")
+	}
+}
+
+func TestDeploymentMetricsIncludeRepositoryAndDeploymentLabels(t *testing.T) {
+	t.Parallel()
+
+	DeploymentsTotal.WithLabelValues("github.com/example/repo", "test-stack").Inc()
+
+	req, err := http.NewRequest("GET", MetricsPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	promhttp.Handler().ServeHTTP(rr, req)
+
+	linePattern := regexp.MustCompile(`doco_cd_deployments_total\{[^}]*deployment="test-stack"[^}]*repository="github.com/example/repo"[^}]*\}\s+1`)
+	if !linePattern.MatchString(rr.Body.String()) {
+		t.Fatalf("expected deployments_total with repository and deployment labels, got:\n%s", rr.Body.String())
 	}
 }


### PR DESCRIPTION
This pull request enhances deployment metrics by adding more granular labeling for Prometheus metrics, allowing errors and durations to be tracked per repository and deployment. It introduces helper functions to consistently extract and normalize these labels, updates all relevant metric calls, and adds a test to ensure these labels are present in the exported metrics.

**Prometheus metrics improvements:**

* Updated `DeploymentsTotal`, `DeploymentErrorsTotal`, and `DeploymentDuration` metrics to include both `repository` and `deployment` labels for finer-grained tracking.
* Modified all metric increment and observation calls in `DeployStack` to use the new label values, replacing the previous single-label approach. [[1]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dL686-R726) [[2]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dL703-R737) [[3]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dL714-R748) [[4]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dL728-R762) [[5]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dL793-R835) [[6]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dL817-R845)

**Label extraction and normalization:**

* Added helper functions (`deploymentRepositoryKey`, `resolveDeploymentMetricsRepositoryLabel`, `resolveDeploymentMetricsDeploymentLabel`) to consistently extract and normalize repository and deployment names for metric labeling. [[1]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dR591-R622) [[2]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dR631-R632) [[3]](diffhunk://#diff-0ccf1f3e4ed173e32699ba849c5a221b34d76badc64a418fda5faf2e11f0305dL793-R835)

**Testing:**

* Added a test to verify that the `DeploymentsTotal` metric includes both `repository` and `deployment` labels in its output. [[1]](diffhunk://#diff-cd15fbd5152b7505f0faae4dd1d30089f34c78ded22079432cd54c731e9ffc23R63-R81) [[2]](diffhunk://#diff-cd15fbd5152b7505f0faae4dd1d30089f34c78ded22079432cd54c731e9ffc23R6)

These changes will make it easier to monitor and diagnose deployment issues at a more granular level.