### PR TITLE
docs(examples): add full working examples for common setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ ed25519
 
 *.env
 .env
+# examples commit their env files on purpose (cleartext non-secret config)
+!examples/**/*.env
 
 cover.out
 cover.html

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,16 +3,16 @@
 Full working setups for common doco-cd scenarios. Each example replicates every repo it needs:
 
 - `app-repo/` or `deployments-repo/` — what you commit to Git.
-- `server/` — what you put on the VM next to Docker (doco-cd itself).
+- `server/` — what you put on the Docker host (doco-cd itself).
 
 | Example | Pattern | Pick it when |
 |---|---|---|
-| [single-repo-single-env](single-repo-single-env/) | App repo carries its own compose + `.doco-cd.yml`. One VM polls it. | You have one app and one server. Start here. |
-| [single-repo-two-envs](single-repo-two-envs/) | Same repo, two deploy configs. Each VM selects its own via poll `target:`. Adds notifications. | You have staging and prod of the same app. |
-| [deployments-repo](deployments-repo/) | One central repo deploys many apps to many VMs. Version pins per VM, compose files pulled from app repos, secrets encrypted with SOPS. | You have a fleet of apps/VMs and want one place that states what runs where. |
+| [single-repo-single-env](single-repo-single-env/) | App repo carries its own compose + `.doco-cd.yml`. One doco-cd instance polls it. | You have one app and one Docker host. Start here. |
+| [single-repo-two-envs](single-repo-two-envs/) | Same repo, two deploy configs. Each doco-cd instance selects its own via poll `target:`. Adds notifications. | You have staging and prod of the same app. |
+| [deployments-repo](deployments-repo/) | One central repo deploys many apps to many hosts. Version pins per host, compose files pulled from app repos, secrets encrypted with SOPS. | You have a fleet of apps/hosts and want one place that states what runs where. |
 
 Notes that apply to all examples:
 
-- All examples poll. Polling needs no inbound port, so the VM firewall stays closed. Webhooks work the same way — set `WEBHOOK_SECRET` and publish the port.
+- All examples poll. Polling needs no inbound port, so the host firewall stays closed. Webhooks work the same way — set `WEBHOOK_SECRET` and publish the port.
 - Examples use the `latest` image tag to stay copy-pasteable. In real use pin the doco-cd image by tag + digest.
