### PR TITLE
fix(docker): improve registry auth diagnostics

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/common/types/slice"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
+	"github.com/kimdre/doco-cd/internal/docker/registryauth"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/encryption"
 	"github.com/kimdre/doco-cd/internal/filesystem"
@@ -416,6 +417,20 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 		IgnoreBuildable: true,
 	})
 	if err != nil {
+		imageRefs := make([]string, 0, len(project.Services))
+		for _, svc := range project.Services {
+			if svc.Image == "" {
+				continue
+			}
+
+			imageRefs = append(imageRefs, svc.Image)
+		}
+
+		hint := registryauth.BuildFailureHint(dockerCli.ConfigFile(), imageRefs, err)
+		if hint != "" {
+			return fmt.Errorf("failed to pull images: %w; %s", err, hint)
+		}
+
 		return fmt.Errorf("failed to pull images: %w", err)
 	}
 

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -22,6 +22,7 @@ import (
 	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/common/types/set"
+	"github.com/kimdre/doco-cd/internal/docker/registryauth"
 
 	swarmInternal "github.com/kimdre/doco-cd/internal/docker/swarm"
 )
@@ -54,6 +55,13 @@ var (
 func registryAuthForImage(dockerCli command.Cli, imageRef string) string {
 	encoded, err := command.RetrieveAuthTokenFromImage(dockerCli.ConfigFile(), imageRef)
 	if err != nil {
+		hint := registryauth.BuildFailureHint(dockerCli.ConfigFile(), []string{imageRef}, err)
+		if hint != "" {
+			slog.Warn("failed to resolve registry auth token", slog.String("ref", imageRef), slog.String("err", err.Error()), slog.String("hint", hint))
+		} else {
+			slog.Warn("failed to resolve registry auth token", slog.String("ref", imageRef), slog.String("err", err.Error()))
+		}
+
 		return ""
 	}
 
@@ -490,7 +498,26 @@ func PullImages(ctx context.Context, dockerCli command.Cli, projectName string) 
 		return fmt.Errorf("failed to generate project: %w", err)
 	}
 
-	return service.Pull(ctx, project, api.PullOptions{Quiet: true})
+	err = service.Pull(ctx, project, api.PullOptions{Quiet: true})
+	if err != nil {
+		imageRefs := make([]string, 0, len(project.Services))
+		for _, svc := range project.Services {
+			if svc.Image == "" {
+				continue
+			}
+
+			imageRefs = append(imageRefs, svc.Image)
+		}
+
+		hint := registryauth.BuildFailureHint(dockerCli.ConfigFile(), imageRefs, err)
+		if hint != "" {
+			return fmt.Errorf("failed to pull images: %w; %s", err, hint)
+		}
+
+		return fmt.Errorf("failed to pull images: %w", err)
+	}
+
+	return nil
 }
 
 // vars used to allow overriding in tests without needing to mock the entire function.

--- a/internal/docker/registryauth/diagnostics.go
+++ b/internal/docker/registryauth/diagnostics.go
@@ -10,6 +10,7 @@ import (
 
 	distReference "github.com/distribution/reference"
 	"github.com/docker/cli/cli/config/configfile"
+
 	"github.com/kimdre/doco-cd/internal/common/types/set"
 )
 

