### PR TITLE
fix(compose): fail start wait on crashlooping services

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -1858,7 +1858,9 @@ func assessStartedServiceStates(containers []api.ContainerSummary, targetService
 			case "unhealthy":
 				status.unhealthy = true
 			}
-		case "exited", "dead":
+		// "restarting" exists only after a container died and restart policy
+		// kicked in - right after deploy that is a crash, not a slow start
+		case "restarting", "exited", "dead":
 			status.terminal = state
 		}
 
@@ -1885,7 +1887,28 @@ func assessStartedServiceStates(containers []api.ContainerSummary, targetService
 	return len(waiting) == 0, waiting, nil
 }
 
+// startReadyStableSamples is how many consecutive ready samples (1s apart)
+// services must hold before start counts as successful. A service that
+// crashes moments after start spends most of each crash cycle in a short
+// "running" window - one lucky sample used to mark the deploy successful,
+// and every following poll redeployed the crashed container as drift.
+const startReadyStableSamples = 3
+
+// projectContainerLister abstracts container listing so the wait loop can be
+// tested without a Docker daemon.
+type projectContainerLister func(ctx context.Context) ([]api.ContainerSummary, error)
+
 func waitForStartedServices(ctx context.Context, dockerCli command.Cli, projectName string,
+	startServices []string, jobServices set.Set[string], timeout time.Duration,
+) error {
+	listContainers := func(ctx context.Context) ([]api.ContainerSummary, error) {
+		return GetProjectContainers(ctx, dockerCli, projectName)
+	}
+
+	return waitForStartedServicesWith(ctx, listContainers, startServices, jobServices, timeout)
+}
+
+func waitForStartedServicesWith(ctx context.Context, listContainers projectContainerLister,
 	startServices []string, jobServices set.Set[string], timeout time.Duration,
 ) error {
 	nonJobServices := getNonJobServices(startServices, jobServices)
@@ -1902,8 +1925,10 @@ func waitForStartedServices(ctx context.Context, dockerCli command.Cli, projectN
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
+	readyStreak := 0
+
 	for {
-		containers, err := GetProjectContainers(ctx, dockerCli, projectName)
+		containers, err := listContainers(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to inspect project containers: %w", err)
 		}
@@ -1914,11 +1939,16 @@ func waitForStartedServices(ctx context.Context, dockerCli command.Cli, projectN
 		}
 
 		if ready {
-			return nil
-		}
+			readyStreak++
+			if readyStreak >= startReadyStableSamples {
+				return nil
+			}
+		} else {
+			readyStreak = 0
 
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out after %s waiting for services to start: %s", timeout, strings.Join(waiting, ", "))
+			if time.Now().After(deadline) {
+				return fmt.Errorf("timed out after %s waiting for services to start: %s", timeout, strings.Join(waiting, ", "))
+			}
 		}
 
 		select {

--- a/internal/docker/compose_start_services_test.go
+++ b/internal/docker/compose_start_services_test.go
@@ -1,7 +1,9 @@
 package docker
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/compose/v5/pkg/api"
@@ -330,5 +332,108 @@ func TestAssessStartedServiceStates_FailsWhenNonJobExited(t *testing.T) {
 	_, _, err := assessStartedServiceStates(containers, set.New[string]("api"))
 	if err == nil {
 		t.Fatalf("expected error when target service has an exited container")
+	}
+}
+
+func TestAssessStartedServiceStates_FailsWhenRestarting(t *testing.T) {
+	t.Parallel()
+
+	containers := []api.ContainerSummary{
+		{
+			State: "restarting",
+			Labels: map[string]string{
+				api.ServiceLabel: "api",
+			},
+		},
+	}
+
+	_, _, err := assessStartedServiceStates(containers, set.New[string]("api"))
+	if err == nil {
+		t.Fatalf("expected error when target service has a restarting container")
+	}
+}
+
+// scriptedLister returns one containers sample per call, holding the last
+// sample once the script is exhausted.
+func scriptedLister(t *testing.T, samples [][]api.ContainerSummary, calls *int) projectContainerLister {
+	t.Helper()
+
+	return func(_ context.Context) ([]api.ContainerSummary, error) {
+		i := *calls
+		if i >= len(samples) {
+			i = len(samples) - 1
+		}
+
+		*calls++
+
+		return samples[i], nil
+	}
+}
+
+func runningContainer(service string) api.ContainerSummary {
+	return api.ContainerSummary{
+		State: "running",
+		Labels: map[string]string{
+			api.ServiceLabel: service,
+		},
+	}
+}
+
+func TestWaitForStartedServices_FailsOnCrashLoop(t *testing.T) {
+	t.Parallel()
+
+	// crash-right-after-start: first sample catches the brief "running"
+	// window, the next one sees the restart-policy backoff
+	calls := 0
+	lister := scriptedLister(t, [][]api.ContainerSummary{
+		{runningContainer("api")},
+		{{State: "restarting", Labels: map[string]string{api.ServiceLabel: "api"}}},
+	}, &calls)
+
+	err := waitForStartedServicesWith(t.Context(), lister, []string{"api"}, set.New[string](), 30*time.Second)
+	if err == nil {
+		t.Fatalf("expected crashlooping service to fail the start wait")
+	}
+}
+
+func TestWaitForStartedServices_RequiresStableReadiness(t *testing.T) {
+	t.Parallel()
+
+	// a not-yet-running sample resets the streak: success must take the
+	// full startReadyStableSamples consecutive ready samples after the dip
+	calls := 0
+	lister := scriptedLister(t, [][]api.ContainerSummary{
+		{runningContainer("api")},
+		{{State: "created", Labels: map[string]string{api.ServiceLabel: "api"}}},
+		{runningContainer("api")},
+		{runningContainer("api")},
+		{runningContainer("api")},
+	}, &calls)
+
+	err := waitForStartedServicesWith(t.Context(), lister, []string{"api"}, set.New[string](), 30*time.Second)
+	if err != nil {
+		t.Fatalf("waitForStartedServicesWith() returned unexpected error: %v", err)
+	}
+
+	if calls != 5 {
+		t.Fatalf("expected success on the 5th sample (streak reset by the dip), got %d calls", calls)
+	}
+}
+
+func TestWaitForStartedServices_SucceedsAfterStableSamples(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	lister := scriptedLister(t, [][]api.ContainerSummary{
+		{runningContainer("api")},
+	}, &calls)
+
+	err := waitForStartedServicesWith(t.Context(), lister, []string{"api"}, set.New[string](), 30*time.Second)
+	if err != nil {
+		t.Fatalf("waitForStartedServicesWith() returned unexpected error: %v", err)
+	}
+
+	if calls != startReadyStableSamples {
+		t.Fatalf("expected exactly %d samples before success, got %d", startReadyStableSamples, calls)
 	}
 }


### PR DESCRIPTION
Found this live on v0.108.0. Service that crashes right after start (misconfigured env, bot without required secret) was marked as successful deployment, then next poll saw the dead container as drift and redeployed - endless loop, success notification to telegram every ~30s.

Root cause in `waitForStartedServices`: it returns success on first sample where all services are `running`. Crashlooping container spends most of each cycle in a short running window, so one lucky 1s-tick sample wins. And `restarting` state is not handled at all in `assessStartedServiceStates` - service just stays in waiting list instead of failing.

Fix, two parts:
- `restarting` is terminal now: it only exists after container already died and restart policy kicked in, so right after deploy it always means crash-on-start
- readiness must hold 3 consecutive samples before success, so the short running window doesnt win the race. Costs 2 extra seconds per deploy, nothing else changes

Added a lister seam (`waitForStartedServicesWith`) so wait loop is unit-testable without docker daemon. Tests cover crashloop failure, streak reset on a dip, and stable success taking exactly 3 samples.