### PR TITLE
feat(git): recover gracefuly from missing deployed commits after force push

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -369,7 +369,7 @@ func UpdateRepository(path, url, ref string, skipTLSVerify bool, proxyOpts trans
 				slog.String("repair_error", FormatGitErrorMessage(repairErr)))
 		}
 		// Attempt to deepen if the ref is unreachable in a shallow clone
-		if depth > 0 && isRefUnreachableError(err) {
+		if depth > 0 && IsRefUnreachableError(err) {
 			repo, deepenErr := deepenAndCheckout(repo, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
 			if deepenErr != nil {
 				return nil, fmt.Errorf("%w: %w", ErrCheckoutFailed, deepenErr)
@@ -599,7 +599,7 @@ func CloneRepository(path, url, ref string, skipTLSVerify bool, proxyOpts transp
 	err = CheckoutRepository(repo, ref, auth, cloneSubmodules)
 	if err != nil {
 		// Attempt to deepen if the ref is unreachable in a shallow clone
-		if depth > 0 && isRefUnreachableError(err) {
+		if depth > 0 && IsRefUnreachableError(err) {
 			repo, deepenErr := deepenAndCheckout(repo, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
 			if deepenErr != nil {
 				return nil, fmt.Errorf("%w: %w", ErrCheckoutFailed, deepenErr)
@@ -1193,10 +1193,10 @@ func needsReclone(repoPath string, depth int) bool {
 	return isShallow != wantShallow
 }
 
-// isRefUnreachableError returns true when the error indicates the requested ref
+// IsRefUnreachableError returns true when the error indicates the requested ref
 // could not be found, which in a shallow clone likely means the ref is outside
 // the fetched depth.
-func isRefUnreachableError(err error) bool {
+func IsRefUnreachableError(err error) bool {
 	if err == nil {
 		return false
 	}

--- a/internal/git/ref_unreachable_test.go
+++ b/internal/git/ref_unreachable_test.go
@@ -1,0 +1,90 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v5/memfs"
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+func TestIsRefUnreachableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "object not found",
+			err:  plumbing.ErrObjectNotFound,
+			want: true,
+		},
+		{
+			name: "wrapped object not found",
+			err:  fmt.Errorf("wrapped: %w", plumbing.ErrObjectNotFound),
+			want: true,
+		},
+		{
+			name: "reference not found",
+			err:  plumbing.ErrReferenceNotFound,
+			want: true,
+		},
+		{
+			name: "invalid reference",
+			err:  ErrInvalidReference,
+			want: true,
+		},
+		{
+			name: "message match",
+			err:  errors.New("failed to resolve base commit: object not found"),
+			want: true,
+		},
+		{
+			name: "other error",
+			err:  errors.New("permission denied"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRefUnreachableError(tt.err); got != tt.want {
+				t.Fatalf("IsRefUnreachableError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetChangedFilesBetweenCommits_MissingOldCommit(t *testing.T) {
+	repo, err := gogit.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	hashes := commitN(t, wt, 2)
+
+	missingOld := plumbing.NewHash(strings.Repeat("a", 40))
+
+	_, err = GetChangedFilesBetweenCommits(repo, missingOld, hashes[len(hashes)-1])
+	if err == nil {
+		t.Fatal("expected error for missing old commit")
+	}
+
+	if !IsRefUnreachableError(err) {
+		t.Fatalf("expected IsRefUnreachableError=true, got false, err=%v", err)
+	}
+}

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -83,6 +83,13 @@ func shouldSkipOCIDeployment(forceRecreate bool, deployedDigest, resolvedDigest 
 	return deployedDigest == resolvedDigest
 }
 
+// shouldRecoverFromMissingDeployedCommit checks if the error indicates that the deployed commit is no longer reachable
+// in the Git history. This can happen if the commit has been removed or rewritten (e.g., due to a force push).
+// In such cases, we may want to recover by treating it as a full-change deployment.
+func shouldRecoverFromMissingDeployedCommit(err error) bool {
+	return git.IsRefUnreachableError(err)
+}
+
 func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Logger) error {
 	s.Stages.PreDeploy.StartedAt = time.Now()
 
@@ -248,9 +255,27 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 		}
 
 		// Check for file changes
-		gitChangedFiles, err := git.GetChangedFilesBetweenCommits(s.Repository.Git, plumbing.NewHash(deployedCommit), plumbing.NewHash(latestCommit))
-		if err != nil {
-			return fmt.Errorf("failed to get changed files between commits: %w", err)
+		deployedHash := plumbing.NewHash(deployedCommit)
+		latestHash := plumbing.NewHash(latestCommit)
+		gitChangedFiles := make([]git.ChangedFile, 0)
+
+		if _, err := s.Repository.Git.CommitObject(deployedHash); err != nil {
+			if shouldRecoverFromMissingDeployedCommit(err) {
+				stageLog.Warn("previous deployed commit is no longer reachable; continuing with full-change deployment comparison",
+					slog.String("deployed_commit", deployedCommit),
+					slog.String("latest_commit", latestCommit),
+					slog.String("reason", err.Error()),
+				)
+
+				composeChanged = true
+			} else {
+				return fmt.Errorf("failed to resolve deployed commit %s: %w", deployedCommit, err)
+			}
+		} else {
+			gitChangedFiles, err = git.GetChangedFilesBetweenCommits(s.Repository.Git, deployedHash, latestHash)
+			if err != nil {
+				return fmt.Errorf("failed to get changed files between commits: %w", err)
+			}
 		}
 
 		changedFiles := docker.GetPathsFromGitChangedFiles(gitChangedFiles, s.Repository.PathExternal)

--- a/internal/stages/stage_2_pre-deploy_test.go
+++ b/internal/stages/stage_2_pre-deploy_test.go
@@ -1,8 +1,12 @@
 package stages
 
 import (
+	"errors"
+	"fmt"
 	"slices"
 	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
 
 	"github.com/kimdre/doco-cd/internal/docker"
 )
@@ -252,6 +256,49 @@ func TestShouldSkipOCIDeployment(t *testing.T) {
 			got := shouldSkipOCIDeployment(tt.forceRecreate, tt.deployed, tt.resolved)
 			if got != tt.want {
 				t.Errorf("shouldSkipOCIDeployment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldRecoverFromMissingDeployedCommit(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "object not found",
+			err:  plumbing.ErrObjectNotFound,
+			want: true,
+		},
+		{
+			name: "wrapped object not found",
+			err:  fmt.Errorf("wrapped: %w", plumbing.ErrObjectNotFound),
+			want: true,
+		},
+		{
+			name: "reference not found",
+			err:  plumbing.ErrReferenceNotFound,
+			want: true,
+		},
+		{
+			name: "generic error",
+			err:  errors.New("some other git error"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldRecoverFromMissingDeployedCommit(tt.err)
+			if got != tt.want {
+				t.Fatalf("shouldRecoverFromMissingDeployedCommit() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1621 by making pre-deploy Git comparison recover when the previously deployed commit is no longer reachable (e.g., after force-push/rebase).

Instead of failing on `object/reference not found`, doco-cd now logs a warning and proceeds with a full-change deployment path. Non-rewrite-related Git errors still fail normally. 

Also adds tests for unreachable-ref detection and the new fallback behavior.