### PR TITLE
fix(autodiscovery): do not force recreate on inert config label drift

### DIFF
--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -43,6 +43,7 @@ func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]doc
 	}
 
 	affected := make([]string, 0, len(deployedStatus))
+	expectedCfg := docker.ParseAutoDiscoveryConfig(expected)
 
 	var firstObserved string
 
@@ -50,12 +51,22 @@ func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]doc
 		actual, ok := status.Labels[docker.DocoCDLabels.Deployment.AutoDiscoveryConfig]
 
 		actual = strings.TrimSpace(actual)
-		if !ok || actual != expected {
-			affected = append(affected, string(serviceName))
+		if ok && actual == expected {
+			continue
+		}
 
-			if firstObserved == "" {
-				firstObserved = actual
-			}
+		// This label only steers the cleanup of obsolete auto-discovered stacks, and that
+		// cleanup reads containers labeled as auto-discovered. With auto-discovery off on
+		// both sides the label is inert, so a changed default is no reason to recreate
+		// every container of the stack.
+		if !expectedCfg.Enabled && !docker.ParseAutoDiscoveryConfig(actual).Enabled {
+			continue
+		}
+
+		affected = append(affected, string(serviceName))
+
+		if firstObserved == "" {
+			firstObserved = actual
 		}
 	}
 

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -56,10 +57,13 @@ func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]doc
 		}
 
 		// This label only steers the cleanup of obsolete auto-discovered stacks, and that
