### PR TITLE
 fix(scheduler): restore compose interpolation for scheduled jobs

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -45,7 +44,6 @@ import (
 	swarmTypes "github.com/moby/moby/api/types/swarm"
 
 	"github.com/kimdre/doco-cd/internal/prometheus"
-	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
 
@@ -139,7 +137,7 @@ This is required for future compose operations to work, such as finding
 containers that are part of a service.
 */
 func addComposeServiceLabels(project *types.Project, deployConfig *deploy.Config, payload *webhook.ParsedPayload,
-	workingDir, appVersion, timestamp, composeVersion, latestCommit, projectHash, externalSecretsJSON string,
+	workingDir, appVersion, timestamp, composeVersion, latestCommit, projectHash string,
 ) {
 	for i, s := range project.Services {
 		// Extract service dependencies (depends_on)
@@ -174,10 +172,6 @@ func addComposeServiceLabels(project *types.Project, deployConfig *deploy.Config
 			api.VersionLabel:                            composeVersion,
 			api.OneoffLabel:                             "False", // default, will be overridden by docker compose
 			api.DependenciesLabel:                       strings.Join(dependencies, ","),
-		}
-
-		if externalSecretsJSON != "" {
-			s.CustomLabels[DocoCDJobLabels.JobExternalSecretRefs] = externalSecretsJSON
 		}
 
 		project.Services[i] = s
@@ -803,25 +797,7 @@ func DeployStack(
 			}
 		}
 	} else {
-		// Encode external secret refs (just the references, not resolved values) into a JSON label
-		// so the scheduler can re-resolve them at run time for environment-backed compose secrets.
-		var externalSecretsJSON string
-
-		if len(deployConfig.ExternalSecrets) > 0 {
-			encodedRefs, encErr := secrettypes.EncodeExternalSecretRefs(deployConfig.ExternalSecrets)
-			if encErr != nil {
-				return fmt.Errorf("failed to encode external secret refs for label: %w", encErr)
-			}
-
-			b, marshalErr := json.Marshal(encodedRefs)
-			if marshalErr != nil {
-				return fmt.Errorf("failed to marshal external secret refs label: %w", marshalErr)
-			}
-
-			externalSecretsJSON = string(b)
-		}
-
-		addComposeServiceLabels(project, deployConfig, payload, externalWorkingDir, appVersion, timestamp, ComposeVersion, latestCommit, projectHash, externalSecretsJSON)
+		addComposeServiceLabels(project, deployConfig, payload, externalWorkingDir, appVersion, timestamp, ComposeVersion, latestCommit, projectHash)
 		addComposeVolumeLabels(project, deployConfig, payload, appVersion, timestamp, ComposeVersion, latestCommit, projectHash)
 
 		forcedServices := set.New[string]() // services to recreate if project files changed

--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -34,7 +34,7 @@ type composeScheduledServiceRef struct {
 	Service        string
 	WorkingDir     string
 	ConfigFiles    []string
-	Repository     string
+	RepositoryURL  string
 	DeploymentName string
 	ConfigTarget   string
 	Reference      string
@@ -212,12 +212,21 @@ func composeScheduledServiceRefFromLabels(labels map[string]string) (composeSche
 		)
 	}
 
+	// Prefer the full source URL label to reconstruct a host-qualified
+	// repository path (e.g. "github.com/owner/repo") via git.GetRepoName().
+	// The source "name" label only holds the short "owner/repo" form and
+	// cannot be used for this, since it does not carry the host segment.
+	repositoryURL := strings.TrimSpace(labels[DocoCDLabels.Source.URL])
+	if repositoryURL == "" {
+		repositoryURL = strings.TrimSpace(labels[DocoCDLabels.Source.Name])
+	}
+
 	ref := composeScheduledServiceRef{
 		Project:        project,
 		Service:        service,
 		WorkingDir:     strings.TrimSpace(labels[api.WorkingDirLabel]),
 		ConfigFiles:    splitCommaSeparatedLabelValues(labels[api.ConfigFilesLabel]),
-		Repository:     strings.TrimSpace(labels[DocoCDLabels.Source.Name]),
+		RepositoryURL:  repositoryURL,
 		DeploymentName: strings.TrimSpace(labels[DocoCDLabels.Deployment.Name]),
 		ConfigTarget:   strings.TrimSpace(labels[DocoCDLabels.Deployment.ConfigTarget]),
 		Reference:      strings.TrimSpace(labels[DocoCDLabels.Deployment.TargetRef]),
@@ -234,7 +243,7 @@ func loadComposeScheduledDeployConfig(
 	ref composeScheduledServiceRef,
 	secretProvider *secretprovider.SecretProvider,
 ) (*deploy.Config, string, error) {
-	if strings.TrimSpace(ref.Repository) == "" || strings.TrimSpace(ref.DeploymentName) == "" {
+	if strings.TrimSpace(ref.RepositoryURL) == "" || strings.TrimSpace(ref.DeploymentName) == "" {
 		return nil, "", fmt.Errorf("%w: missing deployment repository and/or name label",
 			ErrComposeScheduledMetadataUnavailable)
 	}
@@ -245,7 +254,7 @@ func loadComposeScheduledDeployConfig(
 	}
 
 	sourceRepoPath, err := filesystem.VerifyAndSanitizePath(
-		filepath.Join(appConfig.DataMountPath, git.GetRepoName(ref.Repository)),
+		filepath.Join(appConfig.DataMountPath, git.GetRepoName(ref.RepositoryURL)),
 		appConfig.DataMountPath,
 	)
 	if err != nil {

--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -176,23 +176,6 @@ func prepareComposeProjectForOneOffRun(project *types.Project, serviceName strin
 		svc.CustomLabels = maps.Clone(svc.CustomLabels)
 	}
 
-	// Ensure the one-off container is created with the standard Compose tracking
-	// labels so it remains attributable to its compose project/service in
-	// downstream systems such as log aggregation.
-	svc.CustomLabels[api.ProjectLabel] = project.Name
-	svc.CustomLabels[api.ServiceLabel] = svc.Name
-	svc.CustomLabels[api.WorkingDirLabel] = project.WorkingDir
-	svc.CustomLabels[api.ConfigFilesLabel] = strings.Join(project.ComposeFiles, ",")
-	svc.CustomLabels[api.VersionLabel] = api.ComposeVersion
-
-	// Set oneoff=False on the service definition (Compose will overwrite it to True
-	// on the actual created container). We do not set it to True here because
-	// com.docker.compose.oneoff is a runtime marker managed by Compose itself—setting
-	// it on the service definition would blur the semantics and risk side effects.
-	// The actual container created by RunOneOffContainer will get oneoff=True,
-	// which we rely on as a fallback ephemeral detection mechanism in the scheduler.
-	svc.CustomLabels[api.OneoffLabel] = "False"
-
 	svc.Labels[DocoCDJobLabels.JobEphemeral] = "true"
 	svc.CustomLabels[DocoCDJobLabels.JobEphemeral] = "true"
 

--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -119,6 +119,11 @@ func RunComposeOneOffFromServiceDefinition(
 		return err
 	}
 
+	project, err = prepareComposeProjectForOneOffRun(project, ref.Service)
+	if err != nil {
+		return err
+	}
+
 	service, err := compose.NewComposeService(dockerCli)
 	if err != nil {
 		return fmt.Errorf("create compose service: %w", err)
@@ -143,6 +148,42 @@ func RunComposeOneOffFromServiceDefinition(
 	}
 
 	return nil
+}
+
+// prepareComposeProjectForOneOffRun returns a copy of project whose target
+// service is marked as a scheduler-created ephemeral run. This keeps Compose
+// one-off containers from being rediscovered as standalone scheduled jobs while
+// preserving the rest of the service definition used to launch them.
+func prepareComposeProjectForOneOffRun(project *types.Project, serviceName string) (*types.Project, error) {
+	if project == nil {
+		return nil, errors.New("compose project is required")
+	}
+
+	svc, ok := project.Services[serviceName]
+	if !ok {
+		return nil, fmt.Errorf("compose service %q not found", serviceName)
+	}
+
+	if svc.Labels == nil {
+		svc.Labels = map[string]string{}
+	} else {
+		svc.Labels = maps.Clone(svc.Labels)
+	}
+
+	if svc.CustomLabels == nil {
+		svc.CustomLabels = map[string]string{}
+	} else {
+		svc.CustomLabels = maps.Clone(svc.CustomLabels)
+	}
+
+	svc.Labels[DocoCDJobLabels.JobEphemeral] = "true"
+	svc.CustomLabels[DocoCDJobLabels.JobEphemeral] = "true"
+
+	projectCopy := *project
+	projectCopy.Services = maps.Clone(project.Services)
+	projectCopy.Services[serviceName] = svc
+
+	return &projectCopy, nil
 }
 
 func loadComposeScheduledProject(

--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -2,13 +2,13 @@ package docker
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
+	"os"
+	"path/filepath"
 	"strings"
 
-	composeCli "github.com/compose-spec/compose-go/v2/cli"
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v5/pkg/api"
@@ -16,7 +16,12 @@ import (
 	containerTypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 
+	"github.com/kimdre/doco-cd/internal/config/app"
+	"github.com/kimdre/doco-cd/internal/config/deploy"
+	"github.com/kimdre/doco-cd/internal/filesystem"
+	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
+	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
 )
 
 var (
@@ -25,11 +30,14 @@ var (
 )
 
 type composeScheduledServiceRef struct {
-	Project                string
-	Service                string
-	WorkingDir             string
-	ConfigFiles            []string
-	EncodedExternalSecrets map[string]string // provider-ready encoded external secret refs from deploy time
+	Project        string
+	Service        string
+	WorkingDir     string
+	ConfigFiles    []string
+	Repository     string
+	DeploymentName string
+	ConfigTarget   string
+	Reference      string
 }
 
 func RunComposeScheduledContainer(
@@ -151,40 +159,15 @@ func loadComposeScheduledProject(
 		)
 	}
 
-	service, err := compose.NewComposeService(dockerCli)
+	deployConfig, repoPath, err := loadComposeScheduledDeployConfig(ctx, ref, secretProvider)
 	if err != nil {
-		return nil, fmt.Errorf("create compose service: %w", err)
+		return nil, err
 	}
 
-	project, err := service.LoadProject(ctx, api.ProjectLoadOptions{
-		ProjectName: ref.Project,
-		ConfigPaths: ref.ConfigFiles,
-		WorkingDir:  ref.WorkingDir,
-		Services:    []string{ref.Service},
-		All:         true,
-		ProjectOptionsFns: []composeCli.ProjectOptionsFn{
-			composeCli.WithResolvedPaths(true),
-			composeCli.WithInterpolation(true),
-		},
-	})
+	project, err := LoadCompose(ctx, dockerCli, repoPath, ref.WorkingDir, ref.Project, ref.ConfigFiles,
+		deployConfig.EnvFiles, deployConfig.Profiles, deployConfig.Internal.Environment)
 	if err != nil {
 		return nil, fmt.Errorf("load compose project for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
-	}
-
-	// Re-resolve external secrets so that environment-backed compose secrets
-	// (secrets.my_secret.environment: MY_VAR) have the correct value injected
-	// when compose calls injectSecrets during Start/RunOneOffContainer.
-	if secretProvider != nil && *secretProvider != nil && len(ref.EncodedExternalSecrets) > 0 {
-		resolved, resolveErr := (*secretProvider).ResolveSecretReferences(ctx, ref.EncodedExternalSecrets)
-		if resolveErr != nil {
-			return nil, fmt.Errorf("re-resolve external secrets for scheduled service %s/%s: %w", ref.Project, ref.Service, resolveErr)
-		}
-
-		if project.Environment == nil {
-			project.Environment = make(map[string]string)
-		}
-
-		maps.Copy(project.Environment, resolved)
 	}
 
 	project, err = project.WithSelectedServices([]string{ref.Service}, types.IgnoreDependencies)
@@ -230,20 +213,167 @@ func composeScheduledServiceRefFromLabels(labels map[string]string) (composeSche
 	}
 
 	ref := composeScheduledServiceRef{
-		Project:     project,
-		Service:     service,
-		WorkingDir:  strings.TrimSpace(labels[api.WorkingDirLabel]),
-		ConfigFiles: splitCommaSeparatedLabelValues(labels[api.ConfigFilesLabel]),
-	}
-
-	if raw := strings.TrimSpace(labels[DocoCDJobLabels.JobExternalSecretRefs]); raw != "" {
-		var encodedRefs map[string]string
-		if err := json.Unmarshal([]byte(raw), &encodedRefs); err == nil {
-			ref.EncodedExternalSecrets = encodedRefs
-		}
+		Project:        project,
+		Service:        service,
+		WorkingDir:     strings.TrimSpace(labels[api.WorkingDirLabel]),
+		ConfigFiles:    splitCommaSeparatedLabelValues(labels[api.ConfigFilesLabel]),
+		Repository:     strings.TrimSpace(labels[DocoCDLabels.Source.Name]),
+		DeploymentName: strings.TrimSpace(labels[DocoCDLabels.Deployment.Name]),
+		ConfigTarget:   strings.TrimSpace(labels[DocoCDLabels.Deployment.ConfigTarget]),
+		Reference:      strings.TrimSpace(labels[DocoCDLabels.Deployment.TargetRef]),
 	}
 
 	return ref, nil
+}
+
+// loadComposeScheduledDeployConfig reloads the deploy config that originally
+// defined the scheduled Compose service and returns the repository root that
+// should be used for LoadCompose interpolation and relative path resolution.
+func loadComposeScheduledDeployConfig(
+	ctx context.Context,
+	ref composeScheduledServiceRef,
+	secretProvider *secretprovider.SecretProvider,
+) (*deploy.Config, string, error) {
+	if strings.TrimSpace(ref.Repository) == "" || strings.TrimSpace(ref.DeploymentName) == "" {
+		return nil, "", fmt.Errorf("%w: missing deployment repository and/or name label",
+			ErrComposeScheduledMetadataUnavailable)
+	}
+
+	appConfig, err := app.GetConfig()
+	if err != nil {
+		return nil, "", fmt.Errorf("load app config for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
+	}
+
+	sourceRepoPath, err := filesystem.VerifyAndSanitizePath(
+		filepath.Join(appConfig.DataMountPath, git.GetRepoName(ref.Repository)),
+		appConfig.DataMountPath,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve source repository path for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
+	}
+
+	repoPath, err := resolveScheduledComposeRepoRoot(ref.WorkingDir, appConfig.DataMountPath, sourceRepoPath)
+	if err != nil {
+		return nil, "", err
+	}
+
+	configs, err := deploy.GetConfigs(sourceRepoPath, appConfig.DeployConfigBaseDir, ref.ConfigTarget, ref.Reference, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("load deploy config for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
+	}
+
+	deployConfig, err := findComposeScheduledDeployConfig(configs, ref.DeploymentName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if err = prepareComposeScheduledDeployConfig(ctx, deployConfig, sourceRepoPath, repoPath, secretProvider); err != nil {
+		return nil, "", err
+	}
+
+	return deployConfig, repoPath, nil
+}
+
+// findComposeScheduledDeployConfig selects the deploy config matching the
+// scheduled service's deployment name from the reloaded config set.
+func findComposeScheduledDeployConfig(configs []*deploy.Config, deploymentName string) (*deploy.Config, error) {
+	for _, cfg := range configs {
+		if strings.TrimSpace(cfg.Name) == deploymentName {
+			return cfg, nil
+		}
+	}
+
+	return nil, fmt.Errorf("load deploy config for scheduled service: %w: deployment %q not found",
+		ErrComposeScheduledMetadataUnavailable, deploymentName)
+}
+
+// prepareComposeScheduledDeployConfig rebuilds the interpolation environment
+// used by LoadCompose from env files, deploy-config environment, and any
+// external secrets that resolve to env vars at run time.
+func prepareComposeScheduledDeployConfig(
+	ctx context.Context,
+	deployConfig *deploy.Config,
+	sourceRepoPath string,
+	repoPath string,
+	secretProvider *secretprovider.SecretProvider,
+) error {
+	if deployConfig == nil {
+		return fmt.Errorf("%w: missing deployment config", ErrComposeScheduledMetadataUnavailable)
+	}
+
+	if deployConfig.RepositoryUrl != "" {
+		if err := deploy.LoadLocalDotEnv(deployConfig, sourceRepoPath); err != nil {
+			return fmt.Errorf("load local env files for scheduled service %s: %w", deployConfig.Name, err)
+		}
+
+		if err := deploy.LoadLocalDotEnv(deployConfig, filepath.Join(repoPath, deployConfig.WorkingDirectory)); err != nil {
+			return fmt.Errorf("load remote env files for scheduled service %s: %w", deployConfig.Name, err)
+		}
+	} else {
+		if err := deploy.LoadLocalDotEnv(deployConfig, filepath.Join(sourceRepoPath, deployConfig.WorkingDirectory)); err != nil {
+			return fmt.Errorf("load env files for scheduled service %s: %w", deployConfig.Name, err)
+		}
+	}
+
+	if deployConfig.Internal.Environment == nil {
+		deployConfig.Internal.Environment = make(map[string]string)
+	}
+
+	maps.Copy(deployConfig.Internal.Environment, deployConfig.Environment)
+
+	if secretProvider == nil || *secretProvider == nil || len(deployConfig.ExternalSecrets) == 0 {
+		return nil
+	}
+
+	encodedSecrets, err := secrettypes.EncodeExternalSecretRefs(deployConfig.ExternalSecrets)
+	if err != nil {
+		return fmt.Errorf("encode external secrets for scheduled service %s: %w", deployConfig.Name, err)
+	}
+
+	resolvedSecrets, err := (*secretProvider).ResolveSecretReferences(ctx, encodedSecrets)
+	if err != nil {
+		return fmt.Errorf("resolve external secrets for scheduled service %s: %w", deployConfig.Name, err)
+	}
+
+	maps.Copy(deployConfig.Internal.Environment, resolvedSecrets)
+
+	return nil
+}
+
+// resolveScheduledComposeRepoRoot walks up from the scheduled service working
+// directory to recover the checked-out repository root under the data mount.
+// If no git root can be found, it falls back to the repository path derived
+// from the deployment source label.
+func resolveScheduledComposeRepoRoot(workingDir, dataMountPath, fallbackRepoPath string) (string, error) {
+	resolvedWorkingDir, err := filepath.EvalSymlinks(workingDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("resolve scheduled compose working directory %q: %w", workingDir, err)
+		}
+
+		resolvedWorkingDir = filepath.Clean(workingDir)
+	}
+
+	for dir := resolvedWorkingDir; filesystem.InBasePath(dataMountPath, dir); dir = filepath.Dir(dir) {
+		if filesystem.IsDir(filepath.Join(dir, ".git")) {
+			return dir, nil
+		}
+
+		if dir == filepath.Clean(dataMountPath) {
+			break
+		}
+
+		if parent := filepath.Dir(dir); parent == dir {
+			break
+		}
+	}
+
+	if fallbackRepoPath != "" {
+		return fallbackRepoPath, nil
+	}
+
+	return "", fmt.Errorf("%w: could not determine repository root for %q",
+		ErrComposeScheduledMetadataUnavailable, workingDir)
 }
 
 func splitCommaSeparatedLabelValues(raw string) []string {

--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -176,6 +176,23 @@ func prepareComposeProjectForOneOffRun(project *types.Project, serviceName strin
 		svc.CustomLabels = maps.Clone(svc.CustomLabels)
 	}
 
+	// Ensure the one-off container is created with the standard Compose tracking
+	// labels so it remains attributable to its compose project/service in
+	// downstream systems such as log aggregation.
+	svc.CustomLabels[api.ProjectLabel] = project.Name
+	svc.CustomLabels[api.ServiceLabel] = svc.Name
+	svc.CustomLabels[api.WorkingDirLabel] = project.WorkingDir
+	svc.CustomLabels[api.ConfigFilesLabel] = strings.Join(project.ComposeFiles, ",")
+	svc.CustomLabels[api.VersionLabel] = api.ComposeVersion
+
+	// Set oneoff=False on the service definition (Compose will overwrite it to True
+	// on the actual created container). We do not set it to True here because
+	// com.docker.compose.oneoff is a runtime marker managed by Compose itself—setting
+	// it on the service definition would blur the semantics and risk side effects.
+	// The actual container created by RunOneOffContainer will get oneoff=True,
+	// which we rely on as a fallback ephemeral detection mechanism in the scheduler.
+	svc.CustomLabels[api.OneoffLabel] = "False"
+
 	svc.Labels[DocoCDJobLabels.JobEphemeral] = "true"
 	svc.CustomLabels[DocoCDJobLabels.JobEphemeral] = "true"
 

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -525,3 +525,63 @@ func TestGetServiceSchedulerLabels(t *testing.T) {
 		}
 	})
 }
+
+func TestPrepareComposeProjectForOneOffRun(t *testing.T) {
+	t.Parallel()
+
+	t.Run("marks target service as ephemeral without mutating input project", func(t *testing.T) {
+		t.Parallel()
+
+		project := &types.Project{
+			Services: types.Services{
+				"backup": {
+					Name:         "backup",
+					Labels:       map[string]string{"plain": "label"},
+					CustomLabels: map[string]string{DocoCDJobLabels.JobEnabled: "true"},
+				},
+			},
+		}
+
+		got, err := prepareComposeProjectForOneOffRun(project, "backup")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got == project {
+			t.Fatal("expected returned project copy, got original pointer")
+		}
+
+		if got.Services["backup"].Labels[DocoCDJobLabels.JobEphemeral] != "true" {
+			t.Fatalf("expected service labels to mark one-off run as ephemeral, got %q",
+				got.Services["backup"].Labels[DocoCDJobLabels.JobEphemeral])
+		}
+
+		if got.Services["backup"].CustomLabels[DocoCDJobLabels.JobEphemeral] != "true" {
+			t.Fatalf("expected custom labels to mark one-off run as ephemeral, got %q",
+				got.Services["backup"].CustomLabels[DocoCDJobLabels.JobEphemeral])
+		}
+
+		if _, ok := project.Services["backup"].Labels[DocoCDJobLabels.JobEphemeral]; ok {
+			t.Fatal("input project labels were mutated")
+		}
+
+		if _, ok := project.Services["backup"].CustomLabels[DocoCDJobLabels.JobEphemeral]; ok {
+			t.Fatal("input project custom labels were mutated")
+		}
+	})
+
+	t.Run("returns error for unknown service", func(t *testing.T) {
+		t.Parallel()
+
+		project := &types.Project{
+			Services: types.Services{
+				"backup": {Name: "backup"},
+			},
+		}
+
+		_, err := prepareComposeProjectForOneOffRun(project, "missing")
+		if err == nil {
+			t.Fatal("expected error for missing service, got nil")
+		}
+	})
+}

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -2,14 +2,15 @@ package docker
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
-	"maps"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
 
+	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
 )
@@ -49,10 +50,14 @@ func TestComposeScheduledServiceRefFromLabels(t *testing.T) {
 		t.Parallel()
 
 		ref, err := composeScheduledServiceRefFromLabels(map[string]string{
-			api.ProjectLabel:     "project-a",
-			api.ServiceLabel:     "backup",
-			api.WorkingDirLabel:  "/repo/stack",
-			api.ConfigFilesLabel: "/repo/stack/compose.yaml, /repo/stack/compose.override.yaml",
+			api.ProjectLabel:                     "project-a",
+			api.ServiceLabel:                     "backup",
+			api.WorkingDirLabel:                  "/repo/stack",
+			api.ConfigFilesLabel:                 "/repo/stack/compose.yaml, /repo/stack/compose.override.yaml",
+			DocoCDLabels.Source.Name:             "example.com/owner/repo",
+			DocoCDLabels.Deployment.Name:         "stack-a",
+			DocoCDLabels.Deployment.ConfigTarget: "nas",
+			DocoCDLabels.Deployment.TargetRef:    "refs/heads/main",
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -68,6 +73,22 @@ func TestComposeScheduledServiceRefFromLabels(t *testing.T) {
 
 		if len(ref.ConfigFiles) != 2 {
 			t.Fatalf("expected 2 config files, got %d (%v)", len(ref.ConfigFiles), ref.ConfigFiles)
+		}
+
+		if ref.Repository != "example.com/owner/repo" {
+			t.Fatalf("unexpected repository: %q", ref.Repository)
+		}
+
+		if ref.DeploymentName != "stack-a" {
+			t.Fatalf("unexpected deployment name: %q", ref.DeploymentName)
+		}
+
+		if ref.ConfigTarget != "nas" {
+			t.Fatalf("unexpected config target: %q", ref.ConfigTarget)
+		}
+
+		if ref.Reference != "refs/heads/main" {
+			t.Fatalf("unexpected reference: %q", ref.Reference)
 		}
 	})
 
@@ -126,75 +147,6 @@ func TestComposeScheduledServiceRefFromLabels(t *testing.T) {
 
 		if ref.WorkingDir != "/repo" {
 			t.Errorf("working dir not trimmed: %q", ref.WorkingDir)
-		}
-	})
-
-	t.Run("parses external refs JSON label", func(t *testing.T) {
-		t.Parallel()
-
-		encodedRefs := map[string]string{ //nolint:gosec // test data, not real credentials
-			"DB_PASSWORD": "my-store/db-password",
-			"API_KEY":     "my-store/api-key",
-		}
-		refsJSON, _ := json.Marshal(encodedRefs)
-
-		ref, err := composeScheduledServiceRefFromLabels(map[string]string{
-			api.ProjectLabel:                      "project-a",
-			api.ServiceLabel:                      "backup",
-			api.WorkingDirLabel:                   "/repo/stack",
-			api.ConfigFilesLabel:                  "/repo/stack/compose.yaml",
-			DocoCDJobLabels.JobExternalSecretRefs: string(refsJSON),
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if len(ref.EncodedExternalSecrets) != 2 {
-			t.Fatalf("expected 2 external refs, got %d: %v", len(ref.EncodedExternalSecrets), ref.EncodedExternalSecrets)
-		}
-
-		if ref.EncodedExternalSecrets["DB_PASSWORD"] != "my-store/db-password" {
-			t.Errorf("unexpected DB_PASSWORD ref: %q", ref.EncodedExternalSecrets["DB_PASSWORD"])
-		}
-
-		if ref.EncodedExternalSecrets["API_KEY"] != "my-store/api-key" {
-			t.Errorf("unexpected API_KEY ref: %q", ref.EncodedExternalSecrets["API_KEY"])
-		}
-	})
-
-	t.Run("ignores malformed external refs JSON label", func(t *testing.T) {
-		t.Parallel()
-
-		ref, err := composeScheduledServiceRefFromLabels(map[string]string{
-			api.ProjectLabel:                      "project-a",
-			api.ServiceLabel:                      "backup",
-			api.WorkingDirLabel:                   "/repo/stack",
-			api.ConfigFilesLabel:                  "/repo/stack/compose.yaml",
-			DocoCDJobLabels.JobExternalSecretRefs: "not-valid-json",
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if len(ref.EncodedExternalSecrets) != 0 {
-			t.Fatalf("expected empty external refs on bad JSON, got %v", ref.EncodedExternalSecrets)
-		}
-	})
-
-	t.Run("empty external refs JSON label is ignored", func(t *testing.T) {
-		t.Parallel()
-
-		ref, err := composeScheduledServiceRefFromLabels(map[string]string{
-			api.ProjectLabel:                      "project-a",
-			api.ServiceLabel:                      "backup",
-			DocoCDJobLabels.JobExternalSecretRefs: "   ",
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if ref.EncodedExternalSecrets != nil {
-			t.Fatalf("expected nil external refs on empty label, got %v", ref.EncodedExternalSecrets)
 		}
 	})
 }
@@ -274,94 +226,143 @@ func TestLoadComposeScheduledProject_RequiresComposeMetadata(t *testing.T) {
 	})
 }
 
-func TestLoadComposeScheduledProject_InjectsResolvedSecrets(t *testing.T) {
+func TestPrepareComposeScheduledDeployConfig(t *testing.T) {
 	t.Parallel()
 
-	resolved := map[string]string{
-		"DB_PASSWORD": "s3cr3t",
-		"API_KEY":     "abc123",
-	}
-	provider := newStubProvider(resolved, nil)
+	t.Run("merges deploy environment and resolved secrets", func(t *testing.T) {
+		t.Parallel()
 
-	// Build a minimal in-memory project to stand in for the loaded one.
-	// We test the injection logic directly by constructing a project and
-	// calling the injection block's equivalent: verifying that the values
-	// returned by the provider end up in project.Environment.
-	project := &types.Project{
-		Name:        "project-a",
-		WorkingDir:  "/repo",
-		Environment: map[string]string{},
-		Services: types.Services{
-			"backup": {Name: "backup"},
-		},
+		provider := newStubProvider(map[string]string{
+			"SECRET":  "s3cr3t",
+			"API_KEY": "abc123",
+		}, nil)
+
+		sourceRepoPath := t.TempDir()
+
+		cfg := &deploy.Config{
+			Name:             "project-a",
+			WorkingDirectory: ".",
+			Environment:      map[string]string{"BACKUP_BASE_DIR": "/backups"},
+			ExternalSecrets: map[string]secrettypes.ExternalSecretRef{
+				"SECRET":  {LegacyRef: "store/secret"},  //nolint:gosec // test data, not real credentials
+				"API_KEY": {LegacyRef: "store/api-key"}, //nolint:gosec // test data, not real credentials
+			},
+		}
+
+		if err := prepareComposeScheduledDeployConfig(context.Background(), cfg, sourceRepoPath, sourceRepoPath, provider); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.Internal.Environment["BACKUP_BASE_DIR"] != "/backups" {
+			t.Fatalf("expected BACKUP_BASE_DIR to be preserved, got %q", cfg.Internal.Environment["BACKUP_BASE_DIR"])
+		}
+
+		if cfg.Internal.Environment["SECRET"] != "s3cr3t" {
+			t.Fatalf("expected SECRET from provider, got %q", cfg.Internal.Environment["SECRET"])
+		}
+
+		if cfg.Internal.Environment["API_KEY"] != "abc123" {
+			t.Fatalf("expected API_KEY from provider, got %q", cfg.Internal.Environment["API_KEY"])
+		}
+	})
+
+	t.Run("returns provider errors", func(t *testing.T) {
+		t.Parallel()
+
+		providerErr := errors.New("provider unavailable")
+		provider := newStubProvider(nil, providerErr)
+
+		cfg := &deploy.Config{
+			Name:             "project-a",
+			WorkingDirectory: ".",
+			ExternalSecrets: map[string]secrettypes.ExternalSecretRef{
+				"DB_PASSWORD": {LegacyRef: "store/db"}, //nolint:gosec // test data, not real credentials
+			},
+		}
+
+		err := prepareComposeScheduledDeployConfig(context.Background(), cfg, t.TempDir(), t.TempDir(), provider)
+		if !errors.Is(err, providerErr) {
+			t.Fatalf("expected provider error, got %v", err)
+		}
+	})
+
+	t.Run("loads dotenv values for interpolation", func(t *testing.T) {
+		t.Parallel()
+
+		repoPath := t.TempDir()
+		if err := os.WriteFile(filepath.Join(repoPath, ".env"), []byte("BACKUP_BASE_DIR=/backups\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &deploy.Config{
+			Name:             "project-a",
+			WorkingDirectory: ".",
+			EnvFiles:         []string{".env"},
+		}
+
+		if err := prepareComposeScheduledDeployConfig(context.Background(), cfg, repoPath, repoPath, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.Internal.Environment["BACKUP_BASE_DIR"] != "/backups" {
+			t.Fatalf("expected dotenv interpolation env, got %q", cfg.Internal.Environment["BACKUP_BASE_DIR"])
+		}
+	})
+}
+
+func TestLoadComposeScheduledProject_InterpolatesDeployConfigEnvironment(t *testing.T) {
+	dataMountPath := t.TempDir()
+	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
+	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+
+	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
+
+	workingDir := filepath.Join(repoRoot, "stacks", "nas", "adguard-dns")
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatal(err)
 	}
 
-	// Simulate the re-resolution block from loadComposeScheduledProject.
-	refs := map[string]string{
-		"DB_PASSWORD": "store/db-password", //nolint:gosec // test data, not real credentials
-		"API_KEY":     "store/api-key",
-	}
+	composePath := filepath.Join(workingDir, "compose.yml")
+	createComposeFile(t, composePath, `services:
+  backup:
+    image: busybox:latest
+    volumes:
+      - ${BACKUP_BASE_DIR}/adguard-dns:/backup
+`)
 
-	r, err := (*provider).ResolveSecretReferences(context.Background(), refs)
+	createComposeFile(t, filepath.Join(repoRoot, ".doco-cd.yml"), `name: adguard-dns
+reference: refs/heads/main
+working_dir: stacks/nas/adguard-dns
+compose_files:
+  - compose.yml
+environment:
+  BACKUP_BASE_DIR: /backups
+`)
+
+	project, err := loadComposeScheduledProject(context.Background(), nil, composeScheduledServiceRef{
+		Project:        "adguard-dns",
+		Service:        "backup",
+		WorkingDir:     workingDir,
+		ConfigFiles:    []string{composePath},
+		Repository:     "example.com/owner/repo",
+		DeploymentName: "adguard-dns",
+		Reference:      "refs/heads/main",
+	}, nil)
 	if err != nil {
-		t.Fatalf("ResolveSecretReferences: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	maps.Copy(project.Environment, r)
-
-	if project.Environment["DB_PASSWORD"] != "s3cr3t" {
-		t.Errorf("expected DB_PASSWORD=%q, got %q", "s3cr3t", project.Environment["DB_PASSWORD"])
+	svc, err := project.GetService("backup")
+	if err != nil {
+		t.Fatalf("failed to get backup service: %v", err)
 	}
 
-	if project.Environment["API_KEY"] != "abc123" {
-		t.Errorf("expected API_KEY=%q, got %q", "abc123", project.Environment["API_KEY"])
-	}
-}
-
-func TestLoadComposeScheduledProject_SecretResolutionError(t *testing.T) {
-	t.Parallel()
-
-	providerErr := errors.New("provider unavailable")
-	provider := newStubProvider(nil, providerErr)
-
-	refs := map[string]string{"DB_PASSWORD": "store/db"} //nolint:gosec // test data, not real credentials
-
-	_, err := (*provider).ResolveSecretReferences(context.Background(), refs)
-	if !errors.Is(err, providerErr) {
-		t.Fatalf("expected provider error, got %v", err)
-	}
-}
-
-func TestLoadComposeScheduledProject_SkipsResolutionWithoutProvider(t *testing.T) {
-	t.Parallel()
-
-	// No provider (nil) — early return from metadata check is expected here;
-	// if metadata were present and a real docker was available it would skip
-	// the resolution block. We verify the guard condition directly.
-	var sp *secretprovider.SecretProvider
-
-	shouldResolve := sp != nil && *sp != nil
-
-	if shouldResolve {
-		t.Fatal("should not resolve secrets when provider is nil")
-	}
-}
-
-func TestLoadComposeScheduledProject_SkipsResolutionWithoutRefs(t *testing.T) {
-	t.Parallel()
-
-	provider := newStubProvider(map[string]string{"KEY": "val"}, nil)
-
-	// Zero encoded refs — the guard must prevent calling the provider.
-	ref := composeScheduledServiceRef{
-		Project:                "p",
-		Service:                "s",
-		EncodedExternalSecrets: nil,
+	if len(svc.Volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(svc.Volumes))
 	}
 
-	shouldResolve := provider != nil && *provider != nil && len(ref.EncodedExternalSecrets) > 0
-	if shouldResolve {
-		t.Fatal("should not resolve secrets when encoded refs are empty")
+	if svc.Volumes[0].Source != "/backups/adguard-dns" {
+		t.Fatalf("expected interpolated backup source, got %q", svc.Volumes[0].Source)
 	}
 }
 

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -533,6 +533,9 @@ func TestPrepareComposeProjectForOneOffRun(t *testing.T) {
 		t.Parallel()
 
 		project := &types.Project{
+			Name:         "adguard-dns",
+			WorkingDir:   "/repo/stacks/nas/adguard-dns",
+			ComposeFiles: []string{"/repo/stacks/nas/adguard-dns/compose.yml"},
 			Services: types.Services{
 				"backup": {
 					Name:         "backup",
@@ -561,12 +564,36 @@ func TestPrepareComposeProjectForOneOffRun(t *testing.T) {
 				got.Services["backup"].CustomLabels[DocoCDJobLabels.JobEphemeral])
 		}
 
+		if got.Services["backup"].CustomLabels[api.ProjectLabel] != "adguard-dns" {
+			t.Fatalf("expected compose project label, got %q",
+				got.Services["backup"].CustomLabels[api.ProjectLabel])
+		}
+
+		if got.Services["backup"].CustomLabels[api.ServiceLabel] != "backup" {
+			t.Fatalf("expected compose service label, got %q",
+				got.Services["backup"].CustomLabels[api.ServiceLabel])
+		}
+
+		if got.Services["backup"].CustomLabels[api.WorkingDirLabel] != "/repo/stacks/nas/adguard-dns" {
+			t.Fatalf("expected working dir label, got %q",
+				got.Services["backup"].CustomLabels[api.WorkingDirLabel])
+		}
+
+		if got.Services["backup"].CustomLabels[api.ConfigFilesLabel] != "/repo/stacks/nas/adguard-dns/compose.yml" {
+			t.Fatalf("expected config files label, got %q",
+				got.Services["backup"].CustomLabels[api.ConfigFilesLabel])
+		}
+
 		if _, ok := project.Services["backup"].Labels[DocoCDJobLabels.JobEphemeral]; ok {
 			t.Fatal("input project labels were mutated")
 		}
 
 		if _, ok := project.Services["backup"].CustomLabels[DocoCDJobLabels.JobEphemeral]; ok {
 			t.Fatal("input project custom labels were mutated")
+		}
+
+		if _, ok := project.Services["backup"].CustomLabels[api.ProjectLabel]; ok {
+			t.Fatal("input project compose labels were mutated")
 		}
 	})
 

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -533,9 +533,6 @@ func TestPrepareComposeProjectForOneOffRun(t *testing.T) {
 		t.Parallel()
 
 		project := &types.Project{
-			Name:         "adguard-dns",
-			WorkingDir:   "/repo/stacks/nas/adguard-dns",
-			ComposeFiles: []string{"/repo/stacks/nas/adguard-dns/compose.yml"},
 			Services: types.Services{
 				"backup": {
 					Name:         "backup",
@@ -564,36 +561,12 @@ func TestPrepareComposeProjectForOneOffRun(t *testing.T) {
 				got.Services["backup"].CustomLabels[DocoCDJobLabels.JobEphemeral])
 		}
 
-		if got.Services["backup"].CustomLabels[api.ProjectLabel] != "adguard-dns" {
-			t.Fatalf("expected compose project label, got %q",
-				got.Services["backup"].CustomLabels[api.ProjectLabel])
-		}
-
-		if got.Services["backup"].CustomLabels[api.ServiceLabel] != "backup" {
-			t.Fatalf("expected compose service label, got %q",
-				got.Services["backup"].CustomLabels[api.ServiceLabel])
-		}
-
-		if got.Services["backup"].CustomLabels[api.WorkingDirLabel] != "/repo/stacks/nas/adguard-dns" {
-			t.Fatalf("expected working dir label, got %q",
-				got.Services["backup"].CustomLabels[api.WorkingDirLabel])
-		}
-
-		if got.Services["backup"].CustomLabels[api.ConfigFilesLabel] != "/repo/stacks/nas/adguard-dns/compose.yml" {
-			t.Fatalf("expected config files label, got %q",
-				got.Services["backup"].CustomLabels[api.ConfigFilesLabel])
-		}
-
 		if _, ok := project.Services["backup"].Labels[DocoCDJobLabels.JobEphemeral]; ok {
 			t.Fatal("input project labels were mutated")
 		}
 
 		if _, ok := project.Services["backup"].CustomLabels[DocoCDJobLabels.JobEphemeral]; ok {
 			t.Fatal("input project custom labels were mutated")
-		}
-
-		if _, ok := project.Services["backup"].CustomLabels[api.ProjectLabel]; ok {
-			t.Fatal("input project compose labels were mutated")
 		}
 	})
 

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -54,7 +54,8 @@ func TestComposeScheduledServiceRefFromLabels(t *testing.T) {
 			api.ServiceLabel:                     "backup",
 			api.WorkingDirLabel:                  "/repo/stack",
 			api.ConfigFilesLabel:                 "/repo/stack/compose.yaml, /repo/stack/compose.override.yaml",
-			DocoCDLabels.Source.Name:             "example.com/owner/repo",
+			DocoCDLabels.Source.Name:             "owner/repo",
+			DocoCDLabels.Source.URL:              "https://example.com/owner/repo",
 			DocoCDLabels.Deployment.Name:         "stack-a",
 			DocoCDLabels.Deployment.ConfigTarget: "nas",
 			DocoCDLabels.Deployment.TargetRef:    "refs/heads/main",
@@ -75,8 +76,11 @@ func TestComposeScheduledServiceRefFromLabels(t *testing.T) {
 			t.Fatalf("expected 2 config files, got %d (%v)", len(ref.ConfigFiles), ref.ConfigFiles)
 		}
 
-		if ref.Repository != "example.com/owner/repo" {
-			t.Fatalf("unexpected repository: %q", ref.Repository)
+		// RepositoryURL must come from the full source URL label, not the
+		// short "owner/repo" name label, so that git.GetRepoName() can
+		// reconstruct a host-qualified repository path.
+		if ref.RepositoryURL != "https://example.com/owner/repo" {
+			t.Fatalf("unexpected repository url: %q", ref.RepositoryURL)
 		}
 
 		if ref.DeploymentName != "stack-a" {
@@ -89,6 +93,24 @@ func TestComposeScheduledServiceRefFromLabels(t *testing.T) {
 
 		if ref.Reference != "refs/heads/main" {
 			t.Fatalf("unexpected reference: %q", ref.Reference)
+		}
+	})
+
+	t.Run("falls back to source name label when source url label is missing", func(t *testing.T) {
+		t.Parallel()
+
+		ref, err := composeScheduledServiceRefFromLabels(map[string]string{
+			api.ProjectLabel:             "project-a",
+			api.ServiceLabel:             "backup",
+			DocoCDLabels.Source.Name:     "owner/repo",
+			DocoCDLabels.Deployment.Name: "stack-a",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if ref.RepositoryURL != "owner/repo" {
+			t.Fatalf("unexpected repository url: %q", ref.RepositoryURL)
 		}
 	})
 
@@ -344,7 +366,7 @@ environment:
 		Service:        "backup",
 		WorkingDir:     workingDir,
 		ConfigFiles:    []string{composePath},
-		Repository:     "example.com/owner/repo",
+		RepositoryURL:  "https://example.com/owner/repo",
 		DeploymentName: "adguard-dns",
 		Reference:      "refs/heads/main",
 	}, nil)

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -86,33 +86,31 @@ const (
 const jobLabelPrefix = "cd.doco.job."
 
 var docoCDJobLabelNames = struct {
-	JobEnabled            string // Enable scheduling for a service/container
-	JobSchedule           string // Schedule of the job in 5-field cron format or @every duration
-	JobWaitRunning        string // Override if deployment waits for this running job based on wait_running_jobs
-	JobSkipRunning        string // Skip a schedule trigger when a previous run is still in progress
-	JobExecutionMode      string // Defines if a run restarts/reruns the job or starts an ephemeral one-off execution
-	JobEphemeral          string // Marks a runtime-created scheduler one-off target that should be ignored as drift
-	JobNotifyOn           string // Controls notification behavior: none, success, failure, all
-	JobSwarmReplicas      string // Number of replicas for one-off replicated-job runs in swarm mode
-	JobRestartReplicas    string // Intended replica count for swarm restart-mode jobs deployed at 0 replicas
-	JobLastRun            string // Timestamp of the last run in RFC3339 format
-	JobNextRun            string // Timestamp of the next scheduled run in RFC3339 format
-	JobStopServices       string // Comma-separated list of services to stop before the job runs and restart after
-	JobExternalSecretRefs string // JSON-encoded map of provider-ready external secret references (env-var-name → encoded ref)
+	JobEnabled         string // Enable scheduling for a service/container
+	JobSchedule        string // Schedule of the job in 5-field cron format or @every duration
+	JobWaitRunning     string // Override if deployment waits for this running job based on wait_running_jobs
+	JobSkipRunning     string // Skip a schedule trigger when a previous run is still in progress
+	JobExecutionMode   string // Defines if a run restarts/reruns the job or starts an ephemeral one-off execution
+	JobEphemeral       string // Marks a runtime-created scheduler one-off target that should be ignored as drift
+	JobNotifyOn        string // Controls notification behavior: none, success, failure, all
+	JobSwarmReplicas   string // Number of replicas for one-off replicated-job runs in swarm mode
+	JobRestartReplicas string // Intended replica count for swarm restart-mode jobs deployed at 0 replicas
+	JobLastRun         string // Timestamp of the last run in RFC3339 format
+	JobNextRun         string // Timestamp of the next scheduled run in RFC3339 format
+	JobStopServices    string // Comma-separated list of services to stop before the job runs and restart after
 }{
-	JobEnabled:            "cd.doco.job.enabled",
-	JobSchedule:           "cd.doco.job.schedule",
-	JobWaitRunning:        "cd.doco.job.wait_running_jobs",
-	JobSkipRunning:        "cd.doco.job.skip_running",
-	JobExecutionMode:      "cd.doco.job.execution_mode",
-	JobEphemeral:          "cd.doco.job.ephemeral",
-	JobNotifyOn:           "cd.doco.job.notify_on",
-	JobSwarmReplicas:      "cd.doco.job.swarm.replicas",
-	JobRestartReplicas:    "cd.doco.job.swarm.restart_replicas",
-	JobLastRun:            "cd.doco.job.last_run",
-	JobNextRun:            "cd.doco.job.next_run",
-	JobStopServices:       "cd.doco.job.stop_services",
-	JobExternalSecretRefs: "cd.doco.job.external_secret_refs", // #nosec G101
+	JobEnabled:         "cd.doco.job.enabled",
+	JobSchedule:        "cd.doco.job.schedule",
+	JobWaitRunning:     "cd.doco.job.wait_running_jobs",
+	JobSkipRunning:     "cd.doco.job.skip_running",
+	JobExecutionMode:   "cd.doco.job.execution_mode",
+	JobEphemeral:       "cd.doco.job.ephemeral",
+	JobNotifyOn:        "cd.doco.job.notify_on",
+	JobSwarmReplicas:   "cd.doco.job.swarm.replicas",
+	JobRestartReplicas: "cd.doco.job.swarm.restart_replicas",
+	JobLastRun:         "cd.doco.job.last_run",
+	JobNextRun:         "cd.doco.job.next_run",
+	JobStopServices:    "cd.doco.job.stop_services",
 }
 
 // DocoCDJobLabels exposes the scheduler/job labels for consumers outside this package.

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1447,16 +1447,14 @@ func isEphemeralScheduledContainer(labels map[string]string) bool {
 	}
 
 	raw, ok := labels[docker.DocoCDJobLabels.JobEphemeral]
-	if !ok {
-		return false
+	if ok {
+		isEphemeral, err := strconv.ParseBool(strings.TrimSpace(raw))
+		if err == nil && isEphemeral {
+			return true
+		}
 	}
 
-	isEphemeral, err := strconv.ParseBool(strings.TrimSpace(raw))
-	if err != nil {
-		return false
-	}
-
-	return isEphemeral
+	return strings.EqualFold(strings.TrimSpace(labels[api.OneoffLabel]), "true")
 }
 
 // containerJobKey derives the stable scheduler key for a container from its

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -423,6 +423,13 @@ func TestIsEphemeralScheduledContainer(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "compose one-off label true",
+			labels: map[string]string{
+				api.OneoffLabel: "True",
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Reload the deploy config for scheduled Compose jobs and rebuild the `LoadCompose()` interpolation environment from `env_files`, deploy-config `environment`, and resolved external secrets at run time.

This fixes regressions like `${EXAMPLE_VAR}` resolving empty in scheduled backup jobs after v0.107.0, without storing deploy-config interpolation values in container labels.

Also adds compose labels to one-off job containers