### PR TITLE
fix(docker): check docker config file is readable and valid

### DIFF
--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 
 	"github.com/kimdre/doco-cd/internal/docker"
+	"github.com/kimdre/doco-cd/internal/docker/registryauth"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/prometheus"
@@ -218,6 +219,11 @@ func run() error {
 			log.Error("failed to close docker client", logger.ErrAttr(err))
 		}
 	}(dockerClient)
+
+	// Check if docker config is readable if it exists
+	if err := registryauth.CheckDockerConfigReadable(dockerCli.ConfigFile()); err != nil {
+		log.Error("docker config readability check failed", logger.ErrAttr(err))
+	}
 
 	if c.DockerSwarmFeatures {
 		if err := swarm.RefreshModeEnabled(ctx, dockerClient); err != nil {

--- a/internal/docker/registryauth/diagnostics.go
+++ b/internal/docker/registryauth/diagnostics.go
@@ -1,10 +1,8 @@
 package registryauth
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,7 +25,7 @@ const (
 // CheckDockerConfigReadable verifies if the docker config file is readable
 // for the current user in the container. It checks the path specified by the
 // DOCKER_CONFIG environment variable or defaults to ~/.docker/config.json.
-// Returns an error if the config file exists but is not readable.
+// Returns an error if the config file exists but is not readable or contains invalid content.
 func CheckDockerConfigReadable(cfg *configfile.ConfigFile) error {
 	if cfg == nil {
 		return errors.New("docker config is nil")
@@ -64,12 +62,26 @@ func CheckDockerConfigReadable(cfg *configfile.ConfigFile) error {
 		return fmt.Errorf("docker config path %q is not a regular file", configPath)
 	}
 
-	// Verify the file is readable by opening it
+	// Verify the file is readable and contains valid content using docker's own loader
+	if err := validateDockerConfigContent(configPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateDockerConfigContent checks if the docker config file is readable and contains valid content.
+func validateDockerConfigContent(configPath string) error {
 	file, err := os.Open(configPath)
 	if err != nil {
 		return fmt.Errorf("docker config file %q is not readable: %w", configPath, err)
 	}
 	defer file.Close()
+
+	testCfg := configfile.New(configPath)
+	if err := testCfg.LoadFromReader(file); err != nil {
+		return fmt.Errorf("docker config file %q is invalid: %w", configPath, err)
+	}
 
 	return nil
 }

--- a/internal/docker/registryauth/diagnostics.go
+++ b/internal/docker/registryauth/diagnostics.go
@@ -1,10 +1,13 @@
 package registryauth
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -20,6 +23,56 @@ const (
 	dockerHubRegistryHost = "registry-1.docker.io"
 	dockerHubAuthConfig   = "https://index.docker.io/v1/"
 )
+
+// CheckDockerConfigReadable verifies if the docker config file is readable
+// for the current user in the container. It checks the path specified by the
+// DOCKER_CONFIG environment variable or defaults to ~/.docker/config.json.
+// Returns an error if the config file exists but is not readable.
+func CheckDockerConfigReadable(cfg *configfile.ConfigFile) error {
+	if cfg == nil {
+		return errors.New("docker config is nil")
+	}
+
+	// Determine the config path to check
+	configPath := cfg.Filename
+	if configPath == "" {
+		// If no config file is loaded, use the DOCKER_CONFIG env var or default path
+		dockerConfigEnv := strings.TrimSpace(os.Getenv("DOCKER_CONFIG"))
+		if dockerConfigEnv != "" {
+			configPath = filepath.Join(dockerConfigEnv, "config.json")
+		} else {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("failed to determine home directory: %w", err)
+			}
+			configPath = filepath.Join(homeDir, ".docker", "config.json")
+		}
+	}
+
+	// Check if the config file exists
+	fileInfo, err := os.Stat(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Config file doesn't exist, which is acceptable
+			return nil
+		}
+		return fmt.Errorf("failed to check docker config file %q: %w", configPath, err)
+	}
+
+	// If it exists, verify it's a regular file
+	if !fileInfo.Mode().IsRegular() {
+		return fmt.Errorf("docker config path %q is not a regular file", configPath)
+	}
+
+	// Verify the file is readable by opening it
+	file, err := os.Open(configPath)
+	if err != nil {
+		return fmt.Errorf("docker config file %q is not readable: %w", configPath, err)
+	}
+	defer file.Close()
+
+	return nil
+}
 
 // IsAuthRelatedError reports whether the provided error looks like a
 // registry-authorization/authentication failure.

--- a/internal/docker/registryauth/diagnostics.go
+++ b/internal/docker/registryauth/diagnostics.go
@@ -43,9 +43,13 @@ func CheckDockerConfigReadable(cfg *configfile.ConfigFile) error {
 			if err != nil {
 				return fmt.Errorf("failed to determine home directory: %w", err)
 			}
+
 			configPath = filepath.Join(homeDir, ".docker", "config.json")
 		}
 	}
+
+	// Normalize the path to prevent path traversal
+	configPath = filepath.Clean(configPath)
 
 	// Check if the config file exists
 	fileInfo, err := os.Stat(configPath)
@@ -54,6 +58,7 @@ func CheckDockerConfigReadable(cfg *configfile.ConfigFile) error {
 			// Config file doesn't exist, which is acceptable
 			return nil
 		}
+
 		return fmt.Errorf("failed to check docker config file %q: %w", configPath, err)
 	}
 

--- a/internal/docker/registryauth/diagnostics_test.go
+++ b/internal/docker/registryauth/diagnostics_test.go
@@ -2,12 +2,97 @@ package registryauth
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
 	configtypes "github.com/docker/cli/cli/config/types"
 )
+
+func TestCheckDockerConfigReadable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		cfg     *configfile.ConfigFile
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: true,
+			errMsg:  "docker config is nil",
+		},
+		{
+			name: "config with non-existent file is acceptable",
+			cfg: &configfile.ConfigFile{
+				Filename: "/nonexistent/path/.docker/config.json",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckDockerConfigReadable(tc.cfg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("CheckDockerConfigReadable() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr && err != nil && tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+				t.Fatalf("CheckDockerConfigReadable() error = %v, want error containing %q", err, tc.errMsg)
+			}
+		})
+	}
+
+	t.Run("config with readable file", func(t *testing.T) {
+		tmpFile := t.TempDir()
+		tmpConfigPath := filepath.Join(tmpFile, "config.json")
+		err := os.WriteFile(tmpConfigPath, []byte("{}"), 0644)
+		if err != nil {
+			t.Fatalf("failed to create temp config file: %v", err)
+		}
+
+		cfg := &configfile.ConfigFile{
+			Filename: tmpConfigPath,
+		}
+
+		err = CheckDockerConfigReadable(cfg)
+		if err != nil {
+			t.Fatalf("CheckDockerConfigReadable() error = %v, wantErr false", err)
+		}
+	})
+
+	t.Run("config with unreadable file", func(t *testing.T) {
+		tmpFile := t.TempDir()
+		tmpConfigPath := filepath.Join(tmpFile, "config.json")
+		err := os.WriteFile(tmpConfigPath, []byte("{}"), 0644)
+		if err != nil {
+			t.Fatalf("failed to create temp config file: %v", err)
+		}
+
+		// Change permissions to make unreadable
+		err = os.Chmod(tmpConfigPath, 0000)
+		if err != nil {
+			t.Fatalf("failed to change file permissions: %v", err)
+		}
+		defer os.Chmod(tmpConfigPath, 0644)
+
+		cfg := &configfile.ConfigFile{
+			Filename: tmpConfigPath,
+		}
+
+		err = CheckDockerConfigReadable(cfg)
+		if err == nil {
+			t.Fatalf("CheckDockerConfigReadable() expected error for unreadable file, got nil")
+		}
+		if !strings.Contains(err.Error(), "not readable") {
+			t.Fatalf("CheckDockerConfigReadable() error = %v, want error containing 'not readable'", err)
+		}
+	})
+}
 
 func TestIsAuthRelatedError(t *testing.T) {
 	t.Parallel()

--- a/internal/docker/registryauth/diagnostics_test.go
+++ b/internal/docker/registryauth/diagnostics_test.go
@@ -47,10 +47,11 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 		})
 	}
 
