### PR TITLE
fix(docker): reload registry auth from docker config on every lookup

### DIFF
--- a/internal/docker/cli_config.go
+++ b/internal/docker/cli_config.go
@@ -1,0 +1,40 @@
+package docker
+
+import (
+	"log/slog"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/credentials"
+)
+
+// reloadConfigCli re-reads the docker config file from disk on every
+// ConfigFile() call instead of returning the snapshot the docker cli caches at
+// startup. Registries with short-lived tokens (ECR, GCR, ACR) refresh the
+// mounted config.json while the daemon runs; with the cached snapshot every
+// pull fails after the startup token expires until the daemon restarts.
+// All auth lookups (compose pulls, distribution inspects, swarm) resolve the
+// config at call time, so they all pick up the fresh file through this wrapper.
+type reloadConfigCli struct {
+	command.Cli
+}
+
+// ConfigFile loads the docker config fresh from disk. On a read or parse
+// error (e.g. the file is being rewritten at that moment) it falls back to
+// the snapshot cached by the underlying cli.
+func (c reloadConfigCli) ConfigFile() *configfile.ConfigFile {
+	fresh, err := config.Load(config.Dir())
+	if err != nil {
+		slog.Warn("failed to reload docker config, using cached snapshot", slog.String("error", err.Error()))
+		return c.Cli.ConfigFile()
+	}
+
+	// Mirror config.LoadDefaultConfigFile: detect the platform default
+	// credentials store when the file configures no auth at all.
+	if !fresh.ContainsAuth() {
+		fresh.CredentialsStore = credentials.DetectDefaultStore(fresh.CredentialsStore)
+	}
+
+	return fresh
+}

--- a/internal/docker/cli_config_test.go
+++ b/internal/docker/cli_config_test.go
@@ -1,0 +1,100 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
+	configtypes "github.com/docker/cli/cli/config/types"
+)
+
+// staticConfigCli stands in for the underlying docker cli with its
+// startup-cached config snapshot.
+type staticConfigCli struct {
+	command.Cli
+	cfg *configfile.ConfigFile
+}
+
+func (s staticConfigCli) ConfigFile() *configfile.ConfigFile { return s.cfg }
+
+func useDockerConfigDir(t *testing.T, dir string) {
+	t.Helper()
+
+	orig := config.Dir()
+
+	config.SetDir(dir)
+	t.Cleanup(func() { config.SetDir(orig) })
+}
+
+func writeDockerConfig(t *testing.T, dir, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, config.ConfigFileName), []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write docker config: %v", err)
+	}
+}
+
+func TestReloadConfigCliPicksUpConfigChanges(t *testing.T) {
+	dir := t.TempDir()
+	useDockerConfigDir(t, dir)
+
+	writeDockerConfig(t, dir, `{"auths":{"registry.example.com":{"auth":"dXNlcjp0b2tlbi1vbmU="}}}`)
+
+	cli := reloadConfigCli{staticConfigCli{cfg: configfile.New("startup-snapshot")}}
+
+	// LoadFromReader decodes the base64 `auth` field into Username/Password.
+	if got := cli.ConfigFile().AuthConfigs["registry.example.com"].Password; got != "token-one" {
+		t.Fatalf("expected password from initial config file, got %q", got)
+	}
+
+	// Simulate a credential refresh on disk (e.g. an ECR token rotation cron).
+	writeDockerConfig(t, dir, `{"auths":{"registry.example.com":{"auth":"dXNlcjp0b2tlbi10d28="}}}`)
+
+	if got := cli.ConfigFile().AuthConfigs["registry.example.com"].Password; got != "token-two" {
+		t.Fatalf("expected password from refreshed config file, got %q", got)
+	}
+}
+
+func TestReloadConfigCliFallsBackToSnapshotOnUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	useDockerConfigDir(t, dir)
+
+	writeDockerConfig(t, dir, `{malformed`)
+
+	snapshot := configfile.New("startup-snapshot")
+	snapshot.AuthConfigs = map[string]configtypes.AuthConfig{
+		"registry.example.com": {Auth: "c25hcHNob3Q="},
+	}
+
+	cli := reloadConfigCli{staticConfigCli{cfg: snapshot}}
+
+	if got := cli.ConfigFile(); got != snapshot {
+		t.Fatalf("expected fallback to the cached snapshot, got %+v", got)
+	}
+}
+
+func TestReloadConfigCliMissingFileReturnsEmptyConfig(t *testing.T) {
+	dir := t.TempDir()
+	useDockerConfigDir(t, dir)
+
+	snapshot := configfile.New("startup-snapshot")
+	snapshot.AuthConfigs = map[string]configtypes.AuthConfig{
+		"registry.example.com": {Auth: "c25hcHNob3Q="},
+	}
+
+	cli := reloadConfigCli{staticConfigCli{cfg: snapshot}}
+
+	// Missing file is not an error: the daemon must see the credential removal,
+	// not keep serving the stale snapshot.
+	got := cli.ConfigFile()
+	if got == snapshot {
+		t.Fatal("expected a fresh config, got the cached snapshot")
+	}
+
+	if len(got.AuthConfigs) != 0 {
+		t.Fatalf("expected no auth configs from a missing file, got %+v", got.AuthConfigs)
+	}
+}

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -128,7 +128,10 @@ func CreateDockerCliWithContext(quiet bool, dockerContext string) (command.Cli, 
 			contextName, strings.TrimSpace(initErrBuf.String()))
 	}
 