--- a/internal/docker/registryauth/diagnostics.go
+++ b/internal/docker/registryauth/diagnostics.go
@@ -1,0 +1,240 @@
+package registryauth
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	distReference "github.com/distribution/reference"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/kimdre/doco-cd/internal/common/types/set"
+)
+
+const (
+	dockerHubDomain       = "docker.io"
+	dockerHubIndexDomain  = "index.docker.io"
+	dockerHubRegistryHost = "registry-1.docker.io"
+	dockerHubAuthConfig   = "https://index.docker.io/v1/"
+)
+
+// IsAuthRelatedError reports whether the provided error looks like a
+// registry-authorization/authentication failure.
+func IsAuthRelatedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	authSignals := []string{
+		"access denied",
+		"access forbidden",
+		"authentication required",
+		"authorization",
+		"error getting credentials",
+		"insufficient_scope",
+		"no basic auth credentials",
+		"pull access denied",
+		"unauthorized",
+	}
+
+	for _, signal := range authSignals {
+		if strings.Contains(msg, signal) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// WrapLookupError wraps Docker auth token lookup failures with actionable
+// hints for private-registry setups.
+func WrapLookupError(cfg *configfile.ConfigFile, imageRef string, lookupErr error) error {
+	if lookupErr == nil {
+		return nil
+	}
+
+	hint := BuildFailureHint(cfg, []string{imageRef}, lookupErr)
+	if hint == "" {
+		return fmt.Errorf("retrieve auth token from image %q: %w", imageRef, lookupErr)
+	}
+
+	return fmt.Errorf("retrieve auth token from image %q: %w; %s", imageRef, lookupErr, hint)
+}
+
+// BuildFailureHint returns user-facing guidance for registry auth failures.
+// It returns an empty string for non-auth-related errors.
+func BuildFailureHint(cfg *configfile.ConfigFile, imageRefs []string, failure error) string {
+	if cfg == nil || !IsAuthRelatedError(failure) {
+		return ""
+	}
+
+	registries := imageRegistries(imageRefs)
+	if len(registries) == 0 {
+		return ""
+	}
+
+	var hints []string
+
+	if cfg.Filename != "" {
+		hints = append(hints, "docker config path: "+cfg.Filename)
+	}
+
+	if dockerConfig := strings.TrimSpace(os.Getenv("DOCKER_CONFIG")); dockerConfig != "" {
+		hints = append(hints, "DOCKER_CONFIG="+dockerConfig)
+	}
+
+	missingHelpers := missingCredentialHelpers(cfg, registries)
+	if len(missingHelpers) > 0 {
+		hints = append(hints, "missing helper binaries in container: "+strings.Join(missingHelpers, ", "))
+	}
+
+	missingAuth := registriesWithoutConfigAuth(cfg, registries)
+	if len(missingAuth) > 0 {
+		hints = append(hints, "no credentials configured for registries: "+strings.Join(missingAuth, ", "))
+	}
+
+	if (cfg.CredentialsStore != "" || len(cfg.CredentialHelpers) > 0) && len(cfg.AuthConfigs) == 0 {
+		hints = append(hints, "helper-based credentials require matching docker-credential-* binaries inside the doco-cd container")
+	}
+
+	if len(hints) == 0 {
+		return ""
+	}
+
+	return "registry auth hint: " + strings.Join(hints, "; ")
+}
+
+// imageRegistries returns a sorted list of unique registry domains extracted from the provided image references.
+func imageRegistries(imageRefs []string) []string {
+	unique := set.Set[string]{}
+
+	for _, ref := range imageRefs {
+		namedRef, err := distReference.ParseNormalizedNamed(ref)
+		if err != nil {
+			continue
+		}
+
+		registry := distReference.Domain(namedRef)
+		if registry == "" {
+			continue
+		}
+
+		unique.Add(registry)
+	}
+
+	registries := make([]string, 0, len(unique))
+	for registry := range unique {
+		registries = append(registries, registry)
+	}
+
+	sort.Strings(registries)
+
+	return registries
+}
+
+// registriesWithoutConfigAuth returns a list of registries for which the provided Docker config file
+// does not contain any authentication information (neither inline auth nor configured credential helpers).
+func registriesWithoutConfigAuth(cfg *configfile.ConfigFile, registries []string) []string {
+	var missing []string
+
+	for _, registry := range registries {
+		if hasInlineAuth(cfg, registry) || configuredHelper(cfg, registry) != "" {
+			continue
+		}
+
+		missing = append(missing, registry)
+	}
+
+	return missing
+}
+
+// missingCredentialHelpers returns a list of credential helpers that are configured
+// in the Docker config file but are not found in the system's PATH.
+func missingCredentialHelpers(cfg *configfile.ConfigFile, registries []string) []string {
+	helperByName := map[string]string{}
+
+	for _, registry := range registries {
+		helper := configuredHelper(cfg, registry)
+		if helper == "" {
+			continue
+		}
+
+		if _, exists := helperByName[helper]; exists {
+			continue
+		}
+
+		binaryName := "docker-credential-" + helper
+		if _, err := exec.LookPath(binaryName); err == nil {
+			continue
+		} else if errors.Is(err, exec.ErrNotFound) {
+			helperByName[helper] = binaryName
+		}
+	}
+
+	missing := make([]string, 0, len(helperByName))
+	for helper, binaryName := range helperByName {
+		missing = append(missing, fmt.Sprintf("%s (%s)", helper, binaryName))
+	}
+
+	sort.Strings(missing)
+
+	return missing
+}
+
+// configuredHelper returns the credential helper configured for the given registry in the Docker config file.
+// It checks for registry-specific helpers first, then falls back to the global credentials store if no specific helper is found.
+func configuredHelper(cfg *configfile.ConfigFile, registry string) string {
+	if cfg == nil {
+		return ""
+	}
+
+	if helper, exists := cfg.CredentialHelpers[registry]; exists {
+		return helper
+	}
+
+	switch registry {
+	case dockerHubDomain, dockerHubIndexDomain, dockerHubRegistryHost:
+		if helper, exists := cfg.CredentialHelpers[dockerHubAuthConfig]; exists {
+			return helper
+		}
+
+		if helper, exists := cfg.CredentialHelpers[dockerHubDomain]; exists {
+			return helper
+		}
+
+		if helper, exists := cfg.CredentialHelpers[dockerHubIndexDomain]; exists {
+			return helper
+		}
+	}
+
+	return cfg.CredentialsStore
+}
+
+// hasInlineAuth checks if the Docker config file contains inline authentication information
+// for the given registry. It checks both the registry itself and its HTTPS variant.
+func hasInlineAuth(cfg *configfile.ConfigFile, registry string) bool {
+	if cfg == nil {
+		return false
+	}
+
+	if _, ok := cfg.AuthConfigs[registry]; ok {
+		return true
+	}
+
+	if _, ok := cfg.AuthConfigs["https://"+registry]; ok {
+		return true
+	}
+
+	switch registry {
+	case dockerHubDomain, dockerHubIndexDomain, dockerHubRegistryHost:
+		if _, ok := cfg.AuthConfigs[dockerHubAuthConfig]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/docker/registryauth/diagnostics_test.go
+++ b/internal/docker/registryauth/diagnostics_test.go
@@ -1,0 +1,93 @@
+package registryauth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/docker/cli/cli/config/configfile"
+	configtypes "github.com/docker/cli/cli/config/types"
+)
+
+func TestIsAuthRelatedError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		err  error
+		want bool
+	}{
+		{err: nil, want: false},
+		{err: errors.New("network timeout"), want: false},
+		{err: errors.New("pull access denied for private/app"), want: true},
+		{err: errors.New("Error response from daemon: unauthorized"), want: true},
+		{err: errors.New("error getting credentials - err: exit status 1"), want: true},
+	}
+
+	for _, tc := range testCases {
+		if got := IsAuthRelatedError(tc.err); got != tc.want {
+			t.Fatalf("IsAuthRelatedError(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestBuildFailureHint(t *testing.T) {
+	t.Parallel()
+
+	cfg := &configfile.ConfigFile{
+		Filename:         "/root/.docker/config.json",
+		CredentialsStore: "__missing_helper__",
+	}
+
+	hint := BuildFailureHint(cfg, []string{"ghcr.io/example/private:latest"}, errors.New("pull access denied"))
+	if !strings.Contains(hint, "registry auth hint:") {
+		t.Fatalf("BuildFailureHint() missing prefix: %q", hint)
+	}
+
+	if !strings.Contains(hint, "docker config path: /root/.docker/config.json") {
+		t.Fatalf("BuildFailureHint() missing config path hint: %q", hint)
+	}
+
+	if !strings.Contains(hint, "missing helper binaries in container:") {
+		t.Fatalf("BuildFailureHint() missing helper-binary hint: %q", hint)
+	}
+
+	if !strings.Contains(hint, "helper-based credentials require matching docker-credential-* binaries") {
+		t.Fatalf("BuildFailureHint() missing helper requirement hint: %q", hint)
+	}
+}
+
+func TestBuildFailureHint_NoAuthError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &configfile.ConfigFile{
+		AuthConfigs: map[string]configtypes.AuthConfig{
+			"ghcr.io": {Username: "u", Password: "p"},
+		},
+	}
+
+	if hint := BuildFailureHint(cfg, []string{"ghcr.io/example/private:latest"}, errors.New("connection reset by peer")); hint != "" {
+		t.Fatalf("BuildFailureHint() = %q, want empty hint", hint)
+	}
+}
+
+func TestWrapLookupError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &configfile.ConfigFile{
+		Filename:         "/root/.docker/config.json",
+		CredentialsStore: "__missing_helper__",
+	}
+
+	err := WrapLookupError(cfg, "ghcr.io/example/private:latest", errors.New("error getting credentials"))
+	if err == nil {
+		t.Fatal("WrapLookupError() returned nil error")
+	}
+
+	if !strings.Contains(err.Error(), "retrieve auth token from image") {
+		t.Fatalf("WrapLookupError() missing base context: %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "registry auth hint:") {
+		t.Fatalf("WrapLookupError() missing hint: %v", err)
+	}
+}

--- a/internal/docker/service_utils.go
+++ b/internal/docker/service_utils.go
@@ -82,17 +82,17 @@ func normalizeRepositoryForLabelMatch(repository string) string {
 
 // buildRepositoryLabelCandidates generates a set of candidate repository label values
 // for matching by normalizing the input repository string.
-func buildRepositoryLabelCandidates(repository string) map[string]struct{} {
+func buildRepositoryLabelCandidates(repository string) set.Set[string] {
 	if strings.TrimSpace(repository) == "" {
 		return map[string]struct{}{"": {}}
 	}
 
-	candidates := map[string]struct{}{}
+	candidates := set.Set[string]{}
 
 	add := func(v string) {
 		v = strings.TrimSpace(v)
 		if v != "" {
-			candidates[v] = struct{}{}
+			candidates.Add(v)
 		}
 	}
 

--- a/internal/docker/swarm/deploy_composefile.go
+++ b/internal/docker/swarm/deploy_composefile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/common/types/set"
 
 	"github.com/kimdre/doco-cd/internal/docker/options"
+	"github.com/kimdre/doco-cd/internal/docker/registryauth"
 
 	"github.com/docker/cli/cli/compose/convert"
 	composetypes "github.com/docker/cli/cli/compose/types"
@@ -319,7 +320,7 @@ func deployServices(ctx context.Context, dockerCLI command.Cli, services map[str
 			// Retrieve encoded auth token from the image reference
 			encodedAuth, err = command.RetrieveAuthTokenFromImage(dockerCLI.ConfigFile(), image)
 			if err != nil {
-				return nil, err
+				return nil, registryauth.WrapLookupError(dockerCLI.ConfigFile(), image, err)
 			}
 		}
 

--- a/internal/docker/swarm_job.go
+++ b/internal/docker/swarm_job.go
@@ -18,6 +18,7 @@ import (
 	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 
+	"github.com/kimdre/doco-cd/internal/docker/registryauth"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 )
 
@@ -257,7 +258,7 @@ func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, servi
 	if opts.SendRegistryAuth {
 		encodedAuth, authErr := command.RetrieveAuthTokenFromImage(dockerCLI.ConfigFile(), oneOffSpec.TaskTemplate.ContainerSpec.Image)
 		if authErr != nil {
-			return fmt.Errorf("retrieve auth token from image: %w", authErr)
+			return registryauth.WrapLookupError(dockerCLI.ConfigFile(), oneOffSpec.TaskTemplate.ContainerSpec.Image, authErr)
 		}
 
 		createOpts.EncodedRegistryAuth = encodedAuth

--- a/wiki/docs/Advanced/Private-Container-Registries.md
+++ b/wiki/docs/Advanced/Private-Container-Registries.md
@@ -9,6 +9,15 @@ tags:
 
 To access a private container registry, you need to provide the credentials by adding the docker config file `~/.docker/config.json` to the doco-cd container.
 
+## Supported credential setups
+
+doco-cd uses Docker CLI auth resolution. The following setups are supported:
+
+- Inline credentials in `auths` (recommended), either in [mounted `config.json`](#mounting-an-existing-docker-config-file) or via [`DOCKER_AUTH_CONFIG`](#using-docker_auth_config).
+- `credsStore` / `credHelpers` based configs **only if** the matching `docker-credential-*` helper binaries are available inside the doco-cd container.
+
+If your host `config.json` references helpers that are not available in the container, registry authentication will fail even though the file is mounted.
+
 ## Mounting an existing docker config file
 
 You can mount your existing `~/.docker/config.json` file from the host to the container if you have already added the credentials using `docker login` on the host machine.
@@ -84,3 +93,33 @@ services:
     volumes:
       data:
     ```
+
+## Using `DOCKER_AUTH_CONFIG`
+
+Instead of mounting a file, you can provide credentials directly through `DOCKER_AUTH_CONFIG`:
+
+```yaml title="docker-compose.yml"
+services:
+  app:
+    environment:
+      DOCKER_AUTH_CONFIG: |
+        {
+          "auths": {
+            "my.registry.example": {
+              "auth": "BASE64_USERNAME_PASSWORD"
+            }
+          }
+        }
+```
+
+!!! warning "Less secure than file or secret mounts"
+    `DOCKER_AUTH_CONFIG` stores registry credentials directly in an environment variable. In containerized setups, environment variables are often easier to expose accidentally (for example through inspect/debug output, process environment dumps, or logs) than mounted files/secrets with restrictive permissions.
+    Prefer mounted secrets or a mounted `config.json` where possible.
+
+## Troubleshooting auth failures
+
+When pull/update logs contain authorization errors (for example `pull access denied`, `unauthorized`, or `access forbidden`):
+
+1. Ensure doco-cd reads the expected config path (`/root/.docker/config.json` by default, or your [`DOCKER_CONFIG`](../Docker-Settings.md#common-environment-variables) override).
+2. If config uses `credsStore` / `credHelpers`, ensure required `docker-credential-*` binaries exist in the container at the expected path (for example `/usr/local/bin/<docker-credential-helper>`). If they are missing, either install/mount them in the container or use a different credential setup.
+3. Prefer inline `auths` entries for containerized doco-cd deployments when helper binaries are unavailable.

--- a/wiki/docs/Docker-Settings.md
+++ b/wiki/docs/Docker-Settings.md
@@ -15,14 +15,15 @@ Most users can leave them at the defaults, and you can set them with [environmen
     See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables) for more information on available Docker CLI environment variables.  
     The list below contains the most commonly used environment variables that are relevant for Doco-CD.
 
-| Key                     | Type    | Description                                                                                                                                                                                      | Default value |
-|-------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `DOCKER_API_VERSION`    | string  | Overwrites the API version that doco-cd will use to connect to the Docker Daemon (e.g. `"1.49"`)                                                                                                 |               |
-| `DOCKER_CERT_PATH`      | string  | The directory from which to load the TLS certificates ("ca.pem", "cert.pem", "key.pem'). The directory has to be accessible from inside the container, e.g. by using a bind mount                |               |
-| `DOCKER_HOST`           | string  | The url that doco-cd will use to connect to the Docker Daemon (e.g. `tcp://192.168.0.10:2375`). Do not set this when using [Docker contexts](Advanced/Docker-Contexts.md) in deployment configs. |               |
-| `DOCKER_QUIET_DEPLOY`   | boolean | Disable the status output of Docker Compose deployments (e.g. pull, create, start, healthy) in the application logs                                                                              | `true`        |
-| `DOCKER_TLS_VERIFY`     | boolean | Enable or disable TLS verification                                                                                                                                                               |               |
-| `DOCKER_SWARM_FEATURES` | boolean | Enable the use Docker Swarm Mode features if the app has detected that it is running in a Docker Swarm environment                                                                               | `true`        |
+| Key                     | Type    | Description                                                                                                                                                                                      | Default value           |
+|-------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
+| `DOCKER_API_VERSION`    | string  | Overwrites the API version that doco-cd will use to connect to the Docker Daemon (e.g. `"1.49"`)                                                                                                 |                         |
+| `DOCKER_CERT_PATH`      | string  | The directory from which to load the TLS certificates ("ca.pem", "cert.pem", "key.pem'). The directory has to be accessible from inside the container, e.g. by using a bind mount                |                         |
+| `DOCKER_CONFIG`         | string  | Overrides the Docker CLI config directory. Doco-CD then reads Docker credentials from `<DOCKER_CONFIG>/config.json`.                                                                             | `~/.docker/config.json` |
+| `DOCKER_HOST`           | string  | The url that doco-cd will use to connect to the Docker Daemon (e.g. `tcp://192.168.0.10:2375`). Do not set this when using [Docker contexts](Advanced/Docker-Contexts.md) in deployment configs. |                         |
+| `DOCKER_QUIET_DEPLOY`   | boolean | Disable the status output of Docker Compose deployments (e.g. pull, create, start, healthy) in the application logs                                                                              | `true`                  |
+| `DOCKER_TLS_VERIFY`     | boolean | Enable or disable TLS verification                                                                                                                                                               |                         |
+| `DOCKER_SWARM_FEATURES` | boolean | Enable the use Docker Swarm Mode features if the app has detected that it is running in a Docker Swarm environment                                                                               | `true`                  |
 
 ## Remote Docker Daemons
 


### PR DESCRIPTION
This PR improves private-registry troubleshooting in doco-cd and updates docs to make supported credential methods clearer.

### What changed
- Added registry-auth diagnostics in image pull/update paths to provide actionable hints when auth fails (e.g. missing `docker-credential-*` helper binaries, missing registry creds, active `DOCKER_CONFIG` path).
- Wrapped auth-token lookup errors in Swarm deploy/job flows with clearer context.
- Updated private registry docs with:
  - supported credential setups (`auths`, `DOCKER_AUTH_CONFIG`, helper-based configs with caveats),
  - a warning for `DOCKER_AUTH_CONFIG` security tradeoffs,
  - troubleshooting guidance for common auth failures.
- Added `DOCKER_CONFIG` to the Docker settings environment variable table.

Related to #1471