-	t.Run("config with readable file", func(t *testing.T) {
+	t.Run("config with readable and valid config file", func(t *testing.T) {
 		tmpFile := t.TempDir()
 		tmpConfigPath := filepath.Join(tmpFile, "config.json")
-		err := os.WriteFile(tmpConfigPath, []byte("{}"), 0644)
+		// Valid docker config format
+		err := os.WriteFile(tmpConfigPath, []byte(`{"auths":{}}`), 0644)
 		if err != nil {
 			t.Fatalf("failed to create temp config file: %v", err)
 		}
@@ -68,7 +69,7 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 	t.Run("config with unreadable file", func(t *testing.T) {
 		tmpFile := t.TempDir()
 		tmpConfigPath := filepath.Join(tmpFile, "config.json")
-		err := os.WriteFile(tmpConfigPath, []byte("{}"), 0644)
+		err := os.WriteFile(tmpConfigPath, []byte(`{"auths":{}}`), 0644)
 		if err != nil {
 			t.Fatalf("failed to create temp config file: %v", err)
 		}
@@ -90,6 +91,28 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "not readable") {
 			t.Fatalf("CheckDockerConfigReadable() error = %v, want error containing 'not readable'", err)
+		}
+	})
+
+	t.Run("config with invalid JSON", func(t *testing.T) {
+		tmpFile := t.TempDir()
+		tmpConfigPath := filepath.Join(tmpFile, "config.json")
+		// Invalid JSON format
+		err := os.WriteFile(tmpConfigPath, []byte(`{invalid json content}`), 0644)
+		if err != nil {
+			t.Fatalf("failed to create temp config file: %v", err)
+		}
+
+		cfg := &configfile.ConfigFile{
+			Filename: tmpConfigPath,
+		}
+
+		err = CheckDockerConfigReadable(cfg)
+		if err == nil {
+			t.Fatalf("CheckDockerConfigReadable() expected error for invalid config, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid") {
+			t.Fatalf("CheckDockerConfigReadable() error = %v, want error containing 'invalid'", err)
 		}
 	})
 }

--- a/internal/docker/registryauth/diagnostics_test.go
+++ b/internal/docker/registryauth/diagnostics_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/docker/cli/cli/config/configfile"
 	configtypes "github.com/docker/cli/cli/config/types"
+
+	"github.com/kimdre/doco-cd/internal/filesystem"
 )
 
 func TestCheckDockerConfigReadable(t *testing.T) {
@@ -41,6 +43,7 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("CheckDockerConfigReadable() error = %v, wantErr %v", err, tc.wantErr)
 			}
+
 			if tc.wantErr && err != nil && tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
 				t.Fatalf("CheckDockerConfigReadable() error = %v, want error containing %q", err, tc.errMsg)
 			}
@@ -51,7 +54,7 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 		tmpFile := t.TempDir()
 		tmpConfigPath := filepath.Join(tmpFile, "config.json")
 		// Valid docker config format
-		err := os.WriteFile(tmpConfigPath, []byte(`{"auths":{}}`), 0644)
+		err := os.WriteFile(tmpConfigPath, []byte(`{"auths":{}}`), filesystem.PermOwner)
 		if err != nil {
 			t.Fatalf("failed to create temp config file: %v", err)
 		}
@@ -69,17 +72,18 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 	t.Run("config with unreadable file", func(t *testing.T) {
 		tmpFile := t.TempDir()
 		tmpConfigPath := filepath.Join(tmpFile, "config.json")
-		err := os.WriteFile(tmpConfigPath, []byte(`{"auths":{}}`), 0644)
+
+		err := os.WriteFile(tmpConfigPath, []byte(`{"auths":{}}`), filesystem.PermOwner)
 		if err != nil {
 			t.Fatalf("failed to create temp config file: %v", err)
 		}
 
 		// Change permissions to make unreadable
-		err = os.Chmod(tmpConfigPath, 0000)
+		err = os.Chmod(tmpConfigPath, 0o000)
 		if err != nil {
 			t.Fatalf("failed to change file permissions: %v", err)
 		}
-		defer os.Chmod(tmpConfigPath, 0644)
+		defer os.Chmod(tmpConfigPath, filesystem.PermOwner) // nolint:errcheck
 
 		cfg := &configfile.ConfigFile{
 			Filename: tmpConfigPath,
@@ -89,6 +93,7 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 		if err == nil {
 			t.Fatalf("CheckDockerConfigReadable() expected error for unreadable file, got nil")
 		}
+
 		if !strings.Contains(err.Error(), "not readable") {
 			t.Fatalf("CheckDockerConfigReadable() error = %v, want error containing 'not readable'", err)
 		}
@@ -98,7 +103,7 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 		tmpFile := t.TempDir()
 		tmpConfigPath := filepath.Join(tmpFile, "config.json")
 		// Invalid JSON format
-		err := os.WriteFile(tmpConfigPath, []byte(`{invalid json content}`), 0644)
+		err := os.WriteFile(tmpConfigPath, []byte(`{invalid json content}`), filesystem.PermOwner)
 		if err != nil {
 			t.Fatalf("failed to create temp config file: %v", err)
 		}
@@ -111,6 +116,7 @@ func TestCheckDockerConfigReadable(t *testing.T) {
 		if err == nil {
 			t.Fatalf("CheckDockerConfigReadable() expected error for invalid config, got nil")
 		}
+
 		if !strings.Contains(err.Error(), "invalid") {
 			t.Fatalf("CheckDockerConfigReadable() error = %v, want error containing 'invalid'", err)
 		}


### PR DESCRIPTION
Improvement for #1471

This pull request adds a new diagnostic check to ensure the Docker config file is readable and valid before proceeding with Docker operations. The main logic is implemented in a new function, which is invoked early in the application startup. Comprehensive unit tests are also provided to verify correct behavior in various scenarios.

**Docker config diagnostics:**

* Added a new function `CheckDockerConfigReadable` in `internal/docker/registryauth/diagnostics.go` to verify that the Docker config file is readable, exists as a regular file, and contains valid content. The function checks the path specified by the Docker config or environment variable and provides detailed error messages for different failure cases.
* Integrated the `CheckDockerConfigReadable` check into the application startup sequence in `cmd/doco-cd/main.go`, logging an error if the config is not readable or invalid.
* Updated imports in `cmd/doco-cd/main.go` and `internal/docker/registryauth/diagnostics.go` to include the new dependency and required packages. [[1]](diffhunk://#diff-dfbc8c7c81be7e4dfc591f15ed0d387439d6e2040d234cae5bd8d1cab2aabf33R34) [[2]](diffhunk://#diff-fb169c3d749934c9002fdacd03e0bc7bdfa16fc9ad961a38c5ffe772f6c9b25bR8)

**Testing:**

* Added a comprehensive unit test `TestCheckDockerConfigReadable` in `internal/docker/registryauth/diagnostics_test.go` to cover scenarios such as nil config, non-existent file, valid config, unreadable file, and invalid JSON.