### PR TITLE
fix(docker): detect Swarm rollbacks as deployment failures

### DIFF
--- a/internal/docker/swarm/common_test.go
+++ b/internal/docker/swarm/common_test.go
@@ -7,18 +7,28 @@ import (
 func TestSwarmModeEnabled(t *testing.T) {
 	t.Parallel()
 
-	dockerCli := getDockerClient(t)
+	prevDisable := disableSwarmFeature.Load()
+	prevMode := modeEnabled.Load()
+	t.Cleanup(func() {
+		disableSwarmFeature.Store(prevDisable)
+		modeEnabled.Store(prevMode)
+	})
 
-	if GetModeEnabled() {
-		t.Fatal("GetModeEnabled want false, got true")
-	}
+	SetDisableSwarmFeature(false)
+
+	dockerCli := getDockerClient(t)
 
 	if err := RefreshModeEnabled(t.Context(), dockerCli); err != nil {
 		t.Fatal(err)
 	}
 
-	if enabled := GetModeEnabled(); enabled {
-		t.Logf("GetModeEnabled: %v", enabled)
+	want, err := ResolveModeEnabled(t.Context(), dockerCli)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := GetModeEnabled(); got != want {
+		t.Fatalf("GetModeEnabled() = %v, want %v", got, want)
 	}
 }
 

--- a/internal/docker/swarm/common_test.go
+++ b/internal/docker/swarm/common_test.go
@@ -9,6 +9,7 @@ func TestSwarmModeEnabled(t *testing.T) {
 
 	prevDisable := disableSwarmFeature.Load()
 	prevMode := modeEnabled.Load()
+
 	t.Cleanup(func() {
 		disableSwarmFeature.Store(prevDisable)
 		modeEnabled.Store(prevMode)

--- a/internal/docker/swarm/deploy_test.go
+++ b/internal/docker/swarm/deploy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/moby/moby/client"
 )
 
-func getDockerClient(t *testing.T) client.APIClient {
+func getDockerCli(t *testing.T) command.Cli {
 	t.Helper()
 
 	dockerCli, err := command.NewDockerCli(
@@ -28,6 +28,14 @@ func getDockerClient(t *testing.T) client.APIClient {
 	if err != nil {
 		t.Fatal(fmt.Errorf("failed to initialize docker cli: %w", err))
 	}
+
+	return dockerCli
+}
+
+func getDockerClient(t *testing.T) client.APIClient {
+	t.Helper()
+
+	dockerCli := getDockerCli(t)
 
 	return dockerCli.Client()
 }

--- a/internal/docker/swarm/deploy_wait_test.go
+++ b/internal/docker/swarm/deploy_wait_test.go
@@ -140,6 +140,33 @@ func TestIsRollbackUpdateState(t *testing.T) {
 	}
 }
 
+func TestIsTerminalNonRollbackUpdateState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state swarmTypes.UpdateState
+		want  bool
+	}{
+		{name: "completed", state: swarmTypes.UpdateStateCompleted, want: true},
+		{name: "paused", state: swarmTypes.UpdateStatePaused, want: true},
+		{name: "updating", state: swarmTypes.UpdateStateUpdating, want: false},
+		{name: "rollback started", state: swarmTypes.UpdateStateRollbackStarted, want: false},
+		{name: "rollback paused", state: swarmTypes.UpdateStateRollbackPaused, want: false},
+		{name: "rollback completed", state: swarmTypes.UpdateStateRollbackCompleted, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isTerminalNonRollbackUpdateState(tt.state); got != tt.want {
+				t.Fatalf("isTerminalNonRollbackUpdateState(%q) = %v, want %v", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRollbackUpdateStatusError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/docker/swarm/deploy_wait_test.go
+++ b/internal/docker/swarm/deploy_wait_test.go
@@ -1,6 +1,7 @@
 package swarm
 
 import (
+	"strings"
 	"testing"
 
 	swarmTypes "github.com/moby/moby/api/types/swarm"
@@ -107,6 +108,106 @@ func TestIsScheduledServiceSpec(t *testing.T) {
 
 			if got := isScheduledServiceSpec(tt.spec); got != tt.want {
 				t.Fatalf("isScheduledServiceSpec() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRollbackUpdateState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state swarmTypes.UpdateState
+		want  bool
+	}{
+		{name: "rollback started", state: swarmTypes.UpdateStateRollbackStarted, want: true},
+		{name: "rollback paused", state: swarmTypes.UpdateStateRollbackPaused, want: true},
+		{name: "rollback completed", state: swarmTypes.UpdateStateRollbackCompleted, want: true},
+		{name: "completed", state: swarmTypes.UpdateStateCompleted, want: false},
+		{name: "updating", state: swarmTypes.UpdateStateUpdating, want: false},
+		{name: "paused", state: swarmTypes.UpdateStatePaused, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isRollbackUpdateState(tt.state); got != tt.want {
+				t.Fatalf("isRollbackUpdateState(%q) = %v, want %v", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRollbackUpdateStatusError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		serviceID   string
+		serviceName string
+		status      *swarmTypes.UpdateStatus
+		wantErr     bool
+		wantParts   []string
+	}{
+		{
+			name:        "nil status",
+			serviceID:   "svc-id",
+			serviceName: "stack_api",
+			status:      nil,
+			wantErr:     false,
+		},
+		{
+			name:        "non rollback state",
+			serviceID:   "svc-id",
+			serviceName: "stack_api",
+			status: &swarmTypes.UpdateStatus{
+				State:   swarmTypes.UpdateStateCompleted,
+				Message: "update completed",
+			},
+			wantErr: false,
+		},
+		{
+			name:        "rollback uses service name and message",
+			serviceID:   "svc-id",
+			serviceName: "stack_api",
+			status: &swarmTypes.UpdateStatus{
+				State:   swarmTypes.UpdateStateRollbackCompleted,
+				Message: "rollback completed",
+			},
+			wantErr:   true,
+			wantParts: []string{"stack_api", string(swarmTypes.UpdateStateRollbackCompleted), "rollback completed"},
+		},
+		{
+			name:        "rollback falls back to service id",
+			serviceID:   "svc-id",
+			serviceName: "   ",
+			status: &swarmTypes.UpdateStatus{
+				State: swarmTypes.UpdateStateRollbackStarted,
+			},
+			wantErr:   true,
+			wantParts: []string{"svc-id", string(swarmTypes.UpdateStateRollbackStarted)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := rollbackUpdateStatusError(tt.serviceID, tt.serviceName, tt.status)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("rollbackUpdateStatusError() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil {
+				return
+			}
+
+			for _, wantPart := range tt.wantParts {
+				if !strings.Contains(err.Error(), wantPart) {
+					t.Fatalf("rollbackUpdateStatusError() error = %q, missing %q", err.Error(), wantPart)
+				}
 			}
 		})
 	}

--- a/internal/docker/swarm/rollback_integration_test.go
+++ b/internal/docker/swarm/rollback_integration_test.go
@@ -1,0 +1,136 @@
+package swarm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	swarmTypes "github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
+)
+
+// TestWaitOnServiceDetectsRollbackIntegration runs a real Swarm service update
+// that fails and rolls back. It verifies waitOnService reports that rollback as
+// an error instead of treating the deployment as successful.
+func TestWaitOnServiceDetectsRollbackIntegration(t *testing.T) {
+	requireSwarmRollbackIntegrationTestGate(t)
+
+	dockerCli := getDockerCli(t)
+	apiClient := dockerCli.Client()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+
+	serviceName := fmt.Sprintf("doco-cd-rollback-%d", time.Now().UnixNano())
+	replicas := uint64(1)
+
+	createSpec := swarmTypes.ServiceSpec{
+		Annotations: swarmTypes.Annotations{
+			Name: serviceName,
+			Labels: map[string]string{
+				"doco-cd.test": "rollback-detection",
+			},
+		},
+		TaskTemplate: swarmTypes.TaskSpec{
+			ContainerSpec: &swarmTypes.ContainerSpec{
+				Image:   "busybox:latest",
+				Command: []string{"sh", "-c", "sleep 600"},
+			},
+		},
+		Mode: swarmTypes.ServiceMode{
+			Replicated: &swarmTypes.ReplicatedService{
+				Replicas: &replicas,
+			},
+		},
+		UpdateConfig: &swarmTypes.UpdateConfig{
+			Parallelism:     1,
+			Delay:           0,
+			FailureAction:   swarmTypes.UpdateFailureActionRollback,
+			Monitor:         15 * time.Second,
+			MaxFailureRatio: 0,
+			Order:           swarmTypes.UpdateOrderStopFirst,
+		},
+		RollbackConfig: &swarmTypes.UpdateConfig{
+			Parallelism:     1,
+			Delay:           0,
+			FailureAction:   swarmTypes.UpdateFailureActionPause,
+			Monitor:         15 * time.Second,
+			MaxFailureRatio: 0,
+			Order:           swarmTypes.UpdateOrderStopFirst,
+		},
+	}
+
+	createRes, err := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{
+		Spec:          createSpec,
+		QueryRegistry: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create test service %q: %v", serviceName, err)
+	}
+
+	t.Cleanup(func() {
+		_, _ = apiClient.ServiceRemove(context.Background(), createRes.ID, client.ServiceRemoveOptions{})
+	})
+
+	if err = waitOnService(ctx, dockerCli, createRes.ID); err != nil {
+		t.Fatalf("expected initial service rollout to succeed, got error: %v", err)
+	}
+
+	inspectRes, err := apiClient.ServiceInspect(ctx, createRes.ID, client.ServiceInspectOptions{})
+	if err != nil {
+		t.Fatalf("failed to inspect test service %q before update: %v", serviceName, err)
+	}
+
+	updateSpec := inspectRes.Service.Spec
+	updateSpec.TaskTemplate.ForceUpdate++
+	updateSpec.TaskTemplate.ContainerSpec.Image = "invalid.invalid/doco-cd/missing:latest"
+
+	_, err = apiClient.ServiceUpdate(ctx, createRes.ID, client.ServiceUpdateOptions{
+		Version: inspectRes.Service.Version,
+		Spec:    updateSpec,
+	})
+	if err != nil {
+		t.Fatalf("failed to update test service %q to trigger rollback: %v", serviceName, err)
+	}
+
+	err = waitOnService(ctx, dockerCli, createRes.ID)
+	if err == nil {
+		t.Fatalf("expected rollback detection error for service %q, got nil", serviceName)
+	}
+
+	if !strings.Contains(err.Error(), "rollback state") {
+		t.Fatalf("expected rollback detection error, got: %v", err)
+	}
+
+	finalInspect, err := apiClient.ServiceInspect(ctx, createRes.ID, client.ServiceInspectOptions{})
+	if err != nil {
+		t.Fatalf("failed to inspect test service %q after rollback: %v", serviceName, err)
+	}
+
+	if finalInspect.Service.UpdateStatus == nil {
+		t.Fatalf("expected update status to be present for service %q after rollback", serviceName)
+	}
+
+	if !isRollbackUpdateState(finalInspect.Service.UpdateStatus.State) {
+		t.Fatalf("expected rollback update state, got %q", finalInspect.Service.UpdateStatus.State)
+	}
+}
+
+func requireSwarmRollbackIntegrationTestGate(t *testing.T) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping swarm rollback integration test in short mode")
+	}
+
+	dockerClient := getDockerClient(t)
+	if err := RefreshModeEnabled(t.Context(), dockerClient); err != nil {
+		t.Skipf("skipping swarm rollback integration test: %v", err)
+	}
+
+	if !GetModeEnabled() {
+		t.Skip("swarm mode is not enabled, skipping rollback integration test")
+	}
+}

--- a/internal/docker/swarm/service.go
+++ b/internal/docker/swarm/service.go
@@ -51,22 +51,27 @@ func waitOnService(ctx context.Context, dockerCli command.Cli, serviceID string)
 		defer pipeWriter.Close() //nolint:errcheck
 	}()
 
-	// Monitor the output of the progress reader for errors
-	err := jsonstream.ErrorReader(ctx, pipeReader)
-	if err == nil {
-		err = <-errChan
-	}
-
-	if err != nil {
-		return err
+	// Monitor the output of the progress reader for errors.
+	progressErr := jsonstream.ErrorReader(ctx, pipeReader)
+	if progressErr == nil {
+		progressErr = <-errChan
 	}
 
 	serviceResult, err := dockerCli.Client().ServiceInspect(ctx, serviceID, client.ServiceInspectOptions{})
 	if err != nil {
+		if progressErr != nil {
+			return progressErr
+		}
+
 		return fmt.Errorf("failed to inspect service %s update status: %w", serviceID, err)
 	}
 
-	return rollbackUpdateStatusError(serviceID, serviceResult.Service.Spec.Name, serviceResult.Service.UpdateStatus)
+	rollbackErr := rollbackUpdateStatusError(serviceID, serviceResult.Service.Spec.Name, serviceResult.Service.UpdateStatus)
+	if rollbackErr != nil {
+		return rollbackErr
+	}
+
+	return progressErr
 }
 
 // rollbackUpdateStatusError returns an error when a service update finished in a rollback state.

--- a/internal/docker/swarm/service.go
+++ b/internal/docker/swarm/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/docker/cli/cli/command"
@@ -56,7 +57,42 @@ func waitOnService(ctx context.Context, dockerCli command.Cli, serviceID string)
 		err = <-errChan
 	}
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	serviceResult, err := dockerCli.Client().ServiceInspect(ctx, serviceID, client.ServiceInspectOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to inspect service %s update status: %w", serviceID, err)
+	}
+
+	return rollbackUpdateStatusError(serviceID, serviceResult.Service.Spec.Name, serviceResult.Service.UpdateStatus)
+}
+
+// rollbackUpdateStatusError returns an error when a service update finished in a rollback state.
+func rollbackUpdateStatusError(serviceID, serviceName string, status *swarm.UpdateStatus) error {
+	if status == nil || !isRollbackUpdateState(status.State) {
+		return nil
+	}
+
+	target := strings.TrimSpace(serviceName)
+	if target == "" {
+		target = serviceID
+	}
+
+	message := strings.TrimSpace(status.Message)
+	if message == "" {
+		return fmt.Errorf("service %s entered rollback state %q", target, status.State)
+	}
+
+	return fmt.Errorf("service %s entered rollback state %q: %s", target, status.State, message)
+}
+
+// isRollbackUpdateState reports whether the update state indicates a rollback lifecycle.
+func isRollbackUpdateState(state swarm.UpdateState) bool {
+	return state == swarm.UpdateStateRollbackStarted ||
+		state == swarm.UpdateStateRollbackPaused ||
+		state == swarm.UpdateStateRollbackCompleted
 }
 
 // waitForNetwork waits for the network to be ready by repeatedly inspecting it until it succeeds or times out.

--- a/internal/docker/swarm/service.go
+++ b/internal/docker/swarm/service.go
@@ -16,6 +16,11 @@ import (
 	"github.com/kimdre/doco-cd/internal/docker/jsonstream"
 )
 
+const (
+	rollbackStatusObservationTimeout  = 20 * time.Second
+	rollbackStatusObservationInterval = 250 * time.Millisecond
+)
+
 // Service represents a service.
 type Service struct {
 	ID string
@@ -71,7 +76,48 @@ func waitOnService(ctx context.Context, dockerCli command.Cli, serviceID string)
 		return rollbackErr
 	}
 
+	if progressErr != nil {
+		delayedRollbackErr := waitForRollbackUpdateStatus(
+			ctx,
+			dockerCli.Client(),
+			serviceID,
+			serviceResult.Service.Spec.Name,
+			rollbackStatusObservationTimeout,
+		)
+		if delayedRollbackErr != nil {
+			return delayedRollbackErr
+		}
+	}
+
 	return progressErr
+}
+
+// waitForRollbackUpdateStatus keeps observing a service update for a short time
+// to catch rollback states that may appear after the first progress error.
+func waitForRollbackUpdateStatus(ctx context.Context, apiClient client.APIClient, serviceID, serviceName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		serviceResult, err := apiClient.ServiceInspect(ctx, serviceID, client.ServiceInspectOptions{})
+		if err == nil {
+			rollbackErr := rollbackUpdateStatusError(serviceID, serviceName, serviceResult.Service.UpdateStatus)
+			if rollbackErr != nil {
+				return rollbackErr
+			}
+
+			if status := serviceResult.Service.UpdateStatus; status != nil && isTerminalNonRollbackUpdateState(status.State) {
+				return nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(rollbackStatusObservationInterval):
+		}
+	}
+
+	return nil
 }
 
 // rollbackUpdateStatusError returns an error when a service update finished in a rollback state.
@@ -98,6 +144,10 @@ func isRollbackUpdateState(state swarm.UpdateState) bool {
 	return state == swarm.UpdateStateRollbackStarted ||
 		state == swarm.UpdateStateRollbackPaused ||
 		state == swarm.UpdateStateRollbackCompleted
+}
+
+func isTerminalNonRollbackUpdateState(state swarm.UpdateState) bool {
+	return state == swarm.UpdateStateCompleted || state == swarm.UpdateStatePaused
 }
 
 // waitForNetwork waits for the network to be ready by repeatedly inspecting it until it succeeds or times out.


### PR DESCRIPTION
This PR fixes a false-positive success path in Swarm deployments.
 When an update fails and Swarm rolls back, doco-cd now reports the deployment as failed by detecting rollback update states (`rollback_started`, `rollback_paused`, or `rollback_completed`) instead of sending `Deployment completed`.

It also hardens rollback detection against timing races by briefly polling final `UpdateStatus` after progress errors, and adds coverage with:

- unit tests for rollback/terminal state helpers
- a real Swarm integration test that triggers update failure + rollback
- a stabilization update for TestSwarmModeEnabled to avoid global-state flakiness.