### PR TITLE
feat(notification): report image digest drifted services in ChangedServices

### DIFF
--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -528,15 +529,15 @@ var (
 	registryDigestDistributionLookup = registryDigestForRefViaDistributionInspect
 )
 
-// HaveDeployedServiceImageDigestsChanged checks if any currently deployed
-// service image digest differs from the registry digest of the configured image ref.
+// DeployedServicesWithChangedImageDigests returns the sorted names of deployed
+// services whose image digest differs from the registry digest of the configured image ref.
 //
 // This compares:
 //  1. deployed service image digest (currently running/deployed)
 //  2. registry digest of configured service image reference (DistributionInspect)
 //
-// Returns true as soon as one service differs.
-func HaveDeployedServiceImageDigestsChanged(ctx context.Context, dockerCli command.Cli, swarmMode bool, project *types.Project, logger *slog.Logger) (bool, error) {
+// A service without a deployed digest is treated as changed.
+func DeployedServicesWithChangedImageDigests(ctx context.Context, dockerCli command.Cli, swarmMode bool, project *types.Project, logger *slog.Logger) ([]string, error) {
 	// service name -> configured image ref
 	configuredRefs := make(map[string]string)
 	uniqueRefs := set.New[string]()
@@ -552,7 +553,7 @@ func HaveDeployedServiceImageDigestsChanged(ctx context.Context, dockerCli comma
 	}
 
 	if len(configuredRefs) == 0 {
-		return false, nil
+		return nil, nil
 	}
 
 	registryDigests := make(map[string]string, uniqueRefs.Len())
@@ -568,8 +569,10 @@ func HaveDeployedServiceImageDigestsChanged(ctx context.Context, dockerCli comma
 
 	deployedDigests, err := deployedServiceDigestLookup(ctx, dockerCli, swarmMode, project.Name, logger)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
+
+	var changedServices []string
 
 	for serviceName, configuredRef := range configuredRefs {
 		registryDigest, ok := registryDigests[configuredRef]
@@ -581,7 +584,10 @@ func HaveDeployedServiceImageDigestsChanged(ctx context.Context, dockerCli comma
 		deployedDigest, ok := deployedDigests[serviceName]
 		if !ok {
 			logger.Debug("deployed service image digest unavailable, treating as changed", slog.String("service", serviceName), slog.String("ref", configuredRef))
-			return true, nil
+
+			changedServices = append(changedServices, serviceName)
+
+			continue
 		}
 
 		if deployedDigest != registryDigest {
@@ -596,9 +602,11 @@ func HaveDeployedServiceImageDigestsChanged(ctx context.Context, dockerCli comma
 				),
 			)
 
-			return true, nil
+			changedServices = append(changedServices, serviceName)
 		}
 	}
 
-	return false, nil
+	slices.Sort(changedServices)
+
+	return changedServices, nil
 }

--- a/internal/docker/images_test.go
+++ b/internal/docker/images_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -141,7 +142,7 @@ func TestRegistryManifestURL(t *testing.T) {
 	}
 }
 
-func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
+func TestDeployedServicesWithChangedImageDigests(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	expectedLookupErr := errors.New("deployed lookup failed")
@@ -160,7 +161,7 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 		registryDigest       string
 		deployedDigests      map[string]string
 		deployedLookupErr    error
-		wantChanged          bool
+		wantChanged          []string
 		wantErr              error
 		wantRegistryCalls    int
 		wantRegistryCallRefs []string
@@ -173,7 +174,7 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 					"web": {Name: "web"},
 				},
 			},
-			wantChanged:       false,
+			wantChanged:       nil,
 			wantRegistryCalls: 0,
 		},
 		{
@@ -187,12 +188,12 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 			},
 			registryDigest:       "sha256:same",
 			deployedDigests:      map[string]string{"web": "sha256:same"},
