### PR TITLE
fix(compose): enhance fallback logic for stale compose file labels

### DIFF
--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -247,11 +247,10 @@ func loadComposeScheduledProjectAll(
 		return nil, nil, err
 	}
 
-	// Swarm-discovered deployments carry no com.docker.compose.config_files label (docker stack
-	// deploy never sets Compose's own tracking labels), so fall back to the freshly reloaded
-	// deploy config's compose file list - the same source a normal (non-scheduled) deploy uses.
+	// Fall back to the reloaded deploy config's compose files if the label is empty
+	// (Swarm) or stale (e.g. renamed compose file not yet reflected in the label).
 	configFiles := ref.ConfigFiles
-	if len(configFiles) == 0 {
+	if len(configFiles) == 0 || !composeConfigFilesExist(configFiles, ref.WorkingDir) {
 		configFiles = deployConfig.ComposeFiles
 	}
 
@@ -269,6 +268,26 @@ func loadComposeScheduledProjectAll(
 	}
 
 	return project, deployConfig, nil
+}
+
+// composeConfigFilesExist reports whether all configFiles exist on disk, resolving
+// relative paths against workingDir like LoadCompose does.
+func composeConfigFilesExist(configFiles []string, workingDir string) bool {
+	if len(configFiles) == 0 {
+		return false
+	}
+
+	for _, f := range configFiles {
+		if !filepath.IsAbs(f) {
+			f = filepath.Join(workingDir, f)
+		}
+
+		if _, err := os.Stat(f); err != nil {
+			return false
+		}
+	}
+
+	return true
 }
 
 func validateComposeScheduledServiceScale(project *types.Project, ref composeScheduledServiceRef) error {

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -472,6 +472,53 @@ environment:
 	}
 }
 
+// TestLoadComposeScheduledProject_FallsBackWhenLabeledComposeFileIsStale is a
+// regression test for https://github.com/kimdre/doco-cd/issues/1737.
+func TestLoadComposeScheduledProject_FallsBackWhenLabeledComposeFileIsStale(t *testing.T) {
+	dataMountPath := t.TempDir()
+	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
+	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+
+	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
+
+	workingDir := filepath.Join(repoRoot, "apps", "imap-backup")
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the renamed file exists; the label still points at the old name.
+	createComposeFile(t, filepath.Join(workingDir, "compose.yaml"), `services:
+  backup:
+    image: busybox:latest
+`)
+
+	createComposeFile(t, filepath.Join(repoRoot, ".doco-cd.yml"), `name: imap-backup
+reference: refs/heads/main
+working_dir: apps/imap-backup
+compose_files:
+  - compose.yaml
+`)
+
+	staleComposePath := filepath.Join(workingDir, "docker-compose.yml")
+
+	project, err := loadComposeScheduledProject(context.Background(), nil, composeScheduledServiceRef{
+		Project:        "imap-backup",
+		Service:        "backup",
+		WorkingDir:     workingDir,
+		ConfigFiles:    []string{staleComposePath},
+		RepositoryURL:  "https://example.com/owner/repo",
+		DeploymentName: "imap-backup",
+		Reference:      "refs/heads/main",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := project.GetService("backup"); err != nil {
+		t.Fatalf("failed to get backup service: %v", err)
+	}
+}
+
 // TestLoadComposeScheduledProject_ResolvesExternalSecrets is a regression test
 // for https://github.com/kimdre/doco-cd/issues/1674: external secrets must be
 // re-resolved and interpolated into the compose service environment when a


### PR DESCRIPTION
This pull request improves the robustness of loading Compose projects for scheduled deployments, particularly when the compose file paths recorded in labels are missing or outdated. The changes ensure that the system correctly falls back to the current compose files on disk, preventing failures when files have been renamed or moved.