### PR TITLE
fix(e2e): scope daemon image by pid and remove it on teardown

### DIFF
--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -45,6 +45,8 @@ type Harness struct {
 	worktree   string // host worktree dir used to build fixture/commits
 	dataVolume string
 
+	daemonImage string // tag built for this scenario, removed on teardown
+
 	wt     *git.Worktree
 	docker *client.Client
 	net    *testcontainers.DockerNetwork
@@ -161,6 +163,7 @@ func (h *Harness) startDaemon(pollConfigPath string) {
 	h.t.Helper()
 
 	image := h.buildDaemonImage()
+	h.daemonImage = image
 
 	daemon, err := testcontainers.GenericContainer(h.ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
@@ -223,7 +226,10 @@ func gitServerImageName() string {
 func (h *Harness) buildDaemonImage() string {
 	h.t.Helper()
 
-	tag := "doco-cd-e2e:" + h.scenario
+	// Scoped by pid as well as scenario: two concurrent runs against one docker
+	// daemon would otherwise build the same tag, and the second build would move it
+	// out from under the first run's containers. Same reason gitServerImageName does it.
+	tag := fmt.Sprintf("doco-cd-e2e:%s-%d", h.scenario, os.Getpid())
 
 	cmd := exec.CommandContext(h.ctx, "docker", "build",
 		"-t", tag,
@@ -303,6 +309,10 @@ func (h *Harness) teardownInternal() {
 		}
 
 		_, _ = h.docker.VolumeRemove(h.ctx, h.dataVolume, client.VolumeRemoveOptions{Force: true})
+
+		if h.daemonImage != "" {
+			_, _ = h.docker.ImageRemove(h.ctx, h.daemonImage, client.ImageRemoveOptions{Force: true})
+		}
 
 		_ = os.RemoveAll(h.workDir)
 	})


### PR DESCRIPTION
Small follow-up on #1732.

`gitServerImageName()` is pid-scoped and removed in `TestMain`. Daemon image is neither — tag is `doco-cd-e2e:<scenario>` and nothing removes it. So two concurrent runs against one docker daemon build the same tag, and the second build moves it out from under the first run containers. Image also stays behind after every run.

Now `doco-cd-e2e:<scenario>-<pid>`, removed together with the network and the data volume in `teardownInternal`, so the keep-across-suite path still cleans it at end of suite.

Ran the suite locally on OrbStack: `TestFailedDeployRetry` PASS in 224s, container came up from `doco-cd-e2e:failed-deploy-retry-46410`. After teardown no e2e image, container or volume left on the host. `golangci-lint run ./...` clean.