-			wantChanged:          false,
+			wantChanged:          nil,
 			wantRegistryCalls:    1,
 			wantRegistryCallRefs: []string{"nginx:latest"},
 		},
 		{
-			name: "returns true when deployed digest missing",
+			name: "returns service when deployed digest missing",
 			project: &types.Project{
 				Name: "test",
 				Services: types.Services{
@@ -201,12 +202,12 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 			},
 			registryDigest:       "sha256:new",
 			deployedDigests:      map[string]string{},
-			wantChanged:          true,
+			wantChanged:          []string{"web"},
 			wantRegistryCalls:    1,
 			wantRegistryCallRefs: []string{"nginx:latest"},
 		},
 		{
-			name: "returns true on digest mismatch",
+			name: "returns service on digest mismatch",
 			project: &types.Project{
 				Name: "test",
 				Services: types.Services{
@@ -215,12 +216,12 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 			},
 			registryDigest:       "sha256:new",
 			deployedDigests:      map[string]string{"web": "sha256:old"},
-			wantChanged:          true,
+			wantChanged:          []string{"web"},
 			wantRegistryCalls:    1,
 			wantRegistryCallRefs: []string{"nginx:latest"},
 		},
 		{
-			name: "returns false when digests match",
+			name: "returns nothing when digests match",
 			project: &types.Project{
 				Name: "test",
 				Services: types.Services{
@@ -229,7 +230,7 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 			},
 			registryDigest:       "sha256:same",
 			deployedDigests:      map[string]string{"web": "sha256:same"},
-			wantChanged:          false,
+			wantChanged:          nil,
 			wantRegistryCalls:    1,
 			wantRegistryCallRefs: []string{"nginx:latest"},
 		},
@@ -258,9 +259,25 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 			},
 			registryDigest:       "sha256:same",
 			deployedDigests:      map[string]string{"web": "sha256:same", "worker": "sha256:same"},
-			wantChanged:          false,
+			wantChanged:          nil,
 			wantRegistryCalls:    1,
 			wantRegistryCallRefs: []string{"nginx:latest"},
+		},
+		{
+			name: "collects all changed services sorted",
+			project: &types.Project{
+				Name: "test",
+				Services: types.Services{
+					"web":    {Name: "web", Image: "nginx:latest"},
+					"worker": {Name: "worker", Image: "nginx:latest"},
+					"db":     {Name: "db", Image: "postgres:latest"},
+				},
+			},
+			registryDigest:       "sha256:new",
+			deployedDigests:      map[string]string{"web": "sha256:old", "worker": "sha256:old", "db": "sha256:new"},
+			wantChanged:          []string{"web", "worker"},
+			wantRegistryCalls:    2,
+			wantRegistryCallRefs: nil, // map iteration order is random, only the count is stable
 		},
 	}
 
@@ -279,12 +296,12 @@ func TestHaveDeployedServiceImageDigestsChanged(t *testing.T) {
 				return tc.deployedDigests, nil
 			}
 
-			changed, err := HaveDeployedServiceImageDigestsChanged(ctx, nil, false, tc.project, logger)
+			changed, err := DeployedServicesWithChangedImageDigests(ctx, nil, false, tc.project, logger)
 			if !errors.Is(err, tc.wantErr) {
 				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
 			}
 
-			if changed != tc.wantChanged {
+			if !slices.Equal(changed, tc.wantChanged) {
 				t.Fatalf("changed = %v, want %v", changed, tc.wantChanged)
 			}
 

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -90,7 +90,7 @@ type Metadata struct {
 	AffectedActorName   string
 	Commits             []git.CommitInfo // commits deployed since the last deploy; empty on first deploy/failure/OCI
 	Duration            time.Duration    // time from job start to the notification; zero when no deploy/destroy ran
-	ChangedServices     []string         // services force-recreated by this deploy; empty when the whole stack is (re)deployed
+	ChangedServices     []string         // services force-recreated by this deploy or with image digest drift; empty when the whole stack is (re)deployed
 }
 
 // TemplateData is the data exposed to a user-configured notification body template.

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -114,7 +114,8 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 
 	// Check for external secret changes and current deployed commit
 	var (
-		imagesChanged bool // Flag to indicate if images have changed
+		imagesChanged        bool     // Flag to indicate if images have changed
+		imageChangedServices []string // Services whose deployed image digest drifted from the registry
 	)
 
 	// Compare external secrets if a secret provider is configured
@@ -245,13 +246,16 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 		} else if s.DeployConfig.ForceImagePull {
 			stageLog.Debug("force image pull enabled, checking deployed image digests against registry")
 
-			imagesChanged, err = docker.HaveDeployedServiceImageDigestsChanged(ctx, s.Docker.Cmd, s.Docker.SwarmMode, s.Docker.Project, stageLog)
+			imageChangedServices, err = docker.DeployedServicesWithChangedImageDigests(ctx, s.Docker.Cmd, s.Docker.SwarmMode, s.Docker.Project, stageLog)
 			if err != nil {
 				return fmt.Errorf("failed to compare deployed service image digests: %w", err)
 			}
 
+			imagesChanged = len(imageChangedServices) > 0
+
 			if imagesChanged {
-				stageLog.Debug("deployed image digests differ from registry, proceeding with deployment")
+				stageLog.Debug("deployed image digests differ from registry, proceeding with deployment",
+					slog.Any("services", imageChangedServices))
 			} else {
 				stageLog.Debug("deployed image digests match registry")
 			}
@@ -322,6 +326,7 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 		}
 
 		s.DeployState.changedServices = changedServices
