### PR TITLE
fix(notification): stop repeating and duplicating failure notifications

### DIFF
--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -342,7 +342,7 @@ func (h *handlerData) HealthCheckHandler(w http.ResponseWriter, _ *http.Request)
 
 	err, errType = docker.VerifyDockerAPIAccess()
 	if err != nil {
-		onError(w, h.log.With(logger.ErrAttr(err)), errType.Error(), err.Error(), http.StatusServiceUnavailable, metadata)
+		onError(w, h.log.With(logger.ErrAttr(err)), errType.Error(), err.Error(), http.StatusServiceUnavailable, metadata, err)
 
 		return
 	}

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -138,6 +138,12 @@ func pollError(jobLog *slog.Logger, metadata notification.Metadata, err error) {
 		jobLog.Error("error during poll job", log.ErrAttr(err))
 	}
 
+	// The stack that failed already sent its own notification with the same
+	// error text, so a job-level one only says it twice.
+	if notification.WasNotified(err) {
+		return
+	}
+
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -236,7 +236,10 @@ type handlerData struct {
 }
 
 // onError handles errors by logging them, sending a JSON error response, and sending a notification.
-func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any, statusCode int, metadata notification.Metadata) {
+// cause is the error behind the response: when a failure notification was already
+// sent for it deeper down, the HTTP response and the log stay the same and only
+// the second notification is dropped.
+func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any, statusCode int, metadata notification.Metadata, cause error) {
 	prometheus.WebhookErrorsTotal.WithLabelValues(metadata.Repository).Inc()
 	log.Error(errMsg)
 	JSONError(w,
@@ -251,6 +254,10 @@ func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any
 
 	if details != "" {
 		errMsg = fmt.Sprintf("%s\n%s", errMsg, details)
+	}
+
+	if notification.WasNotified(cause) {
+		return
 	}
 
 	go func() {
@@ -346,7 +353,7 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	if sourceType == config.SourceTypeGit && shouldUsePayloadSSHURL(cloneURLOverrideApplied, payload.SSHUrl, resolvedSSH) {
 		sshAuth, authErr := git.GetAuthMethod(payload.SSHUrl, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken)
 		if authErr != nil {
-			onError(w, jobLog.With(logger.ErrAttr(authErr)), "failed to resolve SSH auth method", authErr.Error(), http.StatusInternalServerError, metadata)
+			onError(w, jobLog.With(logger.ErrAttr(authErr)), "failed to resolve SSH auth method", authErr.Error(), http.StatusInternalServerError, metadata, authErr)
 
 			if runTracker != nil {
 				runTracker.MarkFailed(metadata.JobID, "failed to resolve SSH auth method: "+authErr.Error())
@@ -369,13 +376,13 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 		// In synchronous mode we should return an error to the caller
 		// For async mode, w is noopResponseWriter and JSONError is a no-op
 		if hr, ok := deployErr.(handleError); ok {
-			onError(w, jobLog.With(logger.ErrAttr(hr.err)), hr.msg, hr.err.Error(), hr.httpStatusCode, metadata)
+			onError(w, jobLog.With(logger.ErrAttr(hr.err)), hr.msg, hr.err.Error(), hr.httpStatusCode, metadata, hr.err)
 
 			if runTracker != nil {
 				runTracker.MarkFailed(metadata.JobID, hr.Error())
 			}
 		} else {
-			onError(w, jobLog.With(logger.ErrAttr(deployErr)), "deployment failed", deployErr.Error(), http.StatusInternalServerError, metadata)
+			onError(w, jobLog.With(logger.ErrAttr(deployErr)), "deployment failed", deployErr.Error(), http.StatusInternalServerError, metadata, deployErr)
 
 			if runTracker != nil {
 				runTracker.MarkFailed(metadata.JobID, deployErr.Error())
@@ -475,7 +482,7 @@ func (h *handlerData) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		onError(w, jobLog.With(slog.String("ip", h.requestIP(r)), logger.ErrAttr(err)), errMsg, err.Error(), statusCode, metadata)
+		onError(w, jobLog.With(slog.String("ip", h.requestIP(r)), logger.ErrAttr(err)), errMsg, err.Error(), statusCode, metadata, err)
 
 		if h.runTracker != nil {
 			h.runTracker.MarkFailed(jobID, errMsg+": "+err.Error())

--- a/internal/config/app/app_config.go
+++ b/internal/config/app/app_config.go
@@ -82,6 +82,7 @@ type Config struct {
 	AppriseNotifyUrls             string                 `env:"APPRISE_NOTIFY_URLS"`                                                                             // AppriseNotifyUrls is a comma-separated list of URLs to notify via the Apprise notification service
 	AppriseNotifyUrlsFile         string                 `env:"APPRISE_NOTIFY_URLS_FILE,file"`                                                                   // AppriseNotifyUrlsFile is the file containing the AppriseNotifyUrls
 	AppriseNotifyLevel            string                 `env:"APPRISE_NOTIFY_LEVEL,notEmpty" envDefault:"success"`                                              // AppriseNotifyLevel is the level of notifications to send via the Apprise notification service
+	AppriseNotifyRepeatInterval   time.Duration          `env:"APPRISE_NOTIFY_REPEAT_INTERVAL,notEmpty" envDefault:"1h"`                                         // AppriseNotifyRepeatInterval is how long an unchanged failure notification is suppressed before it is sent again as a reminder. Zero or less sends every failure.
 	AppriseNotifyBodyTemplate     string                 `env:"APPRISE_NOTIFY_BODY_TEMPLATE"`                                                                    // AppriseNotifyBodyTemplate is an optional Go text/template rendering the notification body. Empty uses the built-in format.
 	AppriseNotifyBodyTemplateFile string                 `env:"APPRISE_NOTIFY_BODY_TEMPLATE_FILE,file"`                                                          // AppriseNotifyBodyTemplateFile is the file containing the AppriseNotifyBodyTemplate
 	SecretProvider                string                 `env:"SECRET_PROVIDER"`                                                                                 // SecretProvider is the secret provider/manager to use for retrieving secrets (e.g. bitwarden secrets manager)
@@ -208,6 +209,8 @@ func GetConfig() (*Config, error) {
 			return nil, fmt.Errorf("DATA_HOST_PATH must be an absolute Unix path: %q", cfg.DataHostPath)
 		}
 	}
+
+	notification.SetFailureRepeatInterval(cfg.AppriseNotifyRepeatInterval)
 
 	err = notification.SetAppriseConfig(
 		string(cfg.AppriseApiURL),

--- a/internal/notification/failure_repeat.go
+++ b/internal/notification/failure_repeat.go
@@ -41,6 +41,10 @@ func SetFailureRepeatInterval(interval time.Duration) {
 	defer failureMu.Unlock()
 
 	failureRepeatInterval = interval
+
+	if interval <= 0 {
+		lastFailures = map[string]failureRecord{}
+	}
 }
 
 // failureKey identifies the thing that failed. The stack is what an operator
@@ -70,6 +74,8 @@ func shouldSendFailure(key, fingerprint string, now time.Time) bool {
 		return true
 	}
 
+	pruneFailures(now)
+
 	last, found := lastFailures[key]
 	if found && last.fingerprint == fingerprint && now.Sub(last.sentAt) < failureRepeatInterval {
 		return false
@@ -78,6 +84,18 @@ func shouldSendFailure(key, fingerprint string, now time.Time) bool {
 	lastFailures[key] = failureRecord{fingerprint: fingerprint, sentAt: now}
 
 	return true
+}
+
+// pruneFailures drops records that cannot suppress anything anymore. Past the
+// repeat interval the next failure is sent whatever the record says, so keeping
+// it only grows the map for stacks that are renamed, removed or fixed without a
+// success notification. Caller holds failureMu.
+func pruneFailures(now time.Time) {
+	for key, record := range lastFailures {
+		if now.Sub(record.sentAt) >= failureRepeatInterval {
+			delete(lastFailures, key)
+		}
+	}
 }
 
 // clearFailure forgets the last failure of a stack, so the next one is sent

--- a/internal/notification/failure_repeat.go
+++ b/internal/notification/failure_repeat.go
@@ -1,0 +1,90 @@
+package notification
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"time"
+)
+
+// A failure notification repeats as often as the trigger does. A poll job runs
+// every interval and a broken deployment fails identically every run, so a
+// single fault turns into a stream of identical messages until someone fixes it
+// - an expired registry token produced around 240 of them in two hours. Track
+// the last failure per stack, stay quiet while it is unchanged, and remind once
+// per failureRepeatInterval so a long outage is not forgotten instead. A
+// successful notification for the same stack clears the entry, which makes the
+// existing "Deployment completed" notification the recovery signal.
+
+// DefaultFailureRepeatInterval is how long an unchanged failure stays quiet
+// before it is sent again as a reminder.
+const DefaultFailureRepeatInterval = time.Hour
+
+var (
+	failureMu             sync.Mutex
+	lastFailures          = map[string]failureRecord{}
+	failureRepeatInterval = DefaultFailureRepeatInterval
+)
+
+// failureRecord is the last failure notification sent for one stack.
+type failureRecord struct {
+	fingerprint string
+	sentAt      time.Time
+}
+
+// SetFailureRepeatInterval sets how long an unchanged failure is suppressed.
+// Zero or less turns suppression off entirely: every failure is sent, as it was
+// before this existed.
+func SetFailureRepeatInterval(interval time.Duration) {
+	failureMu.Lock()
+	defer failureMu.Unlock()
+
+	failureRepeatInterval = interval
+}
+
+// failureKey identifies the thing that failed. The stack is what an operator
+// acts on, and the rest keeps two stacks of the same name apart when one daemon
+// serves several repositories, targets or docker contexts.
+func failureKey(m Metadata) string {
+	return strings.Join([]string{m.Repository, m.Target, m.Stack, m.Context}, "|")
+}
+
+// failureFingerprint identifies the fault itself. Title and message only: job
+// id, duration and revision differ on every attempt, so including them would
+// make every repeat look new.
+func failureFingerprint(title, message string) string {
+	sum := sha256.Sum256([]byte(title + "\n" + message))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// shouldSendFailure reports whether this failure is worth sending: it is new,
+// it differs from the last one for the same stack, or the reminder interval has
+// passed. It records what it lets through.
+func shouldSendFailure(key, fingerprint string, now time.Time) bool {
+	failureMu.Lock()
+	defer failureMu.Unlock()
+
+	if failureRepeatInterval <= 0 {
+		return true
+	}
+
+	last, found := lastFailures[key]
+	if found && last.fingerprint == fingerprint && now.Sub(last.sentAt) < failureRepeatInterval {
+		return false
+	}
+
+	lastFailures[key] = failureRecord{fingerprint: fingerprint, sentAt: now}
+
+	return true
+}
+
+// clearFailure forgets the last failure of a stack, so the next one is sent
+// immediately instead of being taken for a repeat.
+func clearFailure(key string) {
+	failureMu.Lock()
+	defer failureMu.Unlock()
+
+	delete(lastFailures, key)
+}

--- a/internal/notification/failure_repeat_test.go
+++ b/internal/notification/failure_repeat_test.go
@@ -96,6 +96,49 @@ func TestClearFailure_LetsNextFailureThrough(t *testing.T) {
 	}
 }
 
+func TestShouldSendFailure_PrunesStaleRecords(t *testing.T) {
+	resetFailureState(t, time.Hour)
+
+	now := time.Now()
+	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
+
+	gone := failureKey(Metadata{Repository: "acme/deploy", Stack: "removed"})
+	shouldSendFailure(gone, fingerprint, now)
+
+	alive := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
+	shouldSendFailure(alive, fingerprint, now.Add(2*time.Hour))
+
+	failureMu.Lock()
+	_, found := lastFailures[gone]
+	size := len(lastFailures)
+	failureMu.Unlock()
+
+	if found {
+		t.Error("a record older than the repeat interval must be dropped")
+	}
+
+	if size != 1 {
+		t.Errorf("only the current failure must be kept, got %d records", size)
+	}
+}
+
+func TestSetFailureRepeatInterval_ZeroDropsRecords(t *testing.T) {
+	resetFailureState(t, time.Hour)
+
+	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
+	shouldSendFailure(key, failureFingerprint("Deployment Failed", "pull access denied"), time.Now())
+
+	SetFailureRepeatInterval(0)
+
+	failureMu.Lock()
+	size := len(lastFailures)
+	failureMu.Unlock()
+
+	if size != 0 {
+		t.Errorf("turning suppression off must drop the records, got %d", size)
+	}
+}
+
 func TestShouldSendFailure_DisabledByZeroInterval(t *testing.T) {
 	resetFailureState(t, 0)
 

--- a/internal/notification/failure_repeat_test.go
+++ b/internal/notification/failure_repeat_test.go
@@ -1,0 +1,141 @@
+package notification
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// resetFailureState clears the suppression state so tests do not leak into each
+// other. They cannot run in parallel: the state is package level, like the
+// apprise config the other tests here mutate.
+func resetFailureState(t *testing.T, interval time.Duration) {
+	t.Helper()
+
+	failureMu.Lock()
+	lastFailures = map[string]failureRecord{}
+	failureRepeatInterval = interval
+	failureMu.Unlock()
+
+	t.Cleanup(func() {
+		failureMu.Lock()
+		lastFailures = map[string]failureRecord{}
+		failureRepeatInterval = DefaultFailureRepeatInterval
+		failureMu.Unlock()
+	})
+}
+
+func TestShouldSendFailure_SuppressesUnchangedRepeat(t *testing.T) {
+	resetFailureState(t, time.Hour)
+
+	now := time.Now()
+	key := failureKey(Metadata{Repository: "acme/deploy", Target: "prod", Stack: "app"})
+	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
+
+	if !shouldSendFailure(key, fingerprint, now) {
+		t.Fatal("first failure must be sent")
+	}
+
+	if shouldSendFailure(key, fingerprint, now.Add(30*time.Second)) {
+		t.Error("same failure 30s later must be suppressed")
+	}
+
+	if shouldSendFailure(key, fingerprint, now.Add(59*time.Minute)) {
+		t.Error("same failure inside the repeat interval must be suppressed")
+	}
+}
+
+func TestShouldSendFailure_RemindsAfterInterval(t *testing.T) {
+	resetFailureState(t, time.Hour)
+
+	now := time.Now()
+	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
+	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
+
+	shouldSendFailure(key, fingerprint, now)
+
+	if !shouldSendFailure(key, fingerprint, now.Add(time.Hour)) {
+		t.Fatal("failure must be sent again once the repeat interval passed")
+	}
+
+	if shouldSendFailure(key, fingerprint, now.Add(time.Hour+time.Second)) {
+		t.Error("reminder must restart the interval")
+	}
+}
+
+func TestShouldSendFailure_DifferentFaultOrStackIsSent(t *testing.T) {
+	resetFailureState(t, time.Hour)
+
+	now := time.Now()
+	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
+
+	shouldSendFailure(key, failureFingerprint("Deployment Failed", "pull access denied"), now)
+
+	if !shouldSendFailure(key, failureFingerprint("Deployment Failed", "hook exited with status 1"), now) {
+		t.Error("a different error on the same stack must be sent")
+	}
+
+	otherStack := failureKey(Metadata{Repository: "acme/deploy", Stack: "db"})
+	if !shouldSendFailure(otherStack, failureFingerprint("Deployment Failed", "pull access denied"), now) {
+		t.Error("the same error on another stack must be sent")
+	}
+}
+
+func TestClearFailure_LetsNextFailureThrough(t *testing.T) {
+	resetFailureState(t, time.Hour)
+
+	now := time.Now()
+	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
+	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
+
+	shouldSendFailure(key, fingerprint, now)
+	clearFailure(key)
+
+	if !shouldSendFailure(key, fingerprint, now.Add(time.Second)) {
+		t.Error("after a success the next failure must be sent again")
+	}
+}
+
+func TestShouldSendFailure_DisabledByZeroInterval(t *testing.T) {
+	resetFailureState(t, 0)
+
+	now := time.Now()
+	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
+	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
+
+	for i := range 3 {
+		if !shouldSendFailure(key, fingerprint, now.Add(time.Duration(i)*time.Second)) {
+			t.Fatalf("suppression is off, send %d must go through", i+1)
+		}
+	}
+}
+
+func TestWasNotified(t *testing.T) {
+	base := errors.New("hook exited with status 1")
+
+	if WasNotified(nil) {
+		t.Error("nil error was not notified")
+	}
+
+	if WasNotified(base) {
+		t.Error("plain error was not notified")
+	}
+
+	marked := MarkNotified(base)
+
+	if !WasNotified(marked) {
+		t.Error("marked error must report as notified")
+	}
+
+	if !errors.Is(marked, base) {
+		t.Error("marking must keep the original error unwrappable")
+	}
+
+	if marked.Error() != base.Error() {
+		t.Errorf("marking must not change the message, got %q", marked.Error())
+	}
+
+	if MarkNotified(nil) != nil {
+		t.Error("marking nil must stay nil")
+	}
+}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -425,8 +425,20 @@ func Send(level level, title, message string, metadata Metadata, opts ...SendOpt
 		return nil
 	}
 
+	// A success is the recovery signal for whatever failed there before, so the
+	// next failure of that stack is sent even if it repeats an older one. Done
+	// before the level check, so a configured level cannot leave stale state.
+	if level == Success {
+		clearFailure(failureKey(metadata))
+	}
+
 	if level < notifyLevel {
 		return nil // Do not send notification if the level is lower than the configured level
+	}
+
+	// Suppress a failure that is already reported and unchanged, see failure_repeat.go.
+	if level == Failure && !shouldSendFailure(failureKey(metadata), failureFingerprint(title, message), time.Now()) {
+		return nil
 	}
 
 	var o sendOptions

--- a/internal/notification/notified_error.go
+++ b/internal/notification/notified_error.go
@@ -27,6 +27,10 @@ func MarkNotified(err error) error {
 }
 
 // WasNotified reports whether a failure notification was already sent for err.
+// It walks the unwrap chain, so every layer above MarkNotified must wrap with
+// %w. An error rebuilt on the way up - fmt.Errorf("...: %v", err),
+// errors.New(err.Error()), a fresh sentinel - drops the mark and gets notified
+// a second time.
 func WasNotified(err error) bool {
 	var notified *notifiedError
 

--- a/internal/notification/notified_error.go
+++ b/internal/notification/notified_error.go
@@ -1,0 +1,34 @@
+package notification
+
+import "errors"
+
+// A failed deployment is reported where it fails, and the same error then
+// travels up to the poll or webhook handler, which reports it again - two
+// messages, same fault, differing only in title. Marking the error where the
+// notification is sent lets the outer layer log and count it as before, and stay
+// quiet about what the operator already knows.
+
+// notifiedError marks an error whose failure notification was already sent.
+type notifiedError struct {
+	err error
+}
+
+func (e *notifiedError) Error() string { return e.err.Error() }
+
+func (e *notifiedError) Unwrap() error { return e.err }
+
+// MarkNotified marks err as already reported. A nil error stays nil.
+func MarkNotified(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &notifiedError{err: err}
+}
+
+// WasNotified reports whether a failure notification was already sent for err.
+func WasNotified(err error) bool {
+	var notified *notifiedError
+
+	return errors.As(err, &notified)
+}

--- a/internal/stages/manager_test.go
+++ b/internal/stages/manager_test.go
@@ -101,10 +101,20 @@ func TestStageManagerNotifyFailureIncludesTarget(t *testing.T) {
 		got = metadata
 	}
 
-	sm.NotifyFailure(errors.New("boom"))
+	boom := errors.New("boom")
+
+	returned := sm.NotifyFailure(boom)
 
 	if got.Target != "prod-vm" {
 		t.Fatalf("expected target prod-vm, got %q", got.Target)
+	}
+
+	if !notification.WasNotified(returned) {
+		t.Error("a sent notification must mark the error as reported")
+	}
+
+	if !errors.Is(returned, boom) {
+		t.Error("marking must keep the original error unwrappable")
 	}
 }
 

--- a/internal/stages/run.go
+++ b/internal/stages/run.go
@@ -140,13 +140,13 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 				return nil
 			}
 
-			s.NotifyFailure(err)
+			notifiedErr := s.NotifyFailure(err)
 
 			if shouldPostFailureCommitStatus(s.DeployConfig.Destroy.Enabled) {
 				s.PostCommitStatus(ctx, failureCommitStatusState(stageName), failureCommitStatusDescription(err))
 			}
 
-			return err
+			return notifiedErr
 		}
 
 		stageLog.Debug(string("completed stage: "+stageName),

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -248,8 +248,11 @@ func (s *StageManager) GetStageMetaData(stageName StageName) (*MetaData, error) 
 	}
 }
 
-// NotifyFailure sends a failure notification using the provided NotifyFailureFunc.
-func (s *StageManager) NotifyFailure(notifyErr error) {
+// NotifyFailure sends a failure notification using the provided NotifyFailureFunc
+// and returns notifyErr marked as already reported, so the caller that receives
+// it does not notify about the same failure a second time. Without a
+// NotifyFailureFunc nothing is sent and the error is returned unchanged.
+func (s *StageManager) NotifyFailure(notifyErr error) error {
 	var (
 		latestCommit string
 		commitErr    error
@@ -289,7 +292,11 @@ func (s *StageManager) NotifyFailure(notifyErr error) {
 		}
 
 		s.NotifyFailureFunc(s.Log, notifyErr, metadata)
+
+		return notification.MarkNotified(notifyErr)
 	}
+
+	return notifyErr
 }
 
 func (s *StageManager) NotifyDeploymentStarted() error {

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -18,6 +18,7 @@ For that, specify the required settings in the app `environment` section and add
 | `APPRISE_NOTIFY_URLS`      | string | A comma-separated list of Apprise-URLs to send notifications to the [supported services/platforms](https://appriseit.com/services/) (e.g. `pover://{user_key}@{token},mailto://{user}:{password}@{domain}`) |               |
 | `APPRISE_NOTIFY_URLS_FILE` | string | Path to the file inside the container containing the Apprise-URLs (see `APPRISE_NOTIFY_URLS`). Mutually exclusive with `APPRISE_NOTIFY_URLS`.                                                               |               |
 | `APPRISE_NOTIFY_LEVEL`     | string | The minimum level of notifications to send. Possible values: `info`, `success`, `warning`, `failure`                                                                                                        | `success`     |
+| `APPRISE_NOTIFY_REPEAT_INTERVAL` | duration | How long an unchanged failure notification is suppressed before it is sent again as a reminder (see [Repeated failures](#repeated-failures)). `0` sends every failure.                                        | `1h`          |
 | `APPRISE_NOTIFY_BODY_TEMPLATE`  | string | Optional [Go `text/template`](https://pkg.go.dev/text/template) rendering the notification body (see [Custom notification body](#custom-notification-body)). Empty uses the built-in format.                  |               |
 | `APPRISE_NOTIFY_BODY_TEMPLATE_FILE` | string | Path to a file inside the container containing the template (see `APPRISE_NOTIFY_BODY_TEMPLATE`). Mutually exclusive with `APPRISE_NOTIFY_BODY_TEMPLATE`.                                                          |               |
 
@@ -53,6 +54,32 @@ services:
       retries: 3
       start_period: 20s
 ```
+
+## Repeated failures
+
+A failure repeats as often as its trigger. A poll job runs on its interval and a
+broken deployment fails the same way every run, so one fault produces one message
+per poll until somebody fixes it - an expired registry token can turn into
+hundreds of identical notifications overnight.
+
+Failure notifications are therefore de-duplicated per stack:
+
+- The first failure of a stack is sent immediately.
+- While the failure stays the same, further notifications are skipped and repeated
+  only once per `APPRISE_NOTIFY_REPEAT_INTERVAL`, so a long outage stays visible
+  without flooding.
+- A different error on the same stack is sent right away - it is new information.
+- A successful notification for that stack (e.g. `Deployment completed`) clears the
+  suppression, so it also acts as the recovery signal and the next failure is sent
+  immediately.
+- Set `APPRISE_NOTIFY_REPEAT_INTERVAL` to `0` to send every failure, unchanged or not.
+
+Stacks are tracked separately per repository, target and Docker context, and the
+state is in memory: a restarted daemon sends the next failure again.
+
+For the same reason a failed deployment notifies **once**, not twice. The stack
+reports its own failure, and the poll job or webhook that received the same error
+no longer repeats it under its own title. Logs and metrics are unchanged.
 
 ## Metadata fields
 


### PR DESCRIPTION
## Problem

A failure notification repeats as often as its trigger. A poll job runs on its interval, a broken deployment fails the same way every run, so one fault gives one message per poll until somebody fixes it.

On my setup the registry token expired while the daemon was running. Result: **~240 identical messages in two hours**, and each poll sent **two** of them, because the stack reports its own failure and then the poll handler reports the same error again under its own title:

```
❌ Deployment Failed
app-dev -> app @ refs/heads/main (463450d) in 1.704s — failed to pull images: ... token has expired

❌ Poll Job failed
app-dev -> @ refs/heads/main in 0s — deployment failed: failed to pull images: ... token has expired
```

Nothing in the message changes between repeats, so every one after the first carries no information.

## Changes

**De-duplicate failures per stack.** Key is repository + target + stack + context, fingerprint is title + message. The first failure is sent, unchanged repeats are skipped, and one reminder goes out per `APPRISE_NOTIFY_REPEAT_INTERVAL` (new, default `1h`) so a long outage does not disappear. A different error on the same stack is sent immediately - that is new information. A **success** notification for that stack clears the state, so the existing `Deployment completed` is the recovery signal and no new notification type is needed. Set the interval to `0` to get the old behaviour back.

The fingerprint deliberately ignores metadata: job id and duration differ on every attempt, so including them would make every repeat look new.

**Report one fault once.** `StageManager.NotifyFailure` now returns the error marked as already reported, and the poll and webhook handlers skip their own notification for such an error. Logs, metrics and HTTP responses are unchanged - only the second message is dropped.

Suppression state is in memory and per stack, so a restarted daemon sends the next failure again.

## Tests

`internal/notification/failure_repeat_test.go` covers suppression of an unchanged repeat, the reminder after the interval, a changed fault and another stack passing through, clearing on success, the `0` opt-out, and the error marker. Existing `TestNotifyFailure*` extended for the returned marked error.

`go build`, `go vet`, `golangci-lint run` and the touched package tests are green.

## Docs

`wiki/docs/Advanced/Notifications.md`: the new setting in the table plus a "Repeated failures" section describing the behaviour.