### PR TITLE
fix(api): add external secrets resolution to scheduled job execution

### DIFF
--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -252,7 +252,7 @@ func (h *handlerData) TriggerScheduledJobHandler(w http.ResponseWriter, r *http.
 	triggerFn := func(ctx context.Context) error {
 		jobLog.Info("scheduled job run triggered via API", slog.String("job", jobName), slog.String("stack", stackName))
 
-		runID, err := scheduler.TriggerNow(ctx, h.dockerCli, h.log.Logger, jobName, stackName)
+		runID, err := scheduler.TriggerNow(ctx, h.dockerCli, h.log.Logger, jobName, stackName, h.secretProvider)
 
 		runLog := jobLog
 		if runID != "" {

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -388,6 +388,75 @@ environment:
 	}
 }
 
+// TestLoadComposeScheduledProject_ResolvesExternalSecrets is a regression test
+// for https://github.com/kimdre/doco-cd/issues/1674: external secrets must be
+// re-resolved and interpolated into the compose service environment when a
+// standard (single-repository, non `repository_url`) scheduled job reloads
+// its deploy config at run time.
+func TestLoadComposeScheduledProject_ResolvesExternalSecrets(t *testing.T) {
+	dataMountPath := t.TempDir()
+	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
+	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+
+	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
+
+	workingDir := filepath.Join(repoRoot, "stacks", "nas", "backup")
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	composePath := filepath.Join(workingDir, "compose.yml")
+	createComposeFile(t, composePath, `services:
+  backup:
+    image: busybox:latest
+    environment:
+      MY_SECRET: ${MY_SECRET}
+`)
+
+	createComposeFile(t, filepath.Join(repoRoot, ".doco-cd.yml"), `name: backup-job
+reference: refs/heads/main
+working_dir: stacks/nas/backup
+compose_files:
+  - compose.yml
+external_secrets:
+  MY_SECRET:
+    store_ref: bitwarden-login
+    remote_ref:
+      key: my-bitwarden-item-id
+      property: password
+`)
+
+	project, err := loadComposeScheduledProject(context.Background(), nil, composeScheduledServiceRef{
+		Project:        "backup-job",
+		Service:        "backup",
+		WorkingDir:     workingDir,
+		ConfigFiles:    []string{composePath},
+		RepositoryURL:  "https://example.com/owner/repo",
+		DeploymentName: "backup-job",
+		Reference:      "refs/heads/main",
+	}, newStubProvider(map[string]string{"MY_SECRET": "resolved-secret"}, nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	svc, err := project.GetService("backup")
+	if err != nil {
+		t.Fatalf("failed to get backup service: %v", err)
+	}
+
+	if svc.Environment == nil || svc.Environment["MY_SECRET"] == nil {
+		t.Fatal("expected MY_SECRET to be present in service environment")
+	}
+
+	if *svc.Environment["MY_SECRET"] != "resolved-secret" {
+		t.Fatalf("expected MY_SECRET to be resolved from external secret provider, got %q", *svc.Environment["MY_SECRET"])
+	}
+}
+
 func TestValidateComposeScheduledServiceScale(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -254,7 +254,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 
 // TriggerNow executes one configured scheduled job immediately.
 // Job selection matches by container/service name and optional stack name.
-func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jobName, stackName string) (string, error) {
+func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jobName, stackName string, secretProvider *secretprovider.SecretProvider) (string, error) {
 	if dockerCli == nil {
 		return "", errors.New("docker cli is required")
 	}
@@ -268,10 +268,11 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 	}
 
 	s := &scheduler{
-		dockerCli: dockerCli,
-		log:       log.With(slog.String("component", "scheduler")),
-		running:   map[string]bool{},
-		stopHolds: map[stopHoldKey]*stopHoldState{},
+		dockerCli:      dockerCli,
+		log:            log.With(slog.String("component", "scheduler")),
+		running:        map[string]bool{},
+		stopHolds:      map[stopHoldKey]*stopHoldState{},
+		secretProvider: secretProvider,
 	}
 
 	jobs, err := s.discoverJobs(ctx)


### PR DESCRIPTION
`scheduler.TriggerNow()` (used by the `/v1/api/job/{jobName}/run` manual-trigger endpoint) never received the `secretProvider`, so API-triggered "run now" executions silently skip external secret resolution. 

Fixed by threading `secretProvider` through `TriggerNow` and `handler_api.go`. 