+		s.DeployState.imageChangedServices = imageChangedServices
 		s.DeployState.ignoredInfo = ignoredInfo
 
 		stageLog.Debug("changes detected, proceeding with deployment",

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -135,12 +135,13 @@ type Docker struct {
 
 // DeploymentState holds the dynamic state information during the deployment process.
 type DeploymentState struct {
-	changedServices []docker.Change
-	ignoredInfo     docker.IgnoredInfo
-	DeployedCommit  string // previously-deployed commit SHA, carried to post-deploy for the changelog
+	changedServices      []docker.Change
+	imageChangedServices []string // services whose deployed image digest drifted from the registry (force_image_pull)
+	ignoredInfo          docker.IgnoredInfo
+	DeployedCommit       string // previously-deployed commit SHA, carried to post-deploy for the changelog
 }
 
-// changedServiceNames flattens the detected changes into a unique list of service names.
+// changedServiceNames flattens the detected changes and image digest drifts into a unique list of service names.
 func (d *DeploymentState) changedServiceNames() []string {
 	if d == nil {
 		return nil
@@ -150,6 +151,8 @@ func (d *DeploymentState) changedServiceNames() []string {
 	for _, change := range d.changedServices {
 		names = append(names, change.Services...)
 	}
+
+	names = append(names, d.imageChangedServices...)
 
 	names = slice.Unique(names)
 	slices.Sort(names)

--- a/internal/stages/types_test.go
+++ b/internal/stages/types_test.go
@@ -40,4 +40,31 @@ func TestChangedServiceNames(t *testing.T) {
 			t.Errorf("expected %v, got %v", expected, got)
 		}
 	})
+
+	t.Run("merges image digest drift services", func(t *testing.T) {
+		t.Parallel()
+
+		d := &DeploymentState{
+			changedServices: []docker.Change{
+				{Type: "mounts", Services: []string{"worker", "web"}},
+			},
+			imageChangedServices: []string{"web", "app"},
+		}
+
+		expected := []string{"app", "web", "worker"}
+		if got := d.changedServiceNames(); !slices.Equal(got, expected) {
+			t.Errorf("expected %v, got %v", expected, got)
+		}
+	})
+
+	t.Run("image digest drift services alone", func(t *testing.T) {
+		t.Parallel()
+
+		d := &DeploymentState{imageChangedServices: []string{"app"}}
+
+		expected := []string{"app"}
+		if got := d.changedServiceNames(); !slices.Equal(got, expected) {
+			t.Errorf("expected %v, got %v", expected, got)
+		}
+	})
 }

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -102,7 +102,7 @@ The following fields are available:
 | `.AffectedActorName`  | Affected container/service name                                          |
 | `.Commits`            | Commits deployed since the last deploy (see [Commit changelog](#commit-changelog)) |
 | `.Duration`           | Time the deployment (or destroy) took, from job start to the notification, e.g. `12.483s`. Zero where no deployment ran (reconciliation restarts, scheduled jobs) — hide it with `{{if .Duration}}...{{end}}` |
-| `.ChangedServices`    | Sorted names of the services force-recreated by this deploy (changed mounted/referenced files or a changed auto-discovery label). Empty when the whole stack is (re)deployed for other reasons, e.g. a compose config change, an image update, state drift or `force_recreate` |
+| `.ChangedServices`    | Sorted names of the services changed by this deploy: force-recreated ones (changed mounted/referenced files or a changed auto-discovery label) plus services whose image digest changed in the registry (detected with [`force_image_pull`](../Deploy-Settings.md)). Empty when the whole stack is (re)deployed for other reasons, e.g. a compose config change (including image tag changes in the compose file), state drift or `force_recreate` |
 
 `{{ .DefaultBody }}` renders the built-in body (message + metadata), so you can extend the default format instead of replacing it, e.g. `{{ .DefaultBody }}\nhost: my-vm`.
 


### PR DESCRIPTION
Implements option 2 from #1689.

`HaveDeployedServiceImageDigestsChanged` already knew which services drifted, but returned only bool and exited on first hit. Renamed it to `DeployedServicesWithChangedImageDigests`: now it checks all services and returns sorted service names, so the log also shows every drifted service, not just the first one. The names get merged into notification metadata through `changedServiceNames()`, so `.ChangedServices` is populated on plain image bumps detected with `force_image_pull`.

Deploy behavior is not touched: the names go to notification only and don't enter `DeployState.changedServices`, so nothing gets flipped to force recreate. Recreate decision stays with compose as before.

Scope note: this covers digest drift from `force_image_pull`. Image tag change in the compose file itself still goes through the whole-project hash and stays unattributed — that was option 1, dropped for cleanliness.

Also updated the `.ChangedServices` wiki row and the `Metadata` doc comment.
