### PR TITLE
fix(scheduler): preserve manual last run during state updates

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -475,6 +475,8 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 				nextRun:     schedule.Next(now),
 				deployment:  deploymentID,
 				cfg:         cfg,
+				// Keep last run across fingerprint changes (schedule/label edits).
+				lastRun: prevState.lastRun,
 			}
 
 			s.states[job.key] = state
@@ -1547,11 +1549,23 @@ func schedulerNow() time.Time {
 	return time.Now().In(time.Local)
 }
 
+// setRuntimeStatesSnapshot merges in the loop's recomputed states, keeping
+// the newer lastRun so a manually triggered run isn't wiped by the next tick.
 func setRuntimeStatesSnapshot(states map[string]scheduledJobState) {
 	runtimeStatesMu.Lock()
 	defer runtimeStatesMu.Unlock()
 
-	runtimeStates = copyMapLocked(states)
+	merged := make(map[string]scheduledJobState, len(states))
+
+	for key, state := range states {
+		if existing, ok := runtimeStates[key]; ok && existing.lastRun.After(state.lastRun) {
+			state.lastRun = existing.lastRun
+		}
+
+		merged[key] = state
+	}
+
+	runtimeStates = merged
 }
 
 func getRuntimeStatesSnapshot() map[string]scheduledJobState {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -360,6 +360,40 @@ func TestStatusForScheduledJob(t *testing.T) {
 	}
 }
 
+// TestSetRuntimeStatesSnapshot_PreservesNewerManualLastRun guards against a
+// manual TriggerNow's last_run_at being wiped by the scheduler's next tick.
+func TestSetRuntimeStatesSnapshot_PreservesNewerManualLastRun(t *testing.T) {
+	key := "container:project/service"
+
+	runtimeStatesMu.Lock()
+	runtimeStates = map[string]scheduledJobState{}
+	runtimeStatesMu.Unlock()
+
+	manualRun := time.Now()
+	setRuntimeLastRun(key, manualRun)
+
+	// Simulate the loop's next refresh, unaware of the manual run.
+	setRuntimeStatesSnapshot(map[string]scheduledJobState{
+		key: {nextRun: manualRun.Add(time.Hour)},
+	})
+
+	got := getRuntimeStatesSnapshot()[key]
+	if !got.lastRun.Equal(manualRun) {
+		t.Fatalf("expected manually triggered last run %v to survive scheduler refresh, got %v", manualRun, got.lastRun)
+	}
+
+	// A genuinely newer lastRun must still win.
+	newerRun := manualRun.Add(2 * time.Hour)
+	setRuntimeStatesSnapshot(map[string]scheduledJobState{
+		key: {lastRun: newerRun},
+	})
+
+	got = getRuntimeStatesSnapshot()[key]
+	if !got.lastRun.Equal(newerRun) {
+		t.Fatalf("expected newer scheduler-tracked last run %v to win, got %v", newerRun, got.lastRun)
+	}
+}
+
 func TestUpdateRuntimeRunStatus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This pull request improves the reliability of scheduled job state tracking by ensuring that a manually triggered job's last run timestamp is not accidentally overwritten by the scheduler's periodic refresh. The changes also add tests to verify this behavior and clarify the intent in the code.

**State management improvements:**

* Updated the `setRuntimeStatesSnapshot` function in `scheduler.go` to merge existing `lastRun` timestamps, ensuring that a more recent manual run is not overwritten by the scheduler loop. This preserves the correct last run time when jobs are triggered manually or when job configurations change.
* Modified the job state refresh logic in `refreshJobs` to retain the previous `lastRun` value across fingerprint changes, such as schedule or label edits.

**Testing enhancements:**

* Added a new test, `TestSetRuntimeStatesSnapshot_PreservesNewerManualLastRun`, to verify that a manually triggered job's `last_run_at` survives scheduler refreshes and that the most recent timestamp always wins.