-		// cleanup reads containers labeled as auto-discovered. With auto-discovery off on
-		// both sides the label is inert, so a changed default is no reason to recreate
-		// every container of the stack.
-		if !expectedCfg.Enabled && !docker.ParseAutoDiscoveryConfig(actual).Enabled {
+		// cleanup reads containers labeled as auto-discovered. With auto-discovery off in
+		// both configs, including the legacy enabled label when the config label is absent,
+		// the config label is inert, so a changed default is no reason to recreate the stack.
+		deployedCfg := docker.ParseAutoDiscoveryConfig(actual)
+		legacyAutoDiscoveryEnabled, _ := strconv.ParseBool(status.Labels[docker.DocoCDLabels.Deployment.AutoDiscovery])
+
+		if !expectedCfg.Enabled && !deployedCfg.Enabled && (ok || !legacyAutoDiscoveryEnabled) {
 			continue
 		}
 

--- a/internal/stages/stage_2_pre-deploy_test.go
+++ b/internal/stages/stage_2_pre-deploy_test.go
@@ -109,6 +109,19 @@ func TestAutoDiscoveryConfigLabelDriftServices(t *testing.T) {
 			wantServices:   nil,
 			wantFirstLabel: disabled,
 		},
+		{
+			name:     "disabled now, legacy deployment was enabled",
+			expected: disabled,
+			status: map[docker.Service]docker.ServiceStatus{
+				"web": {
+					Labels: docker.Labels{
+						docker.DocoCDLabels.Deployment.AutoDiscovery: "true",
+					},
+				},
+			},
+			wantServices:   []string{"web"},
+			wantFirstLabel: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/stages/stage_2_pre-deploy_test.go
+++ b/internal/stages/stage_2_pre-deploy_test.go
@@ -14,8 +14,11 @@ import (
 func TestAutoDiscoveryConfigLabelDriftServices(t *testing.T) {
 	expected := "{enabled: true, depth: 0, delete: false, remove_volumes: true, remove_images: true}"
 
+	disabled := "{enabled: false, depth: 0, delete: false, remove_volumes: false, remove_images: true}"
+
 	tests := []struct {
 		name           string
+		expected       string // defaults to expected when empty
 		status         map[docker.Service]docker.ServiceStatus
 		wantServices   []string
 		wantFirstLabel string
@@ -67,10 +70,54 @@ func TestAutoDiscoveryConfigLabelDriftServices(t *testing.T) {
 			wantServices:   []string{"a-web", "z-api"},
 			wantFirstLabel: "",
 		},
+		{
+			// A changed default must not recreate the stack while auto-discovery is off,
+			// because the label steers auto-discovery cleanup only.
+			name:     "disabled on both sides, only a default differs",
+			expected: disabled,
+			status: map[docker.Service]docker.ServiceStatus{
+				"web": {
+					Labels: docker.Labels{
+						docker.DocoCDLabels.Deployment.AutoDiscoveryConfig: "{enabled: false, depth: 0, delete: true, remove_volumes: false, remove_images: true}",
+					},
+				},
+			},
+			wantServices:   nil,
+			wantFirstLabel: disabled,
+		},
+		{
+			name:     "disabled now, deployed while enabled",
+			expected: disabled,
+			status: map[docker.Service]docker.ServiceStatus{
+				"web": {
+					Labels: docker.Labels{
+						docker.DocoCDLabels.Deployment.AutoDiscoveryConfig: "{enabled: true, depth: 0, delete: true, remove_volumes: false, remove_images: true}",
+					},
+				},
+			},
+			wantServices:   []string{"web"},
+			wantFirstLabel: "{enabled: true, depth: 0, delete: true, remove_volumes: false, remove_images: true}",
+		},
+		{
+			name:     "disabled with no label yet",
+			expected: disabled,
+			status: map[docker.Service]docker.ServiceStatus{
+				"web": {
+					Labels: docker.Labels{},
+				},
+			},
+			wantServices:   nil,
+			wantFirstLabel: disabled,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			expected := expected
+			if tt.expected != "" {
+				expected = tt.expected
+			}
+
 			gotServices, gotFirst := autoDiscoveryConfigLabelDriftServices(tt.status, expected)
 			if !slices.Equal(gotServices, tt.wantServices) {
 				t.Fatalf("autoDiscoveryConfigLabelDriftServices() services = %v, want %v", gotServices, tt.wantServices)


### PR DESCRIPTION
## Problem

`cd.doco.deployment.auto_discovery.config` label carries fully resolved
auto-discovery config, defaults included. Pre-deploy compares it to the deployed
label with exact string equality, and any difference marks *every* service as
drifted. That becomes an `auto_discovery_config_label` change, and any change at
all selects `api.RecreateForce`.

So when a release changes one default, the next poll recreates every container of
every stack - database containers too.

v0.107.0 changed the `delete` default from `true` to `false` (#1637), which is
enough on its own:

```
0.105.2: {enabled: false, depth: 0, delete: true,  remove_volumes: false, remove_images: true}
0.108.0: {enabled: false, depth: 0, delete: false, remove_volumes: false, remove_images: true}
```

Note `enabled: false`. The recreate hits stacks which never used auto-discovery,
because the comparison never asks whether the config is live. I hit this on
0.105.2 -> 0.108.0 on two hosts, and it reproduces in both directions (downgrade
forces the same recreate), so it is a label mismatch and not a one-way migration.

Debug log from the affected host:

```
"msg":"changed project files detected, forcing recreate",
"changes":[{"Type":"auto_discovery_config_label",
            "Services":["migrate","postgres","walg-nightly","worker","worker-sample"]}]
```

## Fix

Skip the drift when auto-discovery is off on **both** sides - expected config and
deployed label.

The label is consumed only by `cleanupObsoleteAutoDiscoveredContainers`, and that
cleanup selects containers by `cd.doco.deployment.auto_discovery=true`. With
auto-discovery disabled the label steers nothing, so recreating a whole stack to
refresh it buys nothing.

When either side is enabled, behaviour is unchanged: the label still gets
refreshed through a recreate, so the `enabled -> disabled` transition and the
legacy label migration from #1306 keep working.

## Tests

Three cases added to `TestAutoDiscoveryConfigLabelDriftServices`:

- disabled on both sides, only a default differs -> no drift
- disabled now but deployed while enabled -> still drifts
- disabled with no label yet -> no drift

`go build ./...`, `go vet`, `go test ./internal/stages/...` and
`golangci-lint run internal/stages/...` are green.