-- The `server/` compose is the one thing doco-cd cannot GitOps — it deploys stacks, not itself. Copy it to the VM by hand (or see [Self-Updating](https://doco.cd/latest/Advanced/Self-Updating/)).
+- The `server/` compose is the one thing doco-cd cannot GitOps — it deploys stacks, not itself. Copy it to the host by hand (or see [Self-Updating](https://doco.cd/latest/Advanced/Self-Updating/)).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,18 @@
+# Examples
+
+Full working setups for common doco-cd scenarios. Each example replicates every repo it needs:
+
+- `app-repo/` or `deployments-repo/` — what you commit to Git.
+- `server/` — what you put on the VM next to Docker (doco-cd itself).
+
+| Example | Pattern | Pick it when |
+|---|---|---|
+| [single-repo-single-env](single-repo-single-env/) | App repo carries its own compose + `.doco-cd.yml`. One VM polls it. | You have one app and one server. Start here. |
+| [single-repo-two-envs](single-repo-two-envs/) | Same repo, two deploy configs. Each VM selects its own via poll `target:`. Adds notifications. | You have staging and prod of the same app. |
+| [deployments-repo](deployments-repo/) | One central repo deploys many apps to many VMs. Version pins per VM, compose files pulled from app repos, secrets encrypted with SOPS. | You have a fleet of apps/VMs and want one place that states what runs where. |
+
+Notes that apply to all examples:
+
+- All examples poll. Polling needs no inbound port, so the VM firewall stays closed. Webhooks work the same way — set `WEBHOOK_SECRET` and publish the port.
+- Examples use the `latest` image tag to stay copy-pasteable. In real use pin the doco-cd image by tag + digest.
+- The `server/` compose is the one thing doco-cd cannot GitOps — it deploys stacks, not itself. Copy it to the VM by hand (or see [Self-Updating](https://doco.cd/latest/Advanced/Self-Updating/)).

--- a/examples/deployments-repo/README.md
+++ b/examples/deployments-repo/README.md
@@ -1,0 +1,48 @@
+# Central deployments repo → many apps, many VMs
+
+One Git repo is the source of truth for a fleet. Each VM's doco-cd polls the same repo with its own `target:` and reads only its own `.doco-cd.<vm>.yml`. A commit here **is** a deploy.
+
+Needs doco-cd >= 0.108.0 (remote compose `include:`).
+
+## The model
+
+- **One target file per VM.** It lists the VM's stacks and pins **every** version the VM runs: your images by git sha, third-party by exact tag. Nothing floats. A version change is a commit — reviewable, revertable, and the diff is the changelog.
+- **Compose lives with the app code, not here.** Each per-env compose is a small stub that `include:`s the app repo's `deploy/compose.yaml`, pinned at a sha. The compose travels through envs together with the images it describes — a compose change cannot hit prod before its code does.
+- **Non-secret config** is a cleartext env file per environment, committed here.
+- **Secrets** are SOPS-encrypted env files, committed here. The daemon decrypts them at deploy time with an age key (KMS works the same). Secrets land as container env — verify on a box with `docker exec <c> printenv`, never by reading files.
+- **App CI closes the loop:** after building an image, a bump job rewrites the sha pins in the target files of the envs that should follow, and commits. doco-cd does the rest.
+
+## Layout
+
+```
+deployments-repo/            # the fleet's Git repository
+  .doco-cd.shop-dev.yml      # per-VM deploy config: stack list + ALL version pins
+  .doco-cd.shop-prod.yml
+  .sops.yaml                 # SOPS creation rules (age recipient)
+  shop/
+    shop-dev/compose.yaml    # include stub, pinned at ${SHOP_COMPOSE_SHA}
+    shop-prod/compose.yaml
+    env/shop-dev.env         # cleartext config
+    env/shop-prod.env
+    secrets/shop-dev.sops.env         # SOPS-encrypted (example is a template)
+app-repo/                    # the app's own repo (e.g. github.com/example/shop-be)
+  deploy/compose.yaml        # THE family compose — single source for every env
+server/                      # per VM, e.g. /opt/doco-cd/
+  compose.yaml
+  poll.yaml                  # target: shop-dev on the dev VM, shop-prod on prod
+  secrets.env.example
+```
+
+Add more apps as more families (`blog/`, `api/`, …) and more target files. One VM can also run several stacks — add more YAML documents to its target file.
+
+## Try it
+
+1. Push `deployments-repo/` contents to a Git repository. Put `app-repo/deploy/compose.yaml` in your app's repo.
+2. Generate an age key: `age-keygen -o age.key`. Put the public key in `.sops.yaml`.
+3. Create the secret files: `sops encrypt shop/secrets/shop-dev.sops.env` (start from the `.example`).
+4. On each VM: copy `server/` to `/opt/doco-cd/`, set the VM's `target:` in `poll.yaml`, place `age.key` next to it.
+5. `docker compose up -d` in `/opt/doco-cd/`.
+
+## Why a stub and not a plain compose here?
+
+You can start with full compose files in this repo — that also works and is simpler. The stub + pinned `include:` pays off when app developers own their compose: they change it in the app repo, CI bumps `SHOP_COMPOSE_SHA` here per env, and dev/test/prod each run exactly the compose revision they were promoted to. `project_directory: .` makes the included file's relative paths (`../env/*`, `../secrets/*`) resolve against the per-env stub directory, so one compose serves every env.

--- a/examples/deployments-repo/README.md
+++ b/examples/deployments-repo/README.md
@@ -1,22 +1,22 @@
-# Central deployments repo → many apps, many VMs
+# Central deployments repo → many apps, many hosts
 
-One Git repo is the source of truth for a fleet. Each VM's doco-cd polls the same repo with its own `target:` and reads only its own `.doco-cd.<vm>.yml`. A commit here **is** a deploy.
+One Git repo is the source of truth for a fleet. Each host's doco-cd instance polls the same repo with its own `target:` and reads only its own `.doco-cd.<host>.yml`. A commit here **is** a deploy.
 
 Needs doco-cd >= 0.108.0 (remote compose `include:`).
 
 ## The model
 
-- **One target file per VM.** It lists the VM's stacks and pins **every** version the VM runs: your images by git sha, third-party by exact tag. Nothing floats. A version change is a commit — reviewable, revertable, and the diff is the changelog.
+- **One target file per host.** It lists the host's stacks and pins **every** version the host runs: your images by git sha, third-party by exact tag. Nothing floats. A version change is a commit — reviewable, revertable, and the diff is the changelog.
 - **Compose lives with the app code, not here.** Each per-env compose is a small stub that `include:`s the app repo's `deploy/compose.yaml`, pinned at a sha. The compose travels through envs together with the images it describes — a compose change cannot hit prod before its code does.
 - **Non-secret config** is a cleartext env file per environment, committed here.
-- **Secrets** are SOPS-encrypted env files, committed here. The daemon decrypts them at deploy time with an age key (KMS works the same). Secrets land as container env — verify on a box with `docker exec <c> printenv`, never by reading files.
+- **Secrets** are SOPS-encrypted env files, committed here. The daemon decrypts them at deploy time with an age key (KMS works the same). Secrets land as container env — verify on the host with `docker exec <c> printenv`, never by reading files.
 - **App CI closes the loop:** after building an image, a bump job rewrites the sha pins in the target files of the envs that should follow, and commits. doco-cd does the rest.
 
 ## Layout
 
 ```
 deployments-repo/            # the fleet's Git repository
-  .doco-cd.shop-dev.yml      # per-VM deploy config: stack list + ALL version pins
+  .doco-cd.shop-dev.yml      # per-host deploy config: stack list + ALL version pins
   .doco-cd.shop-prod.yml
   .sops.yaml                 # SOPS creation rules (age recipient)
   shop/
@@ -27,20 +27,20 @@ deployments-repo/            # the fleet's Git repository
     secrets/shop-dev.sops.env         # SOPS-encrypted (example is a template)
 app-repo/                    # the app's own repo (e.g. github.com/example/shop-be)
   deploy/compose.yaml        # THE family compose — single source for every env
-server/                      # per VM, e.g. /opt/doco-cd/
+server/                      # per host, e.g. /opt/doco-cd/
   compose.yaml
-  poll.yaml                  # target: shop-dev on the dev VM, shop-prod on prod
+  poll.yaml                  # target: shop-dev on the dev host, shop-prod on prod
   secrets.env.example
 ```
 
-Add more apps as more families (`blog/`, `api/`, …) and more target files. One VM can also run several stacks — add more YAML documents to its target file.
+Add more apps as more families (`blog/`, `api/`, …) and more target files. One host can also run several stacks — add more YAML documents to its target file.
 
 ## Try it
 
 1. Push `deployments-repo/` contents to a Git repository. Put `app-repo/deploy/compose.yaml` in your app's repo.
 2. Generate an age key: `age-keygen -o age.key`. Put the public key in `.sops.yaml`.
 3. Create the secret files: `sops encrypt shop/secrets/shop-dev.sops.env` (start from the `.example`).
-4. On each VM: copy `server/` to `/opt/doco-cd/`, set the VM's `target:` in `poll.yaml`, place `age.key` next to it.
+4. On each host: copy `server/` to `/opt/doco-cd/`, set the host's `target:` in `poll.yaml`, place `age.key` next to it.
 5. `docker compose up -d` in `/opt/doco-cd/`.
 
 ## Why a stub and not a plain compose here?

--- a/examples/deployments-repo/app-repo/deploy/compose.yaml
+++ b/examples/deployments-repo/app-repo/deploy/compose.yaml
@@ -3,7 +3,7 @@
 # repo's per-env stubs via compose `include:` pinned at a sha of this repo.
 #
 # Env differences arrive ONLY through interpolation vars from the env's
-# .doco-cd.<vm>.yml and the per-env env/secret files (relative paths resolve
+# .doco-cd.<host>.yml and the per-env env/secret files (relative paths resolve
 # against the stub's project_directory).
 services:
   shop-be:

--- a/examples/deployments-repo/app-repo/deploy/compose.yaml
+++ b/examples/deployments-repo/app-repo/deploy/compose.yaml
@@ -1,0 +1,34 @@
+# THE shop family compose — single source of truth for every env. Lives in
+# the app repo (github.com/example/shop-be). Consumed by the deployments
+# repo's per-env stubs via compose `include:` pinned at a sha of this repo.
+#
+# Env differences arrive ONLY through interpolation vars from the env's
+# .doco-cd.<vm>.yml and the per-env env/secret files (relative paths resolve
+# against the stub's project_directory).
+services:
+  shop-be:
+    image: ${REGISTRY}/shop-be:${SHOP_BE_TAG}
+    restart: unless-stopped
+    ports:
+      - "80:8080"
+    environment:
+      DOMAIN: ${DOMAIN}
+    env_file:
+      - ../env/shop-${ENV_NAME}.env
+      - ../secrets/shop-${ENV_NAME}.sops.env # decrypted by the daemon
+    # Runs INSIDE the container on every recreate — migrations etc.
+    post_start:
+      - command: ["/post-update.sh"]
+    depends_on:
+      - redis
+    healthcheck:
+      test: ["CMD", "/shop-be", "healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  redis:
+    image: redis:${REDIS_TAG}
+    restart: unless-stopped
+    command: redis-server --save ""

--- a/examples/deployments-repo/deployments-repo/.doco-cd.shop-dev.yml
+++ b/examples/deployments-repo/deployments-repo/.doco-cd.shop-dev.yml
@@ -1,0 +1,23 @@
+# Deploy config for the shop-dev VM. Its daemon polls this repo with
+# `target: shop-dev` and reads ONLY this file.
+#
+# RULE: every service this VM runs has its version pinned HERE — our images by
+# git sha (rolled by app-repo CI bump jobs), third-party by exact tag. Nothing
+# floats. A version change is a commit.
+name: shop
+working_dir: shop/shop-dev
+environment:
+  ENV_NAME: "dev"
+  DOMAIN: "dev.shop.example.com"
+  REGISTRY: "ghcr.io/example"
+  # --- compose pin (app repo's deploy/compose.yaml at this sha)
+  SHOP_COMPOSE_SHA: "b3e21007ad8c2ac1223537d7d5f7c1e2ef51be77"
+  # --- our images
+  SHOP_BE_TAG: "dd5c00230acc348c4b0524730a848ff592189b16"
+  # --- third-party
+  REDIS_TAG: "7.2-alpine"
+# Dropped services must not linger as orphans — an orphaned crashlooper keeps
+# the drift-redeploy loop alive.
+remove_orphans: true
+reconciliation:
+  events: [unhealthy] # never `die` — one-shot/post_start exits would loop it

--- a/examples/deployments-repo/deployments-repo/.doco-cd.shop-dev.yml
+++ b/examples/deployments-repo/deployments-repo/.doco-cd.shop-dev.yml
@@ -1,9 +1,9 @@
-# Deploy config for the shop-dev VM. Its daemon polls this repo with
-# `target: shop-dev` and reads ONLY this file.
+# Deploy config for the shop-dev host. Its doco-cd instance polls this repo
+# with `target: shop-dev` and reads ONLY this file.
 #
-# RULE: every service this VM runs has its version pinned HERE — our images by
-# git sha (rolled by app-repo CI bump jobs), third-party by exact tag. Nothing
-# floats. A version change is a commit.
+# RULE: every service this host runs has its version pinned HERE — our images
+# by git sha (rolled by app-repo CI bump jobs), third-party by exact tag.
+# Nothing floats. A version change is a commit.
 name: shop
 working_dir: shop/shop-dev
 environment:

--- a/examples/deployments-repo/deployments-repo/.doco-cd.shop-prod.yml
+++ b/examples/deployments-repo/deployments-repo/.doco-cd.shop-prod.yml
@@ -1,4 +1,4 @@
-# Deploy config for the shop-prod VM (target: shop-prod). Same rules as dev:
+# Deploy config for the shop-prod host (target: shop-prod). Same rules as dev:
 # everything pinned, nothing floats. Pins here move only when a release
 # promotes them — usually by the app repo's CI, sometimes by hand.
 name: shop

--- a/examples/deployments-repo/deployments-repo/.doco-cd.shop-prod.yml
+++ b/examples/deployments-repo/deployments-repo/.doco-cd.shop-prod.yml
@@ -1,0 +1,18 @@
+# Deploy config for the shop-prod VM (target: shop-prod). Same rules as dev:
+# everything pinned, nothing floats. Pins here move only when a release
+# promotes them — usually by the app repo's CI, sometimes by hand.
+name: shop
+working_dir: shop/shop-prod
+environment:
+  ENV_NAME: "prod"
+  DOMAIN: "shop.example.com"
+  REGISTRY: "ghcr.io/example"
+  # --- compose pin (app repo's deploy/compose.yaml at this sha)
+  SHOP_COMPOSE_SHA: "a7f89ee10def020ff18f46fa7ab167d7939402d7"
+  # --- our images
+  SHOP_BE_TAG: "20b524730a848ff592189b16dd5c00230acc348c"
+  # --- third-party
+  REDIS_TAG: "7.2-alpine"
+remove_orphans: true
+reconciliation:
+  events: [unhealthy]

--- a/examples/deployments-repo/deployments-repo/.sops.yaml
+++ b/examples/deployments-repo/deployments-repo/.sops.yaml
@@ -1,0 +1,9 @@
+# SOPS creation rules. Every file under */secrets/ is encrypted to this age
+# recipient. The matching PRIVATE key sits on each VM next to the daemon
+# (see server/compose.yaml, SOPS_AGE_KEY_FILE).
+#
+# Generate a pair: age-keygen -o age.key  (public key is printed).
+# Cloud KMS instead of age works the same — see the SOPS docs.
+creation_rules:
+  - path_regex: .*/secrets/.*\.sops\.env$
+    age: age1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs3wkdge # replace with YOUR public key

--- a/examples/deployments-repo/deployments-repo/.sops.yaml
+++ b/examples/deployments-repo/deployments-repo/.sops.yaml
@@ -1,5 +1,5 @@
 # SOPS creation rules. Every file under */secrets/ is encrypted to this age
-# recipient. The matching PRIVATE key sits on each VM next to the daemon
+# recipient. The matching PRIVATE key sits on each host next to the daemon
 # (see server/compose.yaml, SOPS_AGE_KEY_FILE).
 #
 # Generate a pair: age-keygen -o age.key  (public key is printed).

--- a/examples/deployments-repo/deployments-repo/shop/env/shop-dev.env
+++ b/examples/deployments-repo/deployments-repo/shop/env/shop-dev.env
@@ -1,0 +1,8 @@
+# Cleartext, non-secret config for shop-dev. Lands as container env via
+# env_file in the app repo's compose.
+APP_ENV=dev
+APP_URL=https://dev.shop.example.com
+LOG_LEVEL=debug
+CACHE_DRIVER=redis
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/examples/deployments-repo/deployments-repo/shop/env/shop-prod.env
+++ b/examples/deployments-repo/deployments-repo/shop/env/shop-prod.env
@@ -1,0 +1,7 @@
+# Cleartext, non-secret config for shop-prod.
+APP_ENV=prod
+APP_URL=https://shop.example.com
+LOG_LEVEL=info
+CACHE_DRIVER=redis
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/examples/deployments-repo/deployments-repo/shop/secrets/shop-dev.sops.env.example
+++ b/examples/deployments-repo/deployments-repo/shop/secrets/shop-dev.sops.env.example
@@ -1,0 +1,12 @@
+# TEMPLATE. The real shop-dev.sops.env is this file SOPS-encrypted and
+# committed — safe in git, only the age/KMS key holder can read it.
+#
+#   cp shop-dev.sops.env.example shop-dev.sops.env
+#   <fill in values>
+#   sops encrypt --in-place shop-dev.sops.env
+#
+# The daemon decrypts it at deploy time (SOPS_AGE_KEY_FILE) and it lands as
+# container env. Verify on a box with `docker exec <c> printenv`, never by
+# reading files.
+DB_PASSWORD=
+API_TOKEN=

--- a/examples/deployments-repo/deployments-repo/shop/secrets/shop-dev.sops.env.example
+++ b/examples/deployments-repo/deployments-repo/shop/secrets/shop-dev.sops.env.example
@@ -6,7 +6,7 @@
 #   sops encrypt --in-place shop-dev.sops.env
 #
 # The daemon decrypts it at deploy time (SOPS_AGE_KEY_FILE) and it lands as
-# container env. Verify on a box with `docker exec <c> printenv`, never by
+# container env. Verify on the host with `docker exec <c> printenv`, never by
 # reading files.
 DB_PASSWORD=
 API_TOKEN=

--- a/examples/deployments-repo/deployments-repo/shop/shop-dev/compose.yaml
+++ b/examples/deployments-repo/deployments-repo/shop/shop-dev/compose.yaml
@@ -1,0 +1,8 @@
+# Stub: the real compose lives in the app repo at deploy/compose.yaml,
+# included here pinned at ${SHOP_COMPOSE_SHA} (rolled by the app repo's CI
+# bump job together with the image tags — compose moves through envs with the
+# code). project_directory makes the included file's relative paths
+# (../env/*, ../secrets/*) resolve against THIS per-env directory.
+include:
+  - path: https://github.com/example/shop-be.git#${SHOP_COMPOSE_SHA}:deploy
+    project_directory: .

--- a/examples/deployments-repo/deployments-repo/shop/shop-prod/compose.yaml
+++ b/examples/deployments-repo/deployments-repo/shop/shop-prod/compose.yaml
@@ -1,0 +1,5 @@
+# Same stub as shop-dev — the env difference arrives only through the vars in
+# .doco-cd.shop-prod.yml and the per-env env/secret files.
+include:
+  - path: https://github.com/example/shop-be.git#${SHOP_COMPOSE_SHA}:deploy
+    project_directory: .

--- a/examples/deployments-repo/server/compose.yaml
+++ b/examples/deployments-repo/server/compose.yaml
@@ -1,5 +1,5 @@
-# doco-cd on one fleet VM. Same file on every VM — only poll.yaml (the
-# `target:`) differs. Lives on the VM (e.g. /opt/doco-cd/), NOT in git.
+# doco-cd on one fleet host. Same file on every host — only poll.yaml (the
+# `target:`) differs. Lives on the host (e.g. /opt/doco-cd/), NOT in git.
 services:
   doco-cd:
     image: ghcr.io/kimdre/doco-cd:latest # pin tag+digest in real use
@@ -27,7 +27,7 @@ services:
 
 secrets:
   sops_age_key:
-    file: ./age.key # chmod 600, delivered to the VM out of band
+    file: ./age.key # chmod 600, delivered to the host out of band
 
 volumes:
   data:

--- a/examples/deployments-repo/server/compose.yaml
+++ b/examples/deployments-repo/server/compose.yaml
@@ -1,0 +1,33 @@
+# doco-cd on one fleet VM. Same file on every VM — only poll.yaml (the
+# `target:`) differs. Lives on the VM (e.g. /opt/doco-cd/), NOT in git.
+services:
+  doco-cd:
+    image: ghcr.io/kimdre/doco-cd:latest # pin tag+digest in real use
+    restart: unless-stopped
+    env_file:
+      - secrets.env # GIT_ACCESS_TOKEN for the private deployments repo
+    environment:
+      TZ: Etc/UTC
+      POLL_CONFIG_FILE: /etc/doco-cd/poll.yaml
+      # Private age key for SOPS decryption of */secrets/*.sops.env. Mounted
+      # as a docker secret below, never in an env var.
+      SOPS_AGE_KEY_FILE: /run/secrets/sops_age_key
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./poll.yaml:/etc/doco-cd/poll.yaml:ro
+      - data:/data
+    secrets:
+      - sops_age_key
+    healthcheck:
+      test: ["CMD", "/doco-cd", "healthcheck"]
+      start_period: 15s
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+secrets:
+  sops_age_key:
+    file: ./age.key # chmod 600, delivered to the VM out of band
+
+volumes:
+  data:

--- a/examples/deployments-repo/server/poll.yaml
+++ b/examples/deployments-repo/server/poll.yaml
@@ -1,0 +1,8 @@
+# Every fleet VM polls the SAME deployments repo. The `target:` names the VM:
+# its daemon reads only .doco-cd.<target>.yml and deploys only its own stacks.
+# This file is the only per-VM difference — here the shop-dev VM; the prod VM
+# says `target: shop-prod`.
+- url: https://github.com/example/deployments-repo.git
+  reference: refs/heads/main
+  interval: 30
+  target: shop-dev

--- a/examples/deployments-repo/server/poll.yaml
+++ b/examples/deployments-repo/server/poll.yaml
@@ -1,7 +1,7 @@
-# Every fleet VM polls the SAME deployments repo. The `target:` names the VM:
-# its daemon reads only .doco-cd.<target>.yml and deploys only its own stacks.
-# This file is the only per-VM difference — here the shop-dev VM; the prod VM
-# says `target: shop-prod`.
+# Every doco-cd instance in the fleet polls the SAME deployments repo. The
+# `target:` names the host: the instance reads only .doco-cd.<target>.yml and
+# deploys only its own stacks. This file is the only per-host difference —
+# here the shop-dev host; the prod host says `target: shop-prod`.
 - url: https://github.com/example/deployments-repo.git
   reference: refs/heads/main
   interval: 30

--- a/examples/deployments-repo/server/secrets.env.example
+++ b/examples/deployments-repo/server/secrets.env.example
@@ -1,0 +1,7 @@
+# TEMPLATE — keys only. Real file is secrets.env on the VM: chmod 600, never
+# committed. App secrets do NOT go here — they live SOPS-encrypted in the
+# deployments repo.
+
+# Read access to the private deployments repo (and to the app repos the
+# compose `include:` stubs pull from):
+GIT_ACCESS_TOKEN=

--- a/examples/deployments-repo/server/secrets.env.example
+++ b/examples/deployments-repo/server/secrets.env.example
@@ -1,4 +1,4 @@
-# TEMPLATE — keys only. Real file is secrets.env on the VM: chmod 600, never
+# TEMPLATE — keys only. Real file is secrets.env on the host: chmod 600, never
 # committed. App secrets do NOT go here — they live SOPS-encrypted in the
 # deployments repo.
 

--- a/examples/single-repo-single-env/README.md
+++ b/examples/single-repo-single-env/README.md
@@ -1,0 +1,41 @@
+# Single repo → single environment
+
+One app repo, one VM. The repo carries the compose files and the deploy config. The VM runs doco-cd, which polls the repo and reconciles the stack on every push to `main`.
+
+## What this example shows
+
+- A deploy config (`.doco-cd.yml`) with the deployed image tag **pinned in Git**. Bumping the tag is the release: commit + push, doco-cd redeploys. No SSH to the VM.
+- Secrets that **never touch the repo**: they live on the VM in `secrets.env`, and `PASS_ENV=true` on the daemon forwards them into compose interpolation.
+- A poll-only daemon: no published ports, no webhook setup, firewall stays closed.
+- Runtime self-healing (`reconciliation`): an unhealthy container gets restarted in place.
+- Mounted config auto-apply: edit the `Caddyfile`, push, and doco-cd force-recreates only the service that mounts it.
+
+## Layout
+
+```
+app-repo/                 # your Git repository
+  .doco-cd.yml            # deploy config: stack name + image tag + non-secret env
+  deploy/
+    compose.yaml          # the stack
+    Caddyfile             # mounted config, edits auto-apply
+server/                   # lives on the VM (e.g. /opt/doco-cd/), NOT in Git
+  compose.yaml            # doco-cd itself
+  poll.yaml               # which repo to watch
+  secrets.env.example     # copy to secrets.env on the VM, chmod 600
+```
+
+## Try it
+
+1. Push `app-repo/` contents to a Git repository.
+2. Copy `server/` to the VM, e.g. to `/opt/doco-cd/`.
+3. Copy `secrets.env.example` to `secrets.env` and fill it in. `chmod 600 secrets.env`.
+4. Edit `poll.yaml` to point at your repository.
+5. Run `docker compose up -d` in `/opt/doco-cd/`.
+
+Within one poll interval the stack is up. From now on, a push to `main` is a deploy.
+
+## How a release works
+
+CI builds the image and tags it with the commit SHA. Then a CI job rewrites `APP_TAG` in `.doco-cd.yml` and commits with `[skip ci]`. doco-cd sees the deploy config changed and redeploys. The repo always states what runs — that is the whole point.
+
+A commit that touches nothing the stack references (docs, other dirs) is skipped: cloned, compared, no `compose up`.

--- a/examples/single-repo-single-env/README.md
+++ b/examples/single-repo-single-env/README.md
@@ -1,11 +1,11 @@
 # Single repo → single environment
 
-One app repo, one VM. The repo carries the compose files and the deploy config. The VM runs doco-cd, which polls the repo and reconciles the stack on every push to `main`.
+One app repo, one Docker host. The repo carries the compose files and the deploy config. The host runs doco-cd, which polls the repo and reconciles the stack on every push to `main`.
 
 ## What this example shows
 
-- A deploy config (`.doco-cd.yml`) with the deployed image tag **pinned in Git**. Bumping the tag is the release: commit + push, doco-cd redeploys. No SSH to the VM.
-- Secrets that **never touch the repo**: they live on the VM in `secrets.env`, and `PASS_ENV=true` on the daemon forwards them into compose interpolation.
+- A deploy config (`.doco-cd.yml`) with the deployed image tag **pinned in Git**. Bumping the tag is the release: commit + push, doco-cd redeploys. No SSH to the host.
+- Secrets that **never touch the repo**: they live on the host in `secrets.env`, and `PASS_ENV=true` on the daemon forwards them into compose interpolation.
 - A poll-only daemon: no published ports, no webhook setup, firewall stays closed.
 - Runtime self-healing (`reconciliation`): an unhealthy container gets restarted in place.
 - Mounted config auto-apply: edit the `Caddyfile`, push, and doco-cd force-recreates only the service that mounts it.
@@ -18,16 +18,16 @@ app-repo/                 # your Git repository
   deploy/
     compose.yaml          # the stack
     Caddyfile             # mounted config, edits auto-apply
-server/                   # lives on the VM (e.g. /opt/doco-cd/), NOT in Git
+server/                   # lives on the host (e.g. /opt/doco-cd/), NOT in Git
   compose.yaml            # doco-cd itself
   poll.yaml               # which repo to watch
-  secrets.env.example     # copy to secrets.env on the VM, chmod 600
+  secrets.env.example     # copy to secrets.env on the host, chmod 600
 ```
 
 ## Try it
 
 1. Push `app-repo/` contents to a Git repository.
-2. Copy `server/` to the VM, e.g. to `/opt/doco-cd/`.
+2. Copy `server/` to the host, e.g. to `/opt/doco-cd/`.
 3. Copy `secrets.env.example` to `secrets.env` and fill it in. `chmod 600 secrets.env`.
 4. Edit `poll.yaml` to point at your repository.
 5. Run `docker compose up -d` in `/opt/doco-cd/`.

--- a/examples/single-repo-single-env/app-repo/.doco-cd.yml
+++ b/examples/single-repo-single-env/app-repo/.doco-cd.yml
@@ -1,0 +1,19 @@
+# Deploy config. The VM's doco-cd polls this repo and reconciles deploy/ on
+# every push to main.
+#
+# Split by sensitivity:
+#   - Non-secrets live HERE in git: the domain and the deployed image tag.
+#     Bumping APP_TAG is the release — commit + push, doco-cd redeploys.
+#     A CI job can do the bump after the image build (commit with [skip ci]).
+#   - Secrets are NOT here. They live on the VM in secrets.env, loaded by the
+#     doco-cd container and forwarded into compose interpolation via
+#     PASS_ENV=true (see server/compose.yaml).
+name: app
+working_dir: deploy
+environment:
+  APP_DOMAIN: app.example.com
+  APP_TAG: "v1.10.1" # pin exact tags; a floating `latest` never auto-deploys
+# Runtime self-healing: doco-cd watches Docker events on this stack. A failing
+# healthcheck -> in-place container restart (redeploy fallback if gone).
+reconciliation:
+  events: [unhealthy]

--- a/examples/single-repo-single-env/app-repo/.doco-cd.yml
+++ b/examples/single-repo-single-env/app-repo/.doco-cd.yml
@@ -1,12 +1,12 @@
-# Deploy config. The VM's doco-cd polls this repo and reconciles deploy/ on
-# every push to main.
+# Deploy config. The doco-cd instance on the host polls this repo and
+# reconciles deploy/ on every push to main.
 #
 # Split by sensitivity:
 #   - Non-secrets live HERE in git: the domain and the deployed image tag.
 #     Bumping APP_TAG is the release — commit + push, doco-cd redeploys.
 #     A CI job can do the bump after the image build (commit with [skip ci]).
-#   - Secrets are NOT here. They live on the VM in secrets.env, loaded by the
-#     doco-cd container and forwarded into compose interpolation via
+#   - Secrets are NOT here. They live on the host in secrets.env, loaded by
+#     the doco-cd container and forwarded into compose interpolation via
 #     PASS_ENV=true (see server/compose.yaml).
 name: app
 working_dir: deploy

--- a/examples/single-repo-single-env/app-repo/deploy/Caddyfile
+++ b/examples/single-repo-single-env/app-repo/deploy/Caddyfile
@@ -1,0 +1,5 @@
+# Edits here auto-apply: doco-cd force-recreates caddy on the next poll after
+# the change lands on main.
+{$APP_DOMAIN} {
+	reverse_proxy app:80
+}

--- a/examples/single-repo-single-env/app-repo/deploy/compose.yaml
+++ b/examples/single-repo-single-env/app-repo/deploy/compose.yaml
@@ -1,0 +1,37 @@
+# The stack doco-cd reconciles. Only caddy publishes ports; the app stays
+# internal to the compose network.
+services:
+  app:
+    # Stand-in for your app image. The tag comes from .doco-cd.yml, so git
+    # always states what runs. whoami is used here so the example runs as-is.
+    image: traefik/whoami:${APP_TAG}
+    restart: unless-stopped
+    environment:
+      # A secret from the VM's secrets.env, arrives via PASS_ENV on the daemon.
+      # `:-` keeps the compose renderable when the var is absent.
+      API_KEY: ${API_KEY:-}
+    # whoami is a scratch image with no shell, so no healthcheck is possible
+    # here. Give your real app one — `reconciliation: [unhealthy]` in
+    # .doco-cd.yml keys off it. Distroless image -> probe with your own binary:
+    #   test: ["CMD", "/app", "healthcheck"]
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      APP_DOMAIN: ${APP_DOMAIN}
+    volumes:
+      # Caddyfile edits auto-apply: doco-cd tracks files a service mounts and
+      # force-recreates ONLY caddy when the content changes. No --watch needed.
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      # Host bind mount so certs survive redeploys — no re-ACME on every deploy.
+      - /srv/app/caddy:/data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:2019/metrics"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s

--- a/examples/single-repo-single-env/app-repo/deploy/compose.yaml
+++ b/examples/single-repo-single-env/app-repo/deploy/compose.yaml
@@ -7,7 +7,8 @@ services:
     image: traefik/whoami:${APP_TAG}
     restart: unless-stopped
     environment:
-      # A secret from the VM's secrets.env, arrives via PASS_ENV on the daemon.
+      # A secret from the host's secrets.env, arrives via PASS_ENV on the
+      # daemon.
       # `:-` keeps the compose renderable when the var is absent.
       API_KEY: ${API_KEY:-}
     # whoami is a scratch image with no shell, so no healthcheck is possible

--- a/examples/single-repo-single-env/server/compose.yaml
+++ b/examples/single-repo-single-env/server/compose.yaml
@@ -1,0 +1,31 @@
+# doco-cd itself. This file lives on the VM (e.g. /opt/doco-cd/), NOT in the
+# app repo — the controller cannot GitOps itself.
+#
+# Poll-only setup: no published ports, webhook/API endpoints stay disabled
+# (their secrets are unset), the VM firewall stays closed.
+services:
+  doco-cd:
+    image: ghcr.io/kimdre/doco-cd:latest # pin tag+digest in real use
+    restart: unless-stopped
+    # secrets.env holds the app stack's secrets. PASS_ENV forwards the daemon's
+    # own env into every deployment's compose interpolation, so ${API_KEY} in
+    # the app compose resolves here — secrets stay on the VM, never in git.
+    env_file:
+      - secrets.env
+    environment:
+      TZ: Etc/UTC
+      POLL_CONFIG_FILE: /etc/doco-cd/poll.yaml
+      PASS_ENV: "true"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./poll.yaml:/etc/doco-cd/poll.yaml:ro
+      - data:/data
+    healthcheck:
+      test: ["CMD", "/doco-cd", "healthcheck"]
+      start_period: 15s
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  data:

--- a/examples/single-repo-single-env/server/compose.yaml
+++ b/examples/single-repo-single-env/server/compose.yaml
@@ -1,15 +1,15 @@
-# doco-cd itself. This file lives on the VM (e.g. /opt/doco-cd/), NOT in the
-# app repo — the controller cannot GitOps itself.
+# doco-cd itself. This file lives on the host (e.g. /opt/doco-cd/), NOT in
+# the app repo — the controller cannot GitOps itself.
 #
 # Poll-only setup: no published ports, webhook/API endpoints stay disabled
-# (their secrets are unset), the VM firewall stays closed.
+# (their secrets are unset), the host firewall stays closed.
 services:
   doco-cd:
     image: ghcr.io/kimdre/doco-cd:latest # pin tag+digest in real use
     restart: unless-stopped
     # secrets.env holds the app stack's secrets. PASS_ENV forwards the daemon's
     # own env into every deployment's compose interpolation, so ${API_KEY} in
-    # the app compose resolves here — secrets stay on the VM, never in git.
+    # the app compose resolves here — secrets stay on the host, never in git.
     env_file:
       - secrets.env
     environment:

--- a/examples/single-repo-single-env/server/poll.yaml
+++ b/examples/single-repo-single-env/server/poll.yaml
@@ -1,5 +1,6 @@
-# What this VM's doco-cd watches. No `target:` -> the repo's bare .doco-cd.yml
-# is used. Push to main -> within one interval the VM runs `docker compose up`.
+# What this doco-cd instance watches. No `target:` -> the repo's bare
+# .doco-cd.yml is used. Push to main -> within one interval doco-cd runs
+# `docker compose up` on the host.
 # Private repo? Add GIT_ACCESS_TOKEN to secrets.env.
 - url: https://github.com/example/app-repo.git
   reference: refs/heads/main

--- a/examples/single-repo-single-env/server/poll.yaml
+++ b/examples/single-repo-single-env/server/poll.yaml
@@ -1,0 +1,6 @@
+# What this VM's doco-cd watches. No `target:` -> the repo's bare .doco-cd.yml
+# is used. Push to main -> within one interval the VM runs `docker compose up`.
+# Private repo? Add GIT_ACCESS_TOKEN to secrets.env.
+- url: https://github.com/example/app-repo.git
+  reference: refs/heads/main
+  interval: 30

--- a/examples/single-repo-single-env/server/secrets.env.example
+++ b/examples/single-repo-single-env/server/secrets.env.example
@@ -1,4 +1,4 @@
-# TEMPLATE — keys only, no values. The real file is secrets.env on the VM:
+# TEMPLATE — keys only, no values. The real file is secrets.env on the host:
 # chmod 600, never committed. The daemon loads it (env_file) and PASS_ENV=true
 # forwards it into the app stack's compose interpolation.
 

--- a/examples/single-repo-single-env/server/secrets.env.example
+++ b/examples/single-repo-single-env/server/secrets.env.example
@@ -1,0 +1,9 @@
+# TEMPLATE — keys only, no values. The real file is secrets.env on the VM:
+# chmod 600, never committed. The daemon loads it (env_file) and PASS_ENV=true
+# forwards it into the app stack's compose interpolation.
+
+# Private repo auth (drop if the repo is public):
+GIT_ACCESS_TOKEN=
+
+# App secrets, referenced as ${API_KEY} in app-repo/deploy/compose.yaml:
+API_KEY=

--- a/examples/single-repo-two-envs/README.md
+++ b/examples/single-repo-two-envs/README.md
@@ -1,6 +1,6 @@
 # Single repo → two environments
 
-One app repo, two VMs (staging + prod). The repo carries **two deploy configs**. Each VM's doco-cd picks its own via the poll `target:` field. Two stacks per environment: `app` and `db`.
+One app repo, two Docker hosts (staging + prod). The repo carries **two deploy configs**. Each host's doco-cd instance picks its own via the poll `target:` field. Two stacks per environment: `app` and `db`.
 
 ## What this example shows
 
@@ -20,19 +20,19 @@ app-repo/                  # your Git repository
   deploy/
     app/compose.yaml       # web stack
     db/compose.yaml        # postgres + one-shot migrate
-server/                    # one copy per VM, e.g. /opt/doco-cd/
-  compose.yaml             # doco-cd + apprise sidecar (same file on both VMs)
-  poll.staging.yaml        # staging VM: no target
-  poll.prod.yaml           # prod VM: target: prod
+server/                    # one copy per host, e.g. /opt/doco-cd/
+  compose.yaml             # doco-cd + apprise sidecar (same file on both hosts)
+  poll.staging.yaml        # staging host: no target
+  poll.prod.yaml           # prod host: target: prod
   secrets.env.example
 ```
 
 ## Try it
 
 1. Push `app-repo/` contents to a Git repository.
-2. On each VM: copy `server/` to `/opt/doco-cd/`, rename the VM's poll file to `poll.yaml`.
+2. On each host: copy `server/` to `/opt/doco-cd/`, rename the host's poll file to `poll.yaml`.
 3. Fill in `secrets.env` (from the example), `chmod 600`.
-4. Create the shared network once per VM: `docker network create appnet`.
+4. Create the shared network once per host: `docker network create appnet`.
 5. `docker compose up -d` in `/opt/doco-cd/`.
 
 ## Release flow

--- a/examples/single-repo-two-envs/README.md
+++ b/examples/single-repo-two-envs/README.md
@@ -1,0 +1,42 @@
+# Single repo → two environments
+
+One app repo, two VMs (staging + prod). The repo carries **two deploy configs**. Each VM's doco-cd picks its own via the poll `target:` field. Two stacks per environment: `app` and `db`.
+
+## What this example shows
+
+- **`target:` is real isolation.** The staging daemon (no `target:`) reads only the bare `.doco-cd.yml`. The prod daemon (`target: prod`) reads only `.doco-cd.prod.yml`. Staging values cannot leak into prod.
+- The prod config repeats only what differs: image tags, domain, log level. Behavior blocks are copied on purpose, so the two files cannot argue.
+- **Separate tags per stack.** The db stack pins its own tag. A web-only release must not recreate the stateful side.
+- Why `reconciliation.events` stays `[unhealthy]` and never gets `die`: the one-shot `migrate` container exits 0 on every deploy by design, and `die` reads that as a failure — an unbounded reconcile loop.
+- Cross-stack networking via an **external network** — each stack is its own compose project.
+- **Deploy notifications** to Telegram (or anything else) via an Apprise sidecar, with a compact body template.
+
+## Layout
+
+```
+app-repo/                  # your Git repository
+  .doco-cd.yml             # staging config (both stacks)
+  .doco-cd.prod.yml        # prod config — only the values that differ
+  deploy/
+    app/compose.yaml       # web stack
+    db/compose.yaml        # postgres + one-shot migrate
+server/                    # one copy per VM, e.g. /opt/doco-cd/
+  compose.yaml             # doco-cd + apprise sidecar (same file on both VMs)
+  poll.staging.yaml        # staging VM: no target
+  poll.prod.yaml           # prod VM: target: prod
+  secrets.env.example
+```
+
+## Try it
+
+1. Push `app-repo/` contents to a Git repository.
+2. On each VM: copy `server/` to `/opt/doco-cd/`, rename the VM's poll file to `poll.yaml`.
+3. Fill in `secrets.env` (from the example), `chmod 600`.
+4. Create the shared network once per VM: `docker network create appnet`.
+5. `docker compose up -d` in `/opt/doco-cd/`.
+
+## Release flow
+
+Merge to `main` → staging deploys within one poll interval. To release to prod, bump the tags in `.doco-cd.prod.yml` (by hand or by a CI release job) and push.
+
+Want prod to move **only** on releases, config included? Point the prod poll at a moving tag (`refs/tags/live`) that your release job force-pushes. Then a compose or Caddyfile merge to `main` cannot reach prod between releases, and moving the tag backward is a complete rollback. See the comment in `poll.prod.yaml`.

--- a/examples/single-repo-two-envs/app-repo/.doco-cd.prod.yml
+++ b/examples/single-repo-two-envs/app-repo/.doco-cd.prod.yml
@@ -1,0 +1,21 @@
+# PROD deploy config. Selected by the prod VM's poll `target: prod` — a
+# targeted daemon reads ONLY this file, never the bare .doco-cd.yml.
+#
+# Deliberately only the values that differ from staging. Anything BEHAVIOURAL
+# (the reconciliation blocks) is copied verbatim on purpose.
+name: app
+working_dir: deploy/app
+environment:
+  APP_TAG: "1c8842de" # written by the release job, never edit by hand
+  APP_DOMAIN: app.example.com
+  LOG_LEVEL: info
+reconciliation:
+  events: [unhealthy]
+---
+name: db
+working_dir: deploy/db
+environment:
+  DB_TAG: "1c8842de" # written by the release job, never edit by hand
+  PG_TAG: "17-alpine"
+reconciliation:
+  events: [unhealthy]

--- a/examples/single-repo-two-envs/app-repo/.doco-cd.prod.yml
+++ b/examples/single-repo-two-envs/app-repo/.doco-cd.prod.yml
@@ -1,5 +1,6 @@
-# PROD deploy config. Selected by the prod VM's poll `target: prod` — a
-# targeted daemon reads ONLY this file, never the bare .doco-cd.yml.
+# PROD deploy config. Selected by the prod doco-cd instance's poll
+# `target: prod` — a targeted daemon reads ONLY this file, never the bare
+# .doco-cd.yml.
 #
 # Deliberately only the values that differ from staging. Anything BEHAVIOURAL
 # (the reconciliation blocks) is copied verbatim on purpose.

--- a/examples/single-repo-two-envs/app-repo/.doco-cd.yml
+++ b/examples/single-repo-two-envs/app-repo/.doco-cd.yml
@@ -1,0 +1,29 @@
+# STAGING deploy config (both stacks). The staging VM polls with no `target:`,
+# so it reads this bare file. The prod VM polls with `target: prod` and reads
+# ONLY .doco-cd.prod.yml — that is real isolation, staging values cannot leak.
+#
+# The rationale for every knob lives here; .doco-cd.prod.yml carries only the
+# values that differ, so the two files cannot argue.
+name: app
+working_dir: deploy/app
+environment:
+  APP_TAG: "3fca2b91" # ci-bumped with the commit sha, never edit by hand
+  APP_DOMAIN: staging.example.com
+  LOG_LEVEL: debug
+# Self-healing: unhealthy -> in-place restart + a notification. Events fired by
+# our own deploys are suppressed, so a tag bump won't self-alert.
+reconciliation:
+  events: [unhealthy]
+---
+name: db
+working_dir: deploy/db
+environment:
+  # The db stack pins its OWN tag, bumped only when migrations/worker code
+  # moved. A web-only release must not recreate the stateful side.
+  DB_TAG: "3fca2b91" # ci-bumped, never edit by hand
+  PG_TAG: "17-alpine"
+# NO `die` here: the one-shot migrate container (restart: "no") exits 0 on
+# every deploy by design, and `die` reads that as a failure — reconcile ->
+# re-run -> die -> an unbounded loop. `unhealthy` only.
+reconciliation:
+  events: [unhealthy]

--- a/examples/single-repo-two-envs/app-repo/.doco-cd.yml
+++ b/examples/single-repo-two-envs/app-repo/.doco-cd.yml
@@ -1,6 +1,7 @@
-# STAGING deploy config (both stacks). The staging VM polls with no `target:`,
-# so it reads this bare file. The prod VM polls with `target: prod` and reads
-# ONLY .doco-cd.prod.yml — that is real isolation, staging values cannot leak.
+# STAGING deploy config (both stacks). The staging doco-cd instance polls with
+# no `target:`, so it reads this bare file. The prod instance polls with
+# `target: prod` and reads ONLY .doco-cd.prod.yml — that is real isolation,
+# staging values cannot leak.
 #
 # The rationale for every knob lives here; .doco-cd.prod.yml carries only the
 # values that differ, so the two files cannot argue.

--- a/examples/single-repo-two-envs/app-repo/deploy/app/compose.yaml
+++ b/examples/single-repo-two-envs/app-repo/deploy/app/compose.yaml
@@ -1,0 +1,30 @@
+# Web stack. Talks to postgres in the OTHER stack (deploy/db) over the
+# external network below — each stack is a separate compose project, so a
+# shared network must be external. Create once per VM:
+#   docker network create appnet
+services:
+  web:
+    image: ghcr.io/example/app:${APP_TAG}
+    restart: unless-stopped
+    ports:
+      - "80:8080"
+    environment:
+      LOG_LEVEL: ${LOG_LEVEL}
+      APP_DOMAIN: ${APP_DOMAIN}
+      # Secret from the VM's secrets.env, forwarded by PASS_ENV on the daemon.
+      DATABASE_URL: postgres://app:${PG_PASSWORD:-}@postgres:5432/app
+    networks:
+      - appnet
+    # Readiness gate for `reconciliation: [unhealthy]`. Distroless image has no
+    # curl — probe with your own binary.
+    healthcheck:
+      test: ["CMD", "/app", "healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+networks:
+  appnet:
+    name: appnet
+    external: true

--- a/examples/single-repo-two-envs/app-repo/deploy/app/compose.yaml
+++ b/examples/single-repo-two-envs/app-repo/deploy/app/compose.yaml
@@ -1,6 +1,6 @@
 # Web stack. Talks to postgres in the OTHER stack (deploy/db) over the
 # external network below — each stack is a separate compose project, so a
-# shared network must be external. Create once per VM:
+# shared network must be external. Create once per host:
 #   docker network create appnet
 services:
   web:
@@ -11,7 +11,8 @@ services:
     environment:
       LOG_LEVEL: ${LOG_LEVEL}
       APP_DOMAIN: ${APP_DOMAIN}
-      # Secret from the VM's secrets.env, forwarded by PASS_ENV on the daemon.
+      # Secret from the host's secrets.env, forwarded by PASS_ENV on the
+      # daemon.
       DATABASE_URL: postgres://app:${PG_PASSWORD:-}@postgres:5432/app
     networks:
       - appnet

--- a/examples/single-repo-two-envs/app-repo/deploy/db/compose.yaml
+++ b/examples/single-repo-two-envs/app-repo/deploy/db/compose.yaml
@@ -7,7 +7,7 @@ services:
     environment:
       POSTGRES_DB: app
       POSTGRES_USER: app
-      POSTGRES_PASSWORD: ${PG_PASSWORD:-} # VM's secrets.env via PASS_ENV
+      POSTGRES_PASSWORD: ${PG_PASSWORD:-} # host's secrets.env via PASS_ENV
     volumes:
       # Host bind mount: data survives redeploys, backups stay boring.
       - /srv/app/pgdata:/var/lib/postgresql/data

--- a/examples/single-repo-two-envs/app-repo/deploy/db/compose.yaml
+++ b/examples/single-repo-two-envs/app-repo/deploy/db/compose.yaml
@@ -1,0 +1,39 @@
+# Database stack: postgres + a one-shot migrate container that runs on every
+# deploy of THIS stack (a web-only release does not touch it — separate tags).
+services:
+  postgres:
+    image: postgres:${PG_TAG}
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: app
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: ${PG_PASSWORD:-} # VM's secrets.env via PASS_ENV
+    volumes:
+      # Host bind mount: data survives redeploys, backups stay boring.
+      - /srv/app/pgdata:/var/lib/postgresql/data
+    networks:
+      - appnet
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  # One-shot: runs migrations, exits 0. This exit is WHY the stack's
+  # reconciliation must never watch `die` (see .doco-cd.yml).
+  migrate:
+    image: ghcr.io/example/app-migrations:${DB_TAG}
+    restart: "no"
+    environment:
+      DATABASE_URL: postgres://app:${PG_PASSWORD:-}@postgres:5432/app
+    networks:
+      - appnet
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+networks:
+  appnet:
+    name: appnet
+    external: true

--- a/examples/single-repo-two-envs/server/compose.yaml
+++ b/examples/single-repo-two-envs/server/compose.yaml
@@ -1,5 +1,5 @@
-# doco-cd + Apprise sidecar. Same file on both VMs — only poll.yaml differs.
-# Lives on the VM (e.g. /opt/doco-cd/), NOT in the app repo.
+# doco-cd + Apprise sidecar. Same file on both hosts — only poll.yaml differs.
+# Lives on the host (e.g. /opt/doco-cd/), NOT in the app repo.
 services:
   doco-cd:
     image: ghcr.io/kimdre/doco-cd:latest # pin tag+digest in real use

--- a/examples/single-repo-two-envs/server/compose.yaml
+++ b/examples/single-repo-two-envs/server/compose.yaml
@@ -1,0 +1,64 @@
+# doco-cd + Apprise sidecar. Same file on both VMs — only poll.yaml differs.
+# Lives on the VM (e.g. /opt/doco-cd/), NOT in the app repo.
+services:
+  doco-cd:
+    image: ghcr.io/kimdre/doco-cd:latest # pin tag+digest in real use
+    restart: unless-stopped
+    # secrets.env: GIT_ACCESS_TOKEN (private repo), PG_PASSWORD (forwarded to
+    # the stacks via PASS_ENV), APPRISE_NOTIFY_URLS (carries the bot token).
+    env_file:
+      - secrets.env
+    environment:
+      TZ: Etc/UTC
+      POLL_CONFIG_FILE: /etc/doco-cd/poll.yaml
+      PASS_ENV: "true"
+      # Notifications -> Telegram (or 100+ other targets) via the Apprise
+      # sidecar. `success` is a MINIMUM level: fires on completed/failed
+      # deploys + reconciliation warnings, never per-poll.
+      APPRISE_API_URL: http://apprise:8000/notify
+      APPRISE_NOTIFY_LEVEL: success
+      # Compact body (default is verbose): identity one-liner, then one line
+      # per deployed commit. Validated at startup — a bad field means the
+      # daemon won't boot. Notes:
+      #   - .Message carries the failure reason and is appended only on
+      #     non-success — without it a failed deploy pings with no error.
+      #   - .Commits is empty on first deploy / failures / reconcile events,
+      #     so the body degrades back to the one-liner.
+      #   - the repo prefix is a literal: each daemon polls one repo anyway.
+      APPRISE_NOTIFY_BODY_TEMPLATE: |-
+        myapp -> {{.Stack}} @ {{.Revision}}{{if .IsReconciliation}} · {{.ReconciliationEvent}}{{else}} in {{.Duration}}{{end}}{{if ne .Level "success"}} — {{.Message}}{{end}}
+        {{- range .Commits }}
+        - {{ . }}
+        {{- end }}
+    depends_on:
+      # started, not healthy: a broken apprise must never block polling.
+      - apprise
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./poll.yaml:/etc/doco-cd/poll.yaml:ro
+      - data:/data
+    healthcheck:
+      test: ["CMD", "/doco-cd", "healthcheck"]
+      start_period: 15s
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Apprise API server — doco-cd's notification transport. Stateless,
+  # internal-only (no published port; reached at apprise:8000 on the compose
+  # network). Turns doco-cd's POST into the actual Telegram/Slack/email call.
+  apprise:
+    image: caronc/apprise:latest
+    restart: unless-stopped
+    environment:
+      TZ: Etc/UTC
+      APPRISE_WORKER_COUNT: 1
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/status"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+volumes:
+  data:

--- a/examples/single-repo-two-envs/server/poll.prod.yaml
+++ b/examples/single-repo-two-envs/server/poll.prod.yaml
@@ -1,4 +1,4 @@
-# PROD VM — copy to /opt/doco-cd/poll.yaml there. `target: prod` picks
+# PROD host — copy to /opt/doco-cd/poll.yaml there. `target: prod` picks
 # .doco-cd.prod.yml, and this daemon never reads the bare .doco-cd.yml.
 #
 # Optional hardening: point `reference` at a moving release tag instead of

--- a/examples/single-repo-two-envs/server/poll.prod.yaml
+++ b/examples/single-repo-two-envs/server/poll.prod.yaml
@@ -1,0 +1,12 @@
+# PROD VM — copy to /opt/doco-cd/poll.yaml there. `target: prod` picks
+# .doco-cd.prod.yml, and this daemon never reads the bare .doco-cd.yml.
+#
+# Optional hardening: point `reference` at a moving release tag instead of
+# main, e.g. refs/tags/live, force-pushed by your CI release job. Then prod
+# moves ONLY on releases — compose/config merges to main cannot reach it in
+# between, and moving the tag backward is a complete rollback (config and
+# image together). doco-cd follows a force-moved tag in both directions.
+- url: https://github.com/example/app-repo.git
+  reference: refs/heads/main
+  interval: 30
+  target: prod

--- a/examples/single-repo-two-envs/server/poll.staging.yaml
+++ b/examples/single-repo-two-envs/server/poll.staging.yaml
@@ -1,4 +1,4 @@
-# STAGING VM — copy to /opt/doco-cd/poll.yaml there. No `target:` -> the bare
+# STAGING host — copy to /opt/doco-cd/poll.yaml there. No `target:` -> the bare
 # .doco-cd.yml (both stacks). Push to main -> staging deploys.
 - url: https://github.com/example/app-repo.git
   reference: refs/heads/main

--- a/examples/single-repo-two-envs/server/poll.staging.yaml
+++ b/examples/single-repo-two-envs/server/poll.staging.yaml
@@ -1,0 +1,5 @@
+# STAGING VM — copy to /opt/doco-cd/poll.yaml there. No `target:` -> the bare
+# .doco-cd.yml (both stacks). Push to main -> staging deploys.
+- url: https://github.com/example/app-repo.git
+  reference: refs/heads/main
+  interval: 30

--- a/examples/single-repo-two-envs/server/secrets.env.example
+++ b/examples/single-repo-two-envs/server/secrets.env.example
@@ -1,0 +1,16 @@
+# TEMPLATE — keys only. The real file is secrets.env on each VM: chmod 600,
+# never committed. PASS_ENV=true forwards these into the stacks' compose
+# interpolation.
+
+# Private repo auth:
+GIT_ACCESS_TOKEN=
+# For tokens with a fixed username (e.g. GitLab deploy tokens,
+# gitlab+deploy-token-N) also set:
+# GIT_ACCESS_TOKEN_USER=
+
+# Forwarded into both stacks (${PG_PASSWORD}):
+PG_PASSWORD=
+
+# Apprise notification targets, comma-separated. Empty -> notifications
+# silently off. Telegram example: tgram://<bot_token>/<chat_id>/
+APPRISE_NOTIFY_URLS=

--- a/examples/single-repo-two-envs/server/secrets.env.example
+++ b/examples/single-repo-two-envs/server/secrets.env.example
@@ -1,4 +1,4 @@
-# TEMPLATE — keys only. The real file is secrets.env on each VM: chmod 600,
+# TEMPLATE — keys only. The real file is secrets.env on each host: chmod 600,
 # never committed. PASS_ENV=true forwards these into the stacks' compose
 # interpolation.
 

--- a/wiki/docs/Getting-Started.md
+++ b/wiki/docs/Getting-Started.md
@@ -23,6 +23,10 @@ If you are new to Doco-CD, follow the pages in this order:
 
     You can find the available tags/versions on the [GitHub Container Registry](https://github.com/kimdre/doco-cd/pkgs/container/doco-cd).
 
+!!! tip "Full working examples"
+    The [`examples/`](https://github.com/kimdre/doco-cd/tree/main/examples) directory in the repository contains complete setups for common scenarios:
+    a single repo deployed to one environment, a single repo deployed to two environments, and a central deployments repo that manages many apps across many VMs.
+
 Find out about the [Core Concepts](Core-Concepts.md) of Doco-CD to understand how the application works and how to configure it.
 
 You can find all available app settings on the [App Settings](App-Settings.md) wiki page.

--- a/wiki/docs/Getting-Started.md
+++ b/wiki/docs/Getting-Started.md
@@ -25,7 +25,7 @@ If you are new to Doco-CD, follow the pages in this order:
 
 !!! tip "Full working examples"
     The [`examples/`](https://github.com/kimdre/doco-cd/tree/main/examples) directory in the repository contains complete setups for common scenarios:
-    a single repo deployed to one environment, a single repo deployed to two environments, and a central deployments repo that manages many apps across many VMs.
+    a single repo deployed to one environment, a single repo deployed to two environments, and a central deployments repo that manages many apps across many Docker hosts.
 
 Find out about the [Core Concepts](Core-Concepts.md) of Doco-CD to understand how the application works and how to configure it.
 


### PR DESCRIPTION
Follow-up to #1453 — the examples I promised there, distilled from three real doco-cd installs I run.

Adds `examples/` with three complete setups. Each replicates every repo it needs: `app-repo/` (or `deployments-repo/`) is what goes to git, `server/` is what goes on the VM. Small README per example explains the pattern and how to try it.

- **single-repo-single-env** — app repo carries its own compose + `.doco-cd.yml`, one VM polls it. Shows image tag pinned in git (bump = release), secrets kept on VM via `PASS_ENV`, poll-only daemon with no open ports, mounted-config auto-apply.
- **single-repo-two-envs** — same repo, staging + prod via poll `target:` isolation. Shows per-stack image pins (stateful side not recreated on web-only release), why reconciliation should not watch `die` when a one-shot migrate container exists, external network between stacks, apprise notifications with a compact body template.
- **deployments-repo** — one central repo deploys many apps to many VMs. Per-VM target files pin every version (nothing floats), per-env compose stubs `include:` the app repo's compose pinned at a sha, secrets SOPS-encrypted in the repo and decrypted by the daemon with an age/KMS key.

All configs are things running in production for me right now, only names sanitized. YAML validated, composes render with `docker compose config`.

Docs change is minimal per the idea to keep examples in the repo: one tip box in Getting Started linking to the directory. 

I am sure you have usages which are different from this. And maybe I even have some wrong patterns somewhere? IF so this PR is a good opportunity to fix that and publish these first examples. Then you could add yours following the idea