-	return dockerCli, nil
+	// Wrap so ConfigFile() re-reads the docker config from disk on every auth
+	// lookup — required for short-lived registry tokens (ECR etc.) that get
+	// refreshed on disk while the daemon runs. See reloadConfigCli.
+	return reloadConfigCli{dockerCli}, nil
 }
 
 /*

--- a/wiki/docs/Advanced/Container-Registry-Authentication.md
+++ b/wiki/docs/Advanced/Container-Registry-Authentication.md
@@ -49,6 +49,9 @@ services:
 !!! note "File permissions"
     Make sure the mounted file has the correct permissions and is readable inside the container.
 
+!!! tip "Short-lived registry tokens (ECR, GCR, ACR)"
+    Doco-CD re-reads the config file from disk on every registry auth lookup, so credentials refreshed on disk (for example an ECR token rotated by a cron with `aws ecr get-login-password | docker login`) take effect without a restart of doco-cd.
+
 ## Using a custom docker config file
 
 1. Encode your credentials to base64 (here we use `printf` to avoid the trailing newline, you can also use `echo -n`):


### PR DESCRIPTION
Implements option 1 from discussion #1701.

Docker cli loads `config.json` once at startup and caches the struct for whole process lifetime. Registries with short-lived tokens (ECR, GCR, ACR) refresh the mounted file while daemon runs, but every auth lookup keeps using the startup snapshot — after token expiry all pulls fail until daemon restart.

The fix is a thin wrapper around `command.Cli` that re-reads the config file from disk on every `ConfigFile()` call. This covers all auth lookup sites with one change: compose resolves pull auth via `s.dockerCli.ConfigFile()` per pull (`pkg/compose/pull.go`), and our own `RetrieveAuthTokenFromImage` / HEAD digest / swarm sites do the same — they all go through the interface, so all get fresh file. Patching only doco-cd call sites would not be enough, actual pull auth is resolved inside the compose library.

Details:

- On read/parse error (e.g. file is mid-rewrite) the wrapper falls back to the cached startup snapshot and logs a warning. `docker login` writes atomically (temp file + rename), so this path is rare.
- Missing file is not treated as error, same as docker cli: returns empty config, so credential removal on disk takes effect too.
- Mirrors `LoadDefaultConfigFile`: detects platform default credentials store when the file has no auth.
- `DOCKER_AUTH_CONFIG` keeps working — it is resolved from env inside `GetCredentialsStore()` on every call, not stored in the struct.
- Each call returns its own fresh struct, so concurrent deployments share nothing — no races.
- Cost is one small file read per auth lookup, negligible next to registry round-trip.

Added unit tests for the reload, fallback and missing-file paths, plus a docs tip on the registry auth page that rotated tokens now take effect without restart.

