### PR TITLE
feat(notification): name services whose image moved on tag bump

### DIFF
--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -619,7 +619,7 @@ func DeployedServicesWithChangedImageDigests(ctx context.Context, dockerCli comm
 // compare equal. A digest-pinned reference is already exact and is left alone; only a
 // tag-less reference needs `:latest` filled in.
 //
-// An unparseable reference is returned untouched: comparing two raw strings is still
+// An unparsable reference is returned untouched: comparing two raw strings is still
 // better than dropping the comparison entirely.
 func normalizeImageRef(ref string) string {
 	if ref == "" {

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -525,6 +525,7 @@ func PullImages(ctx context.Context, dockerCli command.Cli, projectName string) 
 var (
 	registryDigestLookup             = registryDigestForRef           // registryDigestLookup fetches registry digests for image refs, can be overridden in tests
 	deployedServiceDigestLookup      = getDeployedServiceImageDigests // deployedServiceDigestLookup fetches deployed service image digests, can be overridden in tests
+	deployedServiceRefLookup         = getDeployedServiceImageRefs    // deployedServiceRefLookup fetches deployed service image references, can be overridden in tests
 	registryDigestHeadLookup         = registryDigestForRefViaHEAD
 	registryDigestDistributionLookup = registryDigestForRefViaDistributionInspect
 )
@@ -603,6 +604,159 @@ func DeployedServicesWithChangedImageDigests(ctx context.Context, dockerCli comm
 			)
 
 			changedServices = append(changedServices, serviceName)
+		}
+	}
+
+	slices.Sort(changedServices)
+
+	return changedServices, nil
+}
+
+// normalizeImageRef returns a comparable form of an image reference.
+//
+// Docker reports a deployed image in whatever form it was pulled while compose reports
+// what the project file says, so `nginx` and `docker.io/library/nginx:latest` have to
+// compare equal. A digest-pinned reference is already exact and is left alone; only a
+// tag-less reference needs `:latest` filled in.
+//
+// An unparseable reference is returned untouched: comparing two raw strings is still
+// better than dropping the comparison entirely.
+func normalizeImageRef(ref string) string {
+	if ref == "" {
+		return ""
+	}
+
+	parsed, err := distreference.ParseNormalizedNamed(ref)
+	if err != nil {
+		return ref
+	}
+
+	if _, ok := parsed.(distreference.Canonical); ok {
+		return parsed.String()
+	}
+
+	return distreference.TagNameOnly(parsed).String()
+}
+
+// getDeployedServiceImageRefs returns a map of service name to the image reference of
+// the container or swarm service currently deployed for it.
+//
+// Unlike getDeployedServiceImageDigests this needs no registry round trip and no image
+// inspect, which is what makes it cheap enough to run on every deployment instead of
+// only under force_image_pull.
+func getDeployedServiceImageRefs(ctx context.Context, dockerCli command.Cli, swarmMode bool, projectName string, logger *slog.Logger) (map[string]string, error) {
+	deployed := make(map[string]string)
+
+	if swarmMode {
+		services, err := swarmInternal.GetStackServices(ctx, dockerCli.Client(), projectName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list swarm services for %s: %w", projectName, err)
+		}
+
+		ns := convert.NewNamespace(projectName)
+		for _, svc := range services {
+			deployed[ns.Descope(svc.Spec.Name)] = svc.Spec.TaskTemplate.ContainerSpec.Image
+		}
+
+		logger.Debug("resolved deployed service image references", slog.String("project", projectName), slog.Int("services", len(deployed)))
+
+		return deployed, nil
+	}
+
+	containers, err := GetProjectContainers(ctx, dockerCli, projectName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list project containers for %s: %w", projectName, err)
+	}
+
+	selected := make(map[string]api.ContainerSummary)
+
+	for _, cont := range containers {
+		svcName := cont.Labels[api.ServiceLabel]
+		if svcName == "" {
+			continue
+		}
+
+		existing, ok := selected[svcName]
+		if !ok || (existing.State != container.StateRunning && cont.State == container.StateRunning) {
+			selected[svcName] = cont
+		}
+	}
+
+	for svcName, cont := range selected {
+		deployed[svcName] = cont.Image
+	}
+
+	logger.Debug("resolved deployed service image references", slog.String("project", projectName), slog.Int("services", len(deployed)))
+
+	return deployed, nil
+}
+
+// DeployedServicesWithChangedImageRefs returns the sorted names of services whose
+// configured image reference differs from the one currently deployed.
+//
+// This is the tag-level counterpart of DeployedServicesWithChangedImageDigests. It
+// answers "which services does this deployment move" for the ordinary case of a tag
+// bump in the deploy config, where the digest comparison never runs because
+// force_image_pull is off. It is local only, so it costs no registry lookups.
+//
+// It deliberately under-reports rather than guess, because it feeds a notification and
+// a wrong service name is worse than a missing one:
+//   - nothing deployed yet, i.e. the first deployment of this stack, yields no services;
+//     the stack level notification already says the whole stack came up
+//   - a service whose deployed reference cannot be determined is skipped
+//
+// A service that is configured but has no deployed counterpart while other services do
+// IS reported: it is genuinely arriving with this deployment.
+func DeployedServicesWithChangedImageRefs(ctx context.Context, dockerCli command.Cli, swarmMode bool, project *types.Project, logger *slog.Logger) ([]string, error) {
+	if project == nil {
+		return nil, nil
+	}
+
+	deployedRefs, err := deployedServiceRefLookup(ctx, dockerCli, swarmMode, project.Name, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(deployedRefs) == 0 {
+		return nil, nil
+	}
+
+	var changedServices []string
+
+	for _, svc := range project.Services {
+		// Scale-0 services never produce a container, so they have nothing to compare.
+		if svc.Image == "" || isScaledToZero(svc) {
+			continue
+		}
+
+		configuredRef := normalizeImageRef(svc.Image)
+
+		deployedRaw, ok := deployedRefs[svc.Name]
+		if !ok {
+			logger.Debug("service is not deployed yet, treating as changed", slog.String("service", svc.Name), slog.String("ref", svc.Image))
+
+			changedServices = append(changedServices, svc.Name)
+
+			continue
+		}
+
+		deployedRef := normalizeImageRef(deployedRaw)
+		if deployedRef == "" {
+			logger.Debug("deployed image reference unavailable, skipping service", slog.String("service", svc.Name), slog.String("ref", svc.Image))
+
+			continue
+		}
+
+		if deployedRef != configuredRef {
+			logger.Info("service image reference changed",
+				slog.String("service", svc.Name),
+				slog.Group("image",
+					slog.String("deployed", deployedRef),
+					slog.String("configured", configuredRef),
+				),
+			)
+
+			changedServices = append(changedServices, svc.Name)
 		}
 	}
 

--- a/internal/docker/images.go
+++ b/internal/docker/images.go
@@ -638,6 +638,48 @@ func normalizeImageRef(ref string) string {
 	return distreference.TagNameOnly(parsed).String()
 }
 
+// refTag returns the tag of a reference, defaulting to `latest` when it carries none.
+func refTag(named distreference.Named) string {
+	if tagged, ok := named.(distreference.Tagged); ok {
+		return tagged.Tag()
+	}
+
+	return "latest"
+}
+
+// imageRefsEqual reports whether a deployed image reference is the same image as the
+// configured one.
+//
+// A literal comparison does not work. Swarm records the digest it resolved onto the
+// reference it deployed (`nginx:1.27@sha256:...`) while a compose project normally
+// configures a plain tag (`nginx:1.27`), so every tagged swarm service would be flagged
+// on every deployment. The comparison therefore follows what the CONFIGURATION asks for:
+//
+//   - configured by tag: compare repository and tag, ignore any deployed digest
+//   - configured by digest: compare repository and digest, ignore any tag
+func imageRefsEqual(configured, deployed string) bool {
+	confNamed, confErr := distreference.ParseNormalizedNamed(configured)
+	deplNamed, deplErr := distreference.ParseNormalizedNamed(deployed)
+
+	if confErr != nil || deplErr != nil {
+		// One side is not a reference we can reason about. Comparing the raw strings is
+		// still better than declaring them equal.
+		return configured == deployed
+	}
+
+	if distreference.TrimNamed(confNamed).String() != distreference.TrimNamed(deplNamed).String() {
+		return false
+	}
+
+	if confCanonical, pinned := confNamed.(distreference.Canonical); pinned {
+		deplCanonical, ok := deplNamed.(distreference.Canonical)
+
+		return ok && confCanonical.Digest() == deplCanonical.Digest()
+	}
+
+	return refTag(confNamed) == refTag(deplNamed)
+}
+
 // getDeployedServiceImageRefs returns a map of service name to the image reference of
 // the container or swarm service currently deployed for it.
 //
@@ -740,18 +782,17 @@ func DeployedServicesWithChangedImageRefs(ctx context.Context, dockerCli command
 			continue
 		}
 
-		deployedRef := normalizeImageRef(deployedRaw)
-		if deployedRef == "" {
+		if deployedRaw == "" {
 			logger.Debug("deployed image reference unavailable, skipping service", slog.String("service", svc.Name), slog.String("ref", svc.Image))
 
 			continue
 		}
 
-		if deployedRef != configuredRef {
+		if !imageRefsEqual(svc.Image, deployedRaw) {
 			logger.Info("service image reference changed",
 				slog.String("service", svc.Name),
 				slog.Group("image",
-					slog.String("deployed", deployedRef),
+					slog.String("deployed", normalizeImageRef(deployedRaw)),
 					slog.String("configured", configuredRef),
 				),
 			)

--- a/internal/docker/images_test.go
+++ b/internal/docker/images_test.go
@@ -579,3 +579,152 @@ func requireRegistryIntegrationTestGate(t *testing.T) {
 		t.Skipf("set %s=1 to run registry integration tests", registryIntegrationEnvVar)
 	}
 }
+
+func TestNormalizeImageRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{name: "empty stays empty", ref: "", want: ""},
+		{name: "bare name gets registry and tag", ref: "nginx", want: "docker.io/library/nginx:latest"},
+		{name: "tagged name gets registry", ref: "nginx:1.27", want: "docker.io/library/nginx:1.27"},
+		{name: "fully qualified is stable", ref: "docker.io/library/nginx:latest", want: "docker.io/library/nginx:latest"},
+		{name: "private registry is preserved", ref: "637423286173.dkr.ecr.eu-central-1.amazonaws.com/login-be:20260824-e5136680", want: "637423286173.dkr.ecr.eu-central-1.amazonaws.com/login-be:20260824-e5136680"},
+		{name: "digest pin is left exact", ref: "nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000", want: "docker.io/library/nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+		{name: "unparseable ref is returned untouched", ref: "NOT A REF", want: "NOT A REF"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizeImageRef(tc.ref); got != tc.want {
+				t.Fatalf("normalizeImageRef(%q) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeployedServicesWithChangedImageRefs(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	expectedLookupErr := errors.New("deployed lookup failed")
+
+	oldRefLookup := deployedServiceRefLookup
+
+	t.Cleanup(func() {
+		deployedServiceRefLookup = oldRefLookup
+	})
+
+	tests := []struct {
+		name              string
+		project           *types.Project
+		deployedRefs      map[string]string
+		deployedLookupErr error
+		wantChanged       []string
+		wantErr           error
+	}{
+		{
+			name:        "nil project returns nothing",
+			project:     nil,
+			wantChanged: nil,
+		},
+		{
+			name: "first deployment of a stack reports nothing",
+			project: &types.Project{
+				Name:     "test",
+				Services: types.Services{"web": {Name: "web", Image: "nginx:1.27"}},
+			},
+			deployedRefs: map[string]string{},
+			wantChanged:  nil,
+		},
+		{
+			name: "tag bump names only the moved service",
+			project: &types.Project{
+				Name: "test",
+				Services: types.Services{
+					"web": {Name: "web", Image: "nginx:1.28"},
+					"db":  {Name: "db", Image: "postgres:17"},
+				},
+			},
+			deployedRefs: map[string]string{"web": "nginx:1.27", "db": "postgres:17"},
+			wantChanged:  []string{"web"},
+		},
+		{
+			name: "equivalent references do not count as a change",
+			project: &types.Project{
+				Name:     "test",
+				Services: types.Services{"web": {Name: "web", Image: "nginx"}},
+			},
+			deployedRefs: map[string]string{"web": "docker.io/library/nginx:latest"},
+			wantChanged:  nil,
+		},
+		{
+			name: "service new to an existing stack is reported",
+			project: &types.Project{
+				Name: "test",
+				Services: types.Services{
+					"web":    {Name: "web", Image: "nginx:1.27"},
+					"worker": {Name: "worker", Image: "nginx:1.27"},
+				},
+			},
+			deployedRefs: map[string]string{"web": "nginx:1.27"},
+			wantChanged:  []string{"worker"},
+		},
+		{
+			name: "service without an image is skipped",
+			project: &types.Project{
+				Name: "test",
+				Services: types.Services{
+					"built": {Name: "built"},
+					"web":   {Name: "web", Image: "nginx:1.28"},
+				},
+			},
+			deployedRefs: map[string]string{"web": "nginx:1.27", "built": "test-built:latest"},
+			wantChanged:  []string{"web"},
+		},
+		{
+			name: "unknown deployed reference is skipped rather than guessed",
+			project: &types.Project{
+				Name:     "test",
+				Services: types.Services{"web": {Name: "web", Image: "nginx:1.28"}},
+			},
+			deployedRefs: map[string]string{"web": ""},
+			wantChanged:  nil,
+		},
+		{
+			name: "lookup error is returned",
+			project: &types.Project{
+				Name:     "test",
+				Services: types.Services{"web": {Name: "web", Image: "nginx:1.28"}},
+			},
+			deployedLookupErr: expectedLookupErr,
+			wantErr:           expectedLookupErr,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			deployedServiceRefLookup = func(context.Context, command.Cli, bool, string, *slog.Logger) (map[string]string, error) {
+				if tc.deployedLookupErr != nil {
+					return nil, tc.deployedLookupErr
+				}
+
+				return tc.deployedRefs, nil
+			}
+
+			changed, err := DeployedServicesWithChangedImageRefs(ctx, nil, false, tc.project, logger)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			}
+
+			if !slices.Equal(changed, tc.wantChanged) {
+				t.Fatalf("changed = %v, want %v", changed, tc.wantChanged)
+			}
+		})
+	}
+}

--- a/internal/docker/images_test.go
+++ b/internal/docker/images_test.go
@@ -594,7 +594,7 @@ func TestNormalizeImageRef(t *testing.T) {
 		{name: "fully qualified is stable", ref: "docker.io/library/nginx:latest", want: "docker.io/library/nginx:latest"},
 		{name: "private registry is preserved", ref: "637423286173.dkr.ecr.eu-central-1.amazonaws.com/login-be:20260824-e5136680", want: "637423286173.dkr.ecr.eu-central-1.amazonaws.com/login-be:20260824-e5136680"},
 		{name: "digest pin is left exact", ref: "nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000", want: "docker.io/library/nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000"},
-		{name: "unparseable ref is returned untouched", ref: "NOT A REF", want: "NOT A REF"},
+		{name: "unparsable ref is returned untouched", ref: "NOT A REF", want: "NOT A REF"},
 	}
 
 	for _, tc := range tests {

--- a/internal/docker/images_test.go
+++ b/internal/docker/images_test.go
@@ -608,6 +608,49 @@ func TestNormalizeImageRef(t *testing.T) {
 	}
 }
 
+func TestImageRefsEqual(t *testing.T) {
+	t.Parallel()
+
+	const (
+		digestA = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		digestB = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	)
+
+	tests := []struct {
+		name       string
+		configured string
+		deployed   string
+		want       bool
+	}{
+		{name: "identical tags", configured: "nginx:1.27", deployed: "nginx:1.27", want: true},
+		{name: "familiar and fully qualified are the same image", configured: "nginx", deployed: "docker.io/library/nginx:latest", want: true},
+		{name: "different tag is a change", configured: "nginx:1.28", deployed: "nginx:1.27", want: false},
+		{name: "different repository is a change", configured: "nginx:1.27", deployed: "httpd:1.27", want: false},
+		// Swarm pins the digest it resolved onto the deployed reference. A tag-based
+		// configuration must ignore it, otherwise every tagged swarm service reads as
+		// changed on every deployment.
+		{name: "swarm deployed digest is ignored for a tag-based config", configured: "nginx:1.27", deployed: "nginx:1.27@" + digestA, want: true},
+		{name: "swarm deployed digest is ignored, tag still compared", configured: "nginx:1.28", deployed: "nginx:1.27@" + digestA, want: false},
+		// A digest-pinned configuration means the digest IS the identity.
+		{name: "digest pinned config matches same digest", configured: "nginx@" + digestA, deployed: "nginx@" + digestA, want: true},
+		{name: "digest pinned config matches same digest under any tag", configured: "nginx@" + digestA, deployed: "nginx:1.27@" + digestA, want: true},
+		{name: "digest pinned config sees a different digest", configured: "nginx@" + digestA, deployed: "nginx@" + digestB, want: false},
+		{name: "digest pinned config against an undigested deployment", configured: "nginx@" + digestA, deployed: "nginx:1.27", want: false},
+		{name: "unparsable refs fall back to raw comparison", configured: "NOT A REF", deployed: "NOT A REF", want: true},
+		{name: "unparsable ref against a real one", configured: "NOT A REF", deployed: "nginx:1.27", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := imageRefsEqual(tc.configured, tc.deployed); got != tc.want {
+				t.Fatalf("imageRefsEqual(%q, %q) = %v, want %v", tc.configured, tc.deployed, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDeployedServicesWithChangedImageRefs(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -662,6 +705,23 @@ func TestDeployedServicesWithChangedImageRefs(t *testing.T) {
 			},
 			deployedRefs: map[string]string{"web": "docker.io/library/nginx:latest"},
 			wantChanged:  nil,
+		},
+		{
+			// Swarm reports `<tag>@<digest>`; a tag-based config must not read that as
+			// a change, or every tagged swarm service is flagged on every deployment.
+			name: "swarm digest on the deployed ref is not a change",
+			project: &types.Project{
+				Name: "test",
+				Services: types.Services{
+					"web": {Name: "web", Image: "nginx:1.27"},
+					"db":  {Name: "db", Image: "postgres:17"},
+				},
+			},
+			deployedRefs: map[string]string{
+				"web": "nginx:1.27@sha256:1111111111111111111111111111111111111111111111111111111111111111",
+				"db":  "postgres:17@sha256:2222222222222222222222222222222222222222222222222222222222222222",
+			},
+			wantChanged: nil,
 		},
 		{
 			name: "service new to an existing stack is reported",

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -90,7 +90,7 @@ type Metadata struct {
 	AffectedActorName   string
 	Commits             []git.CommitInfo // commits deployed since the last deploy; empty on first deploy/failure/OCI
 	Duration            time.Duration    // time from job start to the notification; zero when no deploy/destroy ran
-	ChangedServices     []string         // services force-recreated by this deploy or with image digest drift; empty when the whole stack is (re)deployed
+	ChangedServices     []string         // services force-recreated by this deploy, or whose image moved; empty on the first deployment of a stack
 }
 
 // TemplateData is the data exposed to a user-configured notification body template.

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -117,7 +117,7 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 	// Check for external secret changes and current deployed commit
 	var (
 		imagesChanged        bool     // Flag to indicate if images have changed
-		imageChangedServices []string // Services whose deployed image digest drifted from the registry
+		imageChangedServices []string // Services whose image moved: digest drift under force_image_pull, otherwise a changed image reference
 	)
 
 	// Compare external secrets if a secret provider is configured
@@ -365,6 +365,20 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 			)
 
 			return ErrSkipDeployment
+		}
+
+		// The digest comparison above only runs under force_image_pull, but a tag bump in
+		// the deploy config moves images too and its services are knowable without any
+		// registry round trip. Deciding to deploy is already done at this point, so this
+		// only enriches the notification and must never change the outcome: an error is
+		// logged and dropped rather than failing a deployment that is going ahead.
+		if len(imageChangedServices) == 0 {
+			refChangedServices, err := docker.DeployedServicesWithChangedImageRefs(ctx, s.Docker.Cmd, s.Docker.SwarmMode, s.Docker.Project, stageLog)
+			if err != nil {
+				stageLog.Warn("failed to compare deployed image references", slog.String("err", err.Error()))
+			} else {
+				imageChangedServices = refChangedServices
+			}
 		}
 
 		s.DeployState.changedServices = changedServices

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -143,7 +143,7 @@ type Docker struct {
 // DeploymentState holds the dynamic state information during the deployment process.
 type DeploymentState struct {
 	changedServices      []docker.Change
-	imageChangedServices []string // services whose deployed image digest drifted from the registry (force_image_pull)
+	imageChangedServices []string // services whose image moved: digest drift under force_image_pull, otherwise a changed image reference
 	ignoredInfo          docker.IgnoredInfo
 	DeployedCommit       string // previously-deployed commit SHA, carried to post-deploy for the changelog
 }


### PR DESCRIPTION
`.ChangedServices` stays empty on plain tag bump. Two sources fill it — file-mount force-recreates, and digest drift behind `force_image_pull` (#1692). Tag bump in deploy config hits neither, so on normal deploy nothing is named.

Adds `DeployedServicesWithChangedImageRefs`: configured image ref against deployed one. Local only, no registry round trip, so it can run on every deploy where digest path did not answer already. Refs are normalized first, `nginx` and `docker.io/library/nginx:latest` do not count as change.

Runs after the skip decision, and error is logged, not returned — this fills notification only, it must not decide if deploy happens.

Cases:

- first deploy of stack — nothing, stack message already says it came up
- deployed ref cannot be determined — service skipped
- service new to already deployed stack — reported

15 unit tests. `go build`, `go vet` and `golangci-lint run ./...` clean.
