### PR TITLE
feat(docker): implement multi-context daemon support across all subsystems

### DIFF
--- a/cmd/doco-cd/deployment_run_tracker.go
+++ b/cmd/doco-cd/deployment_run_tracker.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kimdre/doco-cd/internal/docker"
 )
 
 type (
@@ -35,17 +37,23 @@ var (
 )
 
 type deploymentRun struct {
-	JobID      string               `json:"job_id"`
-	Trigger    deploymentRunTrigger `json:"trigger"`
-	Status     deploymentRunStatus  `json:"status"`
-	Repository string               `json:"repository,omitempty"`
-	Target     string               `json:"target,omitempty"`
-	Revision   string               `json:"revision,omitempty"`
-	Message    string               `json:"message,omitempty"`
-	CreatedAt  time.Time            `json:"created_at"`
-	StartedAt  *time.Time           `json:"started_at,omitempty"`
-	FinishedAt *time.Time           `json:"finished_at,omitempty"`
-	UpdatedAt  time.Time            `json:"updated_at"`
+	JobID       string                `json:"job_id"`
+	Trigger     deploymentRunTrigger  `json:"trigger"`
+	Status      deploymentRunStatus   `json:"status"`
+	Repository  string                `json:"repository,omitempty"`
+	Target      string                `json:"target,omitempty"`
+	Revision    string                `json:"revision,omitempty"`
+	Deployments []deploymentRunTarget `json:"deployments,omitempty"`
+	Message     string                `json:"message,omitempty"`
+	CreatedAt   time.Time             `json:"created_at"`
+	StartedAt   *time.Time            `json:"started_at,omitempty"`
+	FinishedAt  *time.Time            `json:"finished_at,omitempty"`
+	UpdatedAt   time.Time             `json:"updated_at"`
+}
+
+type deploymentRunTarget struct {
+	Stack   string `json:"stack,omitempty"`
+	Context string `json:"context"`
 }
 
 // deploymentRunTracker is a thread-safe, in-memory registry for tracking deployment runs.
@@ -57,6 +65,16 @@ type deploymentRunTracker struct {
 	orderByTrigger    map[deploymentRunTrigger][]string
 	maxEntriesPerType map[deploymentRunTrigger]int
 	ttl               time.Duration
+}
+
+func (h *handlerData) deploymentTargetObserver(jobID string) func(string, string) {
+	if h == nil || h.runTracker == nil {
+		return nil
+	}
+
+	return func(stack, contextName string) {
+		h.runTracker.AddDeployment(jobID, stack, contextName)
+	}
 }
 
 // newDeploymentRunTracker creates a new deployment run tracker with per-type limits.
@@ -186,6 +204,32 @@ func (t *deploymentRunTracker) SetMetadata(jobID, repository, target, revision s
 			r.Revision = revision
 		}
 
+		r.UpdatedAt = time.Now().UTC()
+	})
+}
+
+func (t *deploymentRunTracker) AddDeployment(jobID, stack, contextName string) {
+	stack = strings.TrimSpace(stack)
+	target := deploymentRunTarget{
+		Stack:   stack,
+		Context: docker.DisplayContextName(contextName),
+	}
+
+	t.update(jobID, func(r *deploymentRun) {
+		for _, existing := range r.Deployments {
+			if existing == target {
+				return
+			}
+		}
+
+		r.Deployments = append(r.Deployments, target)
+		slices.SortFunc(r.Deployments, func(a, b deploymentRunTarget) int {
+			if order := strings.Compare(a.Context, b.Context); order != 0 {
+				return order
+			}
+
+			return strings.Compare(a.Stack, b.Stack)
+		})
 		r.UpdatedAt = time.Now().UTC()
 	})
 }

--- a/cmd/doco-cd/deployment_run_tracker.go
+++ b/cmd/doco-cd/deployment_run_tracker.go
@@ -216,10 +216,8 @@ func (t *deploymentRunTracker) AddDeployment(jobID, stack, contextName string) {
 	}
 
 	t.update(jobID, func(r *deploymentRun) {
-		for _, existing := range r.Deployments {
-			if existing == target {
-				return
-			}
+		if slices.Contains(r.Deployments, target) {
+			return
 		}
 
 		r.Deployments = append(r.Deployments, target)

--- a/cmd/doco-cd/deployment_run_tracker_test.go
+++ b/cmd/doco-cd/deployment_run_tracker_test.go
@@ -17,6 +17,9 @@ func TestDeploymentRunTrackerLifecycle(t *testing.T) {
 
 	tracker.TrackAccepted(jobID, deploymentRunTriggerWebhook)
 	tracker.SetMetadata(jobID, "owner/repo", "prod", "refs/heads/main")
+	tracker.AddDeployment(jobID, "api", "remote")
+	tracker.AddDeployment(jobID, "web", "")
+	tracker.AddDeployment(jobID, "api", "remote")
 	tracker.MarkRunning(jobID)
 	tracker.MarkSucceeded(jobID, "done")
 
@@ -39,6 +42,15 @@ func TestDeploymentRunTrackerLifecycle(t *testing.T) {
 
 	if run.Message != "done" {
 		t.Fatalf("expected message to be set, got %q", run.Message)
+	}
+
+	if len(run.Deployments) != 2 {
+		t.Fatalf("expected two deployment targets, got %#v", run.Deployments)
+	}
+
+	if run.Deployments[0] != (deploymentRunTarget{Stack: "web", Context: "default"}) ||
+		run.Deployments[1] != (deploymentRunTarget{Stack: "api", Context: "remote"}) {
+		t.Fatalf("unexpected deployment targets: %#v", run.Deployments)
 	}
 }
 

--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/config/poll"
+	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 	"github.com/kimdre/doco-cd/internal/git"
@@ -148,6 +149,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 	dataMountPoint container.MountPoint,
 	secretProvider *secretprovider.SecretProvider,
 	dockerCli command.Cli,
+	contexts *docker.ContextRegistry,
 	jobTrigger stages.JobTrigger,
 	sourceType config.SourceType, sourceRef string, ref string, private bool,
 	metadata notification.Metadata,
@@ -386,6 +388,9 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 
 	for _, cfg := range deployConfigs {
 		cfg.Internal.ConfigTarget = strings.TrimSpace(customTarget)
+		if metadata.DeploymentTargetObserver != nil {
+			metadata.DeploymentTargetObserver(cfg.Name, cfg.Context)
+		}
 	}
 
 	repoData := stages.RepositoryData{
@@ -399,7 +404,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 	}
 
 	if err := reconciliation.Deploy(ctx, jobLog, appConfig,
-		dataMountPoint, dockerCli, secretProvider, metadata, jobTrigger,
+		dataMountPoint, dockerCli, contexts, secretProvider, metadata, jobTrigger,
 		repoData, deployConfigs, &payload, testName); err != nil {
 		if errors.Is(err, stages.ErrWebhookFilterMismatch) {
 			return err

--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/cli/cli/command"
+
 	"github.com/kimdre/doco-cd/internal/common/id"
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
@@ -28,10 +30,59 @@ import (
 )
 
 const (
-	apiPath     = "/v1/api"
-	webhookPath = "/v1/webhook"
-	healthPath  = "/v1/health"
+	apiPath             = "/v1/api"
+	webhookPath         = "/v1/webhook"
+	healthPath          = "/v1/health"
+	dockerContextHeader = "X-Doco-CD-Context"
 )
+
+func (h *handlerData) dockerCliForRequest(
+	w http.ResponseWriter,
+	r *http.Request,
+	jobLog *slog.Logger,
+	jobID string,
+) (command.Cli, string, bool) {
+	values, present := r.URL.Query()["context"]
+	if len(values) > 1 {
+		JSONError(w, "invalid parameter: context", "'context' parameter must be specified at most once", jobID, http.StatusBadRequest)
+		return nil, "", false
+	}
+
+	contextName := ""
+	if present && len(values) == 1 {
+		contextName = docker.NormalizeContextName(values[0])
+	}
+
+	displayName := docker.DisplayContextName(contextName)
+	w.Header().Set(dockerContextHeader, displayName)
+
+	if h.contexts == nil {
+		if contextName != "" {
+			JSONError(w, "unknown docker context: "+displayName, "", jobID, http.StatusBadRequest)
+			return nil, "", false
+		}
+
+		return h.dockerCli, displayName, true
+	}
+
+	contextClient, err := h.contexts.Get(r.Context(), contextName)
+	if err != nil {
+		status := http.StatusInternalServerError
+		errMsg := "failed to resolve docker context: " + displayName
+
+		if errors.Is(err, docker.ErrDockerContextNotFound) {
+			status = http.StatusBadRequest
+			errMsg = "unknown docker context: " + displayName
+		}
+
+		jobLog.Error(errMsg, logger.ErrAttr(err))
+		JSONError(w, errMsg, err.Error(), jobID, status)
+
+		return nil, "", false
+	}
+
+	return contextClient.Cli, contextClient.DisplayName(), true
+}
 
 // registerApiEndpoints registers the API endpoints based on the application configuration and
 // returns a list of all enabled endpoints.
@@ -111,9 +162,24 @@ func (h *handlerData) GetScheduledJobsHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	dockerCli, contextName, ok := h.dockerCliForRequest(w, r, jobLog, jobID)
+	if !ok {
+		return
+	}
+
+	jobLog = jobLog.With(slog.String("context", contextName))
 	stackName := getQueryParam(r, w, jobLog, jobID, "stack", "string", "").(string)
 
-	jobs, err := scheduler.ListJobs(r.Context(), h.dockerCli, stackName)
+	var (
+		jobs []scheduler.JobInfo
+		err  error
+	)
+	if h.scheduler != nil {
+		jobs, err = h.scheduler.ListJobs(r.Context(), contextName, stackName)
+	} else {
+		jobs, err = scheduler.ListJobs(r.Context(), dockerCli, stackName)
+	}
+
 	if err != nil {
 		errMsg := "failed to list scheduled jobs"
 		jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -237,12 +303,19 @@ func (h *handlerData) TriggerScheduledJobHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
+	dockerCli, contextName, ok := h.dockerCliForRequest(w, r, jobLog, jobID)
+	if !ok {
+		return
+	}
+
+	jobLog = jobLog.With(slog.String("context", contextName))
 	stackName := getQueryParam(r, w, jobLog, jobID, "stack", "string", "").(string)
 
 	wait := getQueryParam(r, w, jobLog, jobID, "wait", "bool", true).(bool)
 	if h.runTracker != nil {
 		h.runTracker.TrackAccepted(jobID, deploymentRunTriggerScheduledJob)
 		h.runTracker.SetMetadata(jobID, "scheduled:"+jobName, stackName, "")
+		h.runTracker.AddDeployment(jobID, stackName, contextName)
 
 		if wait {
 			h.runTracker.MarkRunning(jobID)
@@ -252,7 +325,15 @@ func (h *handlerData) TriggerScheduledJobHandler(w http.ResponseWriter, r *http.
 	triggerFn := func(ctx context.Context) error {
 		jobLog.Info("scheduled job run triggered via API", slog.String("job", jobName), slog.String("stack", stackName))
 
-		runID, err := scheduler.TriggerNow(ctx, h.dockerCli, h.log.Logger, jobName, stackName, h.secretProvider)
+		var (
+			runID string
+			err   error
+		)
+		if h.scheduler != nil {
+			runID, err = h.scheduler.TriggerNow(ctx, contextName, jobName, stackName, h.secretProvider)
+		} else {
+			runID, err = scheduler.TriggerNow(ctx, dockerCli, h.log.Logger, jobName, stackName, h.secretProvider)
+		}
 
 		runLog := jobLog
 		if runID != "" {
@@ -435,9 +516,16 @@ func (h *handlerData) ProjectApiHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	dockerCli, contextName, ok := h.dockerCliForRequest(w, r, jobLog, jobID)
+	if !ok {
+		return
+	}
+
+	jobLog = jobLog.With(slog.String("context", contextName))
+
 	switch r.Method {
 	case http.MethodGet:
-		containers, err := docker.GetProjectContainers(ctx, h.dockerCli, projectName)
+		containers, err := docker.GetProjectContainers(ctx, dockerCli, projectName)
 		if err != nil {
 			errMsg := "failed to get project: " + projectName
 			jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -460,7 +548,7 @@ func (h *handlerData) ProjectApiHandler(w http.ResponseWriter, r *http.Request) 
 
 		jobLog.Info("removing project", slog.String("project", projectName), slog.Bool("remove_volumes", removeVolumes), slog.Bool("remove_images", removeImages))
 
-		err := docker.RemoveProject(ctx, h.dockerCli, projectName, timeout, removeVolumes, removeImages)
+		err := docker.RemoveProject(ctx, dockerCli, projectName, timeout, removeVolumes, removeImages)
 		if err != nil {
 			errMsg := "failed to remove project: " + projectName
 			jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -506,9 +594,16 @@ func (h *handlerData) GetProjectsApiHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	dockerCli, contextName, ok := h.dockerCliForRequest(w, r, jobLog, jobID)
+	if !ok {
+		return
+	}
+
+	jobLog = jobLog.With(slog.String("context", contextName))
+
 	showAll := getQueryParam(r, w, jobLog, jobID, "all", "bool", false).(bool)
 
-	projects, err := docker.GetProjects(ctx, h.dockerCli, showAll)
+	projects, err := docker.GetProjects(ctx, dockerCli, showAll)
 	if err != nil {
 		errMsg := "failed to get projects"
 		jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -553,10 +648,17 @@ func (h *handlerData) ProjectActionApiHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	dockerCli, contextName, ok := h.dockerCliForRequest(w, r, jobLog, jobID)
+	if !ok {
+		return
+	}
+
+	jobLog = jobLog.With(slog.String("context", contextName))
+
 	timeoutSec := getQueryParam(r, w, jobLog, jobID, "timeout", "int", 30).(int)
 	timeout := time.Duration(timeoutSec) * time.Second
 
-	containers, err := docker.GetProjectContainers(ctx, h.dockerCli, projectName)
+	containers, err := docker.GetProjectContainers(ctx, dockerCli, projectName)
 	if err != nil {
 		errMsg := "failed to get project: " + projectName
 		jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -579,7 +681,7 @@ func (h *handlerData) ProjectActionApiHandler(w http.ResponseWriter, r *http.Req
 
 		jobLog.Info("starting project", slog.String("project", projectName))
 
-		err := docker.StartProject(ctx, h.dockerCli, projectName, timeout)
+		err := docker.StartProject(ctx, dockerCli, projectName, timeout)
 		if err != nil {
 			errMsg := "failed to start project"
 			jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -596,7 +698,7 @@ func (h *handlerData) ProjectActionApiHandler(w http.ResponseWriter, r *http.Req
 
 		jobLog.Info("stopping project", slog.String("project", projectName))
 
-		err := docker.StopProject(ctx, h.dockerCli, projectName, timeout)
+		err := docker.StopProject(ctx, dockerCli, projectName, timeout)
 		if err != nil {
 			errMsg := "failed to stop project"
 			jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -613,7 +715,7 @@ func (h *handlerData) ProjectActionApiHandler(w http.ResponseWriter, r *http.Req
 
 		jobLog.Info("restarting project", slog.String("project", projectName))
 
-		err := docker.RestartProject(ctx, h.dockerCli, projectName, timeout)
+		err := docker.RestartProject(ctx, dockerCli, projectName, timeout)
 		if err != nil {
 			errMsg := "failed to restart project"
 			jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -659,10 +761,17 @@ func (h *handlerData) StackActionApiHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	dockerCli, contextName, ok := h.dockerCliForRequest(w, r, jobLog, jobID)
+	if !ok {
+		return
+	}
+
+	jobLog = jobLog.With(slog.String("context", contextName))
+
 	serviceName := getQueryParam(r, w, jobLog, jobID, "service", "string", "").(string)
 	waitForServices := getQueryParam(r, w, jobLog, jobID, "wait", "bool", true).(bool)
 
-	services, err := swarm.GetStackServices(ctx, h.dockerCli.Client(), stackName)
+	services, err := swarm.GetStackServices(ctx, dockerCli.Client(), stackName)
 	if err != nil {
 		errMsg := "failed to get stack: " + stackName
 		jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -703,7 +812,7 @@ func (h *handlerData) StackActionApiHandler(w http.ResponseWriter, r *http.Reque
 
 			jobLog.Info("scaling service", slog.String("service", svcName), slog.Int("replicas", replicas))
 
-			err = swarm.ScaleService(ctx, h.dockerCli, svcName, uint64(replicas), waitForServices, false)
+			err = swarm.ScaleService(ctx, dockerCli, svcName, uint64(replicas), waitForServices, false)
 			if err != nil {
 				if errors.Is(err, swarm.ErrNotReplicatedService) {
 					jobLog.Debug("skipping non-replicated service for scale action", slog.String("service", svcName))
@@ -746,7 +855,7 @@ func (h *handlerData) StackActionApiHandler(w http.ResponseWriter, r *http.Reque
 			jobLog.Info("restarting service", slog.String("service", svcName))
 
 			// Swarm restart supports replicated/global and skips job-mode services.
-			err = docker.RestartService(ctx, h.dockerCli.Client(), svcName)
+			err = docker.RestartService(ctx, dockerCli.Client(), svcName)
 			if err != nil {
 				if errors.Is(err, docker.ErrJobServiceRestartNotSupported) {
 					jobLog.Debug("skipping restart for job-mode service", slog.String("service", svcName))
@@ -782,7 +891,7 @@ func (h *handlerData) StackActionApiHandler(w http.ResponseWriter, r *http.Reque
 
 			jobLog.Info("retriggering job service", slog.String("service", svcName))
 
-			err = docker.RerunJobService(ctx, h.dockerCli.Client(), svcName)
+			err = docker.RerunJobService(ctx, dockerCli.Client(), svcName)
 			if err != nil {
 				if errors.Is(err, docker.ErrNotAJobService) {
 					jobLog.Debug("skipping non-job service for run action", slog.String("service", svcName))
@@ -845,9 +954,16 @@ func (h *handlerData) StackApiHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	dockerCli, contextName, ok := h.dockerCliForRequest(w, r, jobLog, jobID)
+	if !ok {
+		return
+	}
+
+	jobLog = jobLog.With(slog.String("context", contextName))
+
 	switch r.Method {
 	case http.MethodGet:
-		services, err := swarm.GetStackServices(ctx, h.dockerCli.Client(), stackName)
+		services, err := swarm.GetStackServices(ctx, dockerCli.Client(), stackName)
 		if err != nil {
 			errMsg := "failed to get stack: " + stackName
 			jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -865,7 +981,7 @@ func (h *handlerData) StackApiHandler(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		jobLog.Info("removing stack", slog.String("stack", stackName))
 
-		err := docker.RemoveSwarmStack(ctx, h.dockerCli, stackName)
+		err := docker.RemoveSwarmStack(ctx, dockerCli, stackName)
 		if err != nil {
 			errMsg := "failed to remove stack: " + stackName
 			jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -911,7 +1027,14 @@ func (h *handlerData) GetStacksApiHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	stacks, err := swarm.GetStacks(ctx, h.dockerCli.Client())
+	dockerCli, contextName, ok := h.dockerCliForRequest(w, r, jobLog, jobID)
+	if !ok {
+		return
+	}
+
+	jobLog = jobLog.With(slog.String("context", contextName))
+
+	stacks, err := swarm.GetStacks(ctx, dockerCli.Client())
 	if err != nil {
 		errMsg := "failed to get stacks"
 		jobLog.With(logger.ErrAttr(err)).Error(errMsg)
@@ -1040,13 +1163,14 @@ func (h *handlerData) TriggerPollHandler(w http.ResponseWriter, r *http.Request)
 
 				repository := pollRepositoryName(pollConfig)
 				metadata := notification.Metadata{
-					Repository: repository,
-					Stack:      "",
-					Revision:   notification.GetRevision(pollConfig.Reference, ""),
-					JobID:      jobID,
+					Repository:               repository,
+					Stack:                    "",
+					Revision:                 notification.GetRevision(pollConfig.Reference, ""),
+					JobID:                    jobID,
+					DeploymentTargetObserver: h.deploymentTargetObserver(jobID),
 				}
 
-				errs <- runner(ctx, pollConfig, h.appConfig, h.dataMountPoint, h.dockerCli, h.log.Logger, metadata, h.secretProvider, pollTriggerDefault)
+				errs <- runner(ctx, pollConfig, h.appConfig, h.dataMountPoint, h.dockerCli, h.contexts, h.log.Logger, metadata, h.secretProvider, pollTriggerDefault)
 			}(pollCtx, p)
 		}
 

--- a/cmd/doco-cd/handler_api_test.go
+++ b/cmd/doco-cd/handler_api_test.go
@@ -29,6 +29,53 @@ import (
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 )
 
+func TestDockerCliForRequestContextValidation(t *testing.T) {
+	t.Parallel()
+
+	h := handlerData{log: logger.New(logger.LevelCritical)}
+	jobLog := h.log.With()
+
+	tests := []struct {
+		name       string
+		url        string
+		wantOK     bool
+		wantStatus int
+		wantHeader string
+	}{
+		{"default omitted", "/v1/api/projects", true, http.StatusOK, "default"},
+		{"default explicit", "/v1/api/projects?context=default", true, http.StatusOK, "default"},
+		{"unknown named context", "/v1/api/projects?context=remote", false, http.StatusBadRequest, "remote"},
+		{"repeated context", "/v1/api/projects?context=default&context=remote", false, http.StatusBadRequest, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			recorder := httptest.NewRecorder()
+
+			_, _, ok := h.dockerCliForRequest(recorder, req, jobLog, "job-id")
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+
+			status := recorder.Code
+			if tt.wantOK {
+				status = http.StatusOK
+			}
+
+			if status != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", status, tt.wantStatus)
+			}
+
+			if got := recorder.Header().Get(dockerContextHeader); got != tt.wantHeader {
+				t.Fatalf("%s = %q, want %q", dockerContextHeader, got, tt.wantHeader)
+			}
+		})
+	}
+}
+
 // Make http call to HealthCheckHandler.
 func TestHandlerData_HealthCheckHandler(t *testing.T) {
 	t.Parallel()
@@ -92,6 +139,8 @@ func TestHandlerData_ProjectApiHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	appConfig.ApiSecret = "test-api-secret"
 
 	log := logger.New(logger.LevelCritical)
 
@@ -241,6 +290,8 @@ func TestHandlerData_TriggerPollHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	appConfig.ApiSecret = "test-api-secret"
+
 	dockerCli, err := docker.CreateDockerCli(appConfig.DockerQuietDeploy)
 	if err != nil {
 		t.Fatalf("Failed to create docker client: %v", err)
@@ -328,13 +379,15 @@ func TestHandlerData_TriggerPollHandlerWithoutWait_DetachesRequestContext(t *tes
 		t.Fatal(err)
 	}
 
+	appConfig.ApiSecret = "test-api-secret"
+
 	ctxCancelled := make(chan bool, 1)
 
 	h := handlerData{
 		appConfig: appConfig,
 		log:       logger.New(logger.LevelCritical),
 		runPoll: func(ctx context.Context, _ poll.Config, _ *app.Config, _ container.MountPoint,
-			_ command.Cli, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
+			_ command.Cli, _ *docker.ContextRegistry, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
 			_ string,
 		) error {
 			time.Sleep(50 * time.Millisecond)
@@ -390,6 +443,8 @@ func TestHandlerData_TriggerScheduledJobHandlerValidation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	appConfig.ApiSecret = "test-api-secret"
 
 	h := handlerData{
 		appConfig: appConfig,
@@ -452,6 +507,8 @@ func TestHandlerData_GetScheduledJobsHandlerValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	appConfig.ApiSecret = "test-api-secret"
+
 	h := handlerData{
 		appConfig: appConfig,
 		log:       logger.New(logger.LevelCritical),
@@ -511,6 +568,8 @@ func TestHandlerData_DeploymentRunHandlers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	appConfig.ApiSecret = "test-api-secret"
 
 	tracker := newDeploymentRunTracker(map[deploymentRunTrigger]int{
 		deploymentRunTriggerWebhook:      10,

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/poll"
+	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 	"github.com/kimdre/doco-cd/internal/stages"
@@ -26,7 +27,7 @@ import (
 )
 
 type pollRunner func(ctx context.Context, pollConfig poll.Config, appConfig *app.Config, dataMountPoint container.MountPoint,
-	dockerCli command.Cli, logger *slog.Logger, metadata notification.Metadata, secretProvider *secretprovider.SecretProvider,
+	dockerCli command.Cli, contexts *docker.ContextRegistry, logger *slog.Logger, metadata notification.Metadata, secretProvider *secretprovider.SecretProvider,
 	triggerReason string,
 ) error
 
@@ -130,11 +131,12 @@ func (h *handlerData) PollHandler(ctx context.Context, pollJob *poll.Job) {
 		jobID := id.GenID()
 
 		metadata := notification.Metadata{
-			Repository: repoName,
-			Stack:      "",
-			Target:     pollJob.Config.CustomTarget,
-			Revision:   notification.GetRevision(pollJob.Config.Reference, ""),
-			JobID:      jobID,
+			Repository:               repoName,
+			Stack:                    "",
+			Target:                   pollJob.Config.CustomTarget,
+			Revision:                 notification.GetRevision(pollJob.Config.Reference, ""),
+			JobID:                    jobID,
+			DeploymentTargetObserver: h.deploymentTargetObserver(jobID),
 		}
 
 		logger.Debug("start poll job", slog.String("trigger", trigger))
@@ -150,7 +152,7 @@ func (h *handlerData) PollHandler(ctx context.Context, pollJob *poll.Job) {
 			triggerReason = pollTriggerWatch
 		}
 
-		err := runner(ctx, pollJob.Config, h.appConfig, h.dataMountPoint, h.dockerCli, logger, metadata, h.secretProvider, triggerReason)
+		err := runner(ctx, pollJob.Config, h.appConfig, h.dataMountPoint, h.dockerCli, h.contexts, logger, metadata, h.secretProvider, triggerReason)
 
 		if h.runTracker != nil {
 			if err != nil {
@@ -295,7 +297,7 @@ func pollError(jobLog *slog.Logger, metadata notification.Metadata, err error) {
 // "poll-watch" when triggered by the local repository filesystem watcher) and is
 // reported in the "polling <entity>" log line's trigger.event field.
 func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config, dataMountPoint container.MountPoint,
-	dockerCli command.Cli, logger *slog.Logger, metadata notification.Metadata, secretProvider *secretprovider.SecretProvider,
+	dockerCli command.Cli, contexts *docker.ContextRegistry, logger *slog.Logger, metadata notification.Metadata, secretProvider *secretprovider.SecretProvider,
 	triggerReason string,
 ) error {
 	startTime := time.Now()
@@ -353,7 +355,7 @@ func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config,
 	}
 
 	deployErr := handle(ctx, jobLog,
-		appConfig, dataMountPoint, secretProvider, dockerCli,
+		appConfig, dataMountPoint, secretProvider, dockerCli, contexts,
 		stages.JobTriggerPoll, sourceType, sourceRef, pollReference, false,
 		metadata, pollConfig.CustomTarget, "",
 		pollConfig, webhook.ParsedPayload{},

--- a/cmd/doco-cd/handler_poll_test.go
+++ b/cmd/doco-cd/handler_poll_test.go
@@ -44,7 +44,7 @@ func TestPollHandlerAllowsConcurrentRunsForSameRepository(t *testing.T) {
 	h := handlerData{
 		log: log,
 		runPoll: func(_ context.Context, _ poll.Config, _ *app.Config, _ container.MountPoint,
-			_ command.Cli, _ *slog.Logger, metadata notification.Metadata, _ *secretprovider.SecretProvider,
+			_ command.Cli, _ *docker.ContextRegistry, _ *slog.Logger, metadata notification.Metadata, _ *secretprovider.SecretProvider,
 			_ string,
 		) error {
 			started <- metadata
@@ -209,14 +209,14 @@ func TestRunPoll(t *testing.T) {
 	}
 
 	// Run initial poll
-	if err := RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, log.With(), metadata, &secretProvider, pollTriggerDefault); err != nil {
+	if err := RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, nil, log.With(), metadata, &secretProvider, pollTriggerDefault); err != nil {
 		t.Fatalf("Initial poll deployment failed: %v", err)
 	}
 
 	pollConfig.Reference = "destroy"
 
 	// Run the second poll to destroy
-	if err := RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, log.With(), metadata, &secretProvider, pollTriggerDefault); err != nil {
+	if err := RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, nil, log.With(), metadata, &secretProvider, pollTriggerDefault); err != nil {
 		t.Fatalf("Second poll deployment failed: %v", err)
 	}
 }
@@ -234,7 +234,7 @@ func TestPollHandlerFallsBackWhenWatcherFailsWithZeroInterval(t *testing.T) {
 	h := handlerData{
 		log: log,
 		runPoll: func(_ context.Context, _ poll.Config, _ *app.Config, _ container.MountPoint,
-			_ command.Cli, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
+			_ command.Cli, _ *docker.ContextRegistry, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
 			_ string,
 		) error {
 			runCount.Add(1)
@@ -310,7 +310,7 @@ func TestPollHandlerReportsWatchTriggerReason(t *testing.T) {
 	h := handlerData{
 		log: log,
 		runPoll: func(_ context.Context, _ poll.Config, _ *app.Config, _ container.MountPoint,
-			_ command.Cli, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
+			_ command.Cli, _ *docker.ContextRegistry, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
 			triggerReason string,
 		) error {
 			reasons <- triggerReason
@@ -394,7 +394,7 @@ func TestPollHandlerWatchDisabledFallsBackTo24h(t *testing.T) {
 	h := handlerData{
 		log: log,
 		runPoll: func(_ context.Context, _ poll.Config, _ *app.Config, _ container.MountPoint,
-			_ command.Cli, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
+			_ command.Cli, _ *docker.ContextRegistry, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
 			_ string,
 		) error {
 			runCount.Add(1)
@@ -466,7 +466,7 @@ func TestPollHandlerWatcherOnlyModeHasNoPeriodicFallback(t *testing.T) {
 	h := handlerData{
 		log: log,
 		runPoll: func(_ context.Context, _ poll.Config, _ *app.Config, _ container.MountPoint,
-			_ command.Cli, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
+			_ command.Cli, _ *docker.ContextRegistry, _ *slog.Logger, _ notification.Metadata, _ *secretprovider.SecretProvider,
 			_ string,
 		) error {
 			runCount.Add(1)

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/poll"
+	"github.com/kimdre/doco-cd/internal/docker"
 
 	"github.com/kimdre/doco-cd/internal/lock"
 	"github.com/kimdre/doco-cd/internal/notification"
@@ -28,6 +29,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/prometheus"
+	"github.com/kimdre/doco-cd/internal/scheduler"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
 
@@ -237,9 +239,11 @@ type handlerData struct {
 	appVersion     string               // Application version
 	dataMountPoint container.MountPoint // Mount point for the data directory
 	dockerCli      command.Cli          // Docker CLI client
-	log            *logger.Logger       // Logger for logging messages
+	contexts       *docker.ContextRegistry
+	log            *logger.Logger // Logger for logging messages
 	runTracker     *deploymentRunTracker
 	runPoll        pollRunner
+	scheduler      *scheduler.Manager
 	secretProvider *secretprovider.SecretProvider
 	testName       string // Overwrites the deployConfig.Name to make test deployments unique and prevent conflicts between tests when running in parallel. Not used in production.
 }
@@ -286,7 +290,7 @@ func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any
 // HandleEvent executes the deployment process for a given webhook event.
 func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter, appConfig *app.Config,
 	dataMountPoint container.MountPoint, payload webhook.ParsedPayload, customTarget string, metadata notification.Metadata,
-	dockerCli command.Cli, secretProvider *secretprovider.SecretProvider,
+	dockerCli command.Cli, contexts *docker.ContextRegistry, secretProvider *secretprovider.SecretProvider,
 	testName string, runTracker *deploymentRunTracker,
 ) {
 	startTime := time.Now()
@@ -388,7 +392,7 @@ func HandleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	}
 
 	deployErr := handle(ctx, jobLog,
-		appConfig, dataMountPoint, secretProvider, dockerCli,
+		appConfig, dataMountPoint, secretProvider, dockerCli, contexts,
 		stages.JobTriggerWebhook, sourceType, sourceRef, payload.Ref, payload.Private,
 		metadata, customTarget, testName, poll.Config{}, payload,
 	)
@@ -460,11 +464,12 @@ func (h *handlerData) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	metadata := notification.Metadata{
-		JobID:      jobID,
-		Repository: "unknown", // Will be updated later if we can parse the payload
-		Stack:      "",
-		Target:     strings.TrimSpace(customTarget),
-		Revision:   "",
+		JobID:                    jobID,
+		Repository:               "unknown", // Will be updated later if we can parse the payload
+		Stack:                    "",
+		Target:                   strings.TrimSpace(customTarget),
+		Revision:                 "",
+		DeploymentTargetObserver: h.deploymentTargetObserver(jobID),
 	}
 	if h.runTracker != nil {
 		h.runTracker.TrackAccepted(jobID, deploymentRunTriggerWebhook)
@@ -595,7 +600,7 @@ func (h *handlerData) WebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 		defer repoLock.Unlock()
 
-		HandleEvent(ctx, jobLog, w, h.appConfig, h.dataMountPoint, payload, customTarget, metadata, h.dockerCli, h.secretProvider, h.testName, h.runTracker)
+		HandleEvent(ctx, jobLog, w, h.appConfig, h.dataMountPoint, payload, customTarget, metadata, h.dockerCli, h.contexts, h.secretProvider, h.testName, h.runTracker)
 	}
 
 	if wait {

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -253,6 +253,13 @@ func run() error {
 		log.Debug("swarm features disabled by configuration")
 	}
 
+	contexts := docker.NewContextRegistry(dockerCli, c.DockerQuietDeploy)
+	defer func() {
+		if closeErr := contexts.Close(); closeErr != nil {
+			log.Error("failed to close docker context clients", logger.ErrAttr(closeErr))
+		}
+	}()
+
 	log.Debug("negotiated docker versions to use",
 		slog.Group("versions",
 			slog.String("docker_client", dockerClient.ClientVersion()),
@@ -338,17 +345,21 @@ func run() error {
 		log.Info("secret provider initialized", slog.String("provider", secretProvider.Name()))
 	}
 
+	schedulerManager := scheduler.NewManager(contexts, log.Logger, &wg, &secretProvider)
+
 	h := handlerData{
 		appConfig:      c,
 		appVersion:     app.Version,
 		dataMountPoint: dataMountPoint,
 		dockerCli:      dockerCli,
+		contexts:       contexts,
 		log:            log,
 		runTracker: newDeploymentRunTracker(map[deploymentRunTrigger]int{
 			deploymentRunTriggerPoll:         50,
 			deploymentRunTriggerWebhook:      50,
 			deploymentRunTriggerScheduledJob: 50,
 		}),
+		scheduler:      schedulerManager,
 		secretProvider: &secretProvider,
 	}
 
@@ -373,7 +384,7 @@ func run() error {
 
 	if c.SchedulerEnabled {
 		graceful.SafeGo(&wg, log.Logger, func() {
-			scheduler.Start(ctx, h.dockerCli, log.Logger, &wg, h.secretProvider)
+			schedulerManager.Start(ctx)
 		})
 	} else {
 		log.Info("scheduler disabled by configuration")
@@ -386,7 +397,7 @@ func run() error {
 				slog.String("secret_provider", c.SecretProvider),
 			)
 		} else {
-			watcher := certrotation.New(h.dockerCli, log.Logger, h.secretProvider, c.CertRotationThreshold, c.CertRotationCheckInterval)
+			watcher := certrotation.New(contexts, log.Logger, h.secretProvider, c.CertRotationThreshold, c.CertRotationCheckInterval)
 
 			graceful.SafeGo(&wg, log.Logger, func() {
 				watcher.Start(ctx)

--- a/cmd/doco-cd/main_test.go
+++ b/cmd/doco-cd/main_test.go
@@ -453,6 +453,7 @@ env_files:
 					tc.customTarget,
 					metadata,
 					dockerCli,
+					nil,
 					&secretProvider,
 					stackName,
 					newDeploymentRunTracker(map[deploymentRunTrigger]int{

--- a/internal/certrotation/watcher.go
+++ b/internal/certrotation/watcher.go
@@ -17,11 +17,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v5/pkg/api"
 
 	"github.com/kimdre/doco-cd/internal/docker"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 )
@@ -29,42 +27,56 @@ import (
 // Watcher periodically checks all deployments carrying rotation-capable certificate labels and
 // triggers reissuance + redeploy for any deployment whose certificate expiry falls within the
 // configured rotation threshold.
+//
+// Rotation is performed independently for every locally configured Docker context (see
+// docker.ContextRegistry), not just the default/local one: each context is discovered and
+// processed on its own, using that context's own Docker client and Swarm-mode state, so a broken
+// or unreachable context can never prevent rotation on the others. Contexts are processed
+// sequentially rather than concurrently; this keeps rotation runs simple to reason about and
+// avoids overlapping rotations without needing extra coordination, since each check interval is
+// expected to comfortably fit a full sequential pass over all configured contexts.
 type Watcher struct {
-	dockerCli      command.Cli
+	contexts       *docker.ContextRegistry
 	log            *slog.Logger
 	secretProvider *secretprovider.SecretProvider
 	threshold      time.Duration
 	checkInterval  time.Duration
 
-	// now and swarmEnabled are overridable in tests.
+	// now and listContexts are overridable in tests.
 	now          func() time.Time
-	swarmEnabled func() bool
+	listContexts func(ctx context.Context) ([]docker.ContextClientResult, error)
 }
 
 // New creates a Watcher. threshold is how far ahead of a certificate's expiry rotation is
-// triggered; checkInterval is how often deployments are checked.
+// triggered; checkInterval is how often deployments are checked. contexts is used to discover and
+// connect to every locally configured Docker context on each check.
 func New(
-	dockerCli command.Cli,
+	contexts *docker.ContextRegistry,
 	log *slog.Logger,
 	secretProvider *secretprovider.SecretProvider,
 	threshold, checkInterval time.Duration,
 ) *Watcher {
-	return &Watcher{
-		dockerCli:      dockerCli,
+	w := &Watcher{
+		contexts:       contexts,
 		log:            log.With(slog.String("component", "certrotation")),
 		secretProvider: secretProvider,
 		threshold:      threshold,
 		checkInterval:  checkInterval,
 		now:            time.Now,
-		swarmEnabled:   swarm.GetModeEnabled,
 	}
+
+	if contexts != nil {
+		w.listContexts = contexts.List
+	}
+
+	return w
 }
 
 // Start runs the watcher loop until ctx is cancelled. It performs an initial check immediately,
 // then rechecks every checkInterval. Callers are expected to run Start in its own goroutine, e.g.
 // via graceful.SafeGo, which handles WaitGroup bookkeeping.
 func (w *Watcher) Start(ctx context.Context) {
-	if w.dockerCli == nil || w.log == nil {
+	if w.contexts == nil || w.log == nil {
 		return
 	}
 
@@ -89,30 +101,58 @@ func (w *Watcher) Start(ctx context.Context) {
 	}
 }
 
-// swarmMode reports whether the Docker host is running in Swarm mode, via an overridable hook so
-// tests can exercise both modes without a live daemon.
-func (w *Watcher) swarmMode() bool {
-	if w.swarmEnabled == nil {
-		return swarm.GetModeEnabled()
-	}
-
-	return w.swarmEnabled()
-}
-
-// checkAndRotate discovers all rotatable deployments, and for each project whose certificate
-// expiry is within the configured threshold, triggers a rotation redeploy.
+// checkAndRotate discovers every locally configured Docker context and processes each one
+// independently: for each healthy context, it discovers all rotatable deployments in that
+// context, and for each project whose certificate expiry is within the configured threshold (or
+// whose certificate has been revoked), triggers a rotation redeploy against that context's own
+// Docker client.
+//
+// Contexts are processed sequentially, and a failure discovering or checking one context (e.g. an
+// unreachable remote Docker host) is logged and skipped without aborting the remaining contexts.
 func (w *Watcher) checkAndRotate(ctx context.Context) {
-	services, err := docker.GetLabeledServices(
-		ctx, w.dockerCli.Client(), w.swarmMode(),
-		docker.DocoCDLabels.Deployment.CertRotatable, "true",
-	)
-	if err != nil {
-		w.log.Error("failed to list certificate-rotatable deployments", logger.ErrAttr(err))
+	if w.listContexts == nil {
 		return
 	}
 
-	due := dueProjects(services, w.now(), w.threshold, w.log)
-	revoked := revokedProjects(ctx, services, w.secretProvider, w.log)
+	results, err := w.listContexts(ctx)
+	if err != nil {
+		w.log.Error("failed to list docker contexts for certificate rotation", logger.ErrAttr(err))
+		return
+	}
+
+	for _, result := range results {
+		w.checkAndRotateContext(ctx, result)
+	}
+}
+
+// checkAndRotateContext runs a single certificate-rotation check/redeploy pass against one Docker
+// context. It never returns an error: failures are logged (tagged with the context's display
+// name, see docker.DisplayContextName) and the context is simply skipped, so that one broken or
+// unreachable context can never prevent rotation on the others.
+func (w *Watcher) checkAndRotateContext(ctx context.Context, result docker.ContextClientResult) {
+	contextLog := w.log.With(slog.String("context", result.DisplayName()))
+
+	if result.Err != nil {
+		contextLog.Error("skipping docker context for certificate rotation", logger.ErrAttr(result.Err))
+		return
+	}
+
+	if result.Cli == nil {
+		contextLog.Error("skipping docker context for certificate rotation: no docker client available")
+		return
+	}
+
+	services, err := docker.GetLabeledServices(
+		ctx, result.Cli.Client(), result.SwarmMode,
+		docker.DocoCDLabels.Deployment.CertRotatable, "true",
+	)
+	if err != nil {
+		contextLog.Error("failed to list certificate-rotatable deployments", logger.ErrAttr(err))
+		return
+	}
+
+	due := dueProjects(services, w.now(), w.threshold, contextLog)
+	revoked := revokedProjects(ctx, services, w.secretProvider, contextLog)
 
 	// Reasons must be computed before merging revoked into due, otherwise a project that is only
 	// revoked (and not yet near expiry) would be reported as being due for "expiry" as well.
@@ -121,13 +161,13 @@ func (w *Watcher) checkAndRotate(ctx context.Context) {
 	maps.Copy(due, revoked)
 
 	for project, labels := range due {
-		w.log.Info("certificate needs rotation",
+		contextLog.Info("certificate needs rotation",
 			slog.String("project", project),
 			slog.String("reason", strings.Join(reasons[project], ",")),
 		)
 
-		if err := docker.RotateProjectCertificates(ctx, w.dockerCli, labels, w.secretProvider, w.swarmMode()); err != nil {
-			w.log.Error("failed to rotate certificate",
+		if err := docker.RotateProjectCertificates(ctx, result.Name, result.Cli, labels, w.secretProvider, result.SwarmMode); err != nil {
+			contextLog.Error("failed to rotate certificate",
 				slog.String("project", project),
 				logger.ErrAttr(err),
 			)
@@ -135,7 +175,7 @@ func (w *Watcher) checkAndRotate(ctx context.Context) {
 			continue
 		}
 
-		w.log.Info("certificate rotation redeploy completed", slog.String("project", project))
+		contextLog.Info("certificate rotation redeploy completed", slog.String("project", project))
 	}
 }
 

--- a/internal/certrotation/watcher_test.go
+++ b/internal/certrotation/watcher_test.go
@@ -435,8 +435,8 @@ func TestRotationReasonsForRevokedOnlyProject(t *testing.T) {
 // a live Docker daemon. It embeds the (nil) interface so it satisfies client.APIClient, and only
 // overrides the two calls certrotation actually needs: ContainerList for standalone Compose
 // discovery and ServiceList for Swarm discovery. Any other method call panics via the nil
-// embedded interface, which is intentional: it surfaces a test bug immediately rather than
-// silently doing nothing.
+// embedded interface, which is intentional: it surfaces an incorrect test setup immediately
+// rather than silently doing nothing.
 type fakeAPIClient struct {
 	client.APIClient
 

--- a/internal/certrotation/watcher_test.go
+++ b/internal/certrotation/watcher_test.go
@@ -5,16 +5,21 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v5/pkg/api"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/docker"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
 )
@@ -426,26 +431,289 @@ func TestRotationReasonsForRevokedOnlyProject(t *testing.T) {
 	}
 }
 
-// TestSwarmMode verifies the swarmEnabled hook is consulted (falling back to
-// swarm.GetModeEnabled when unset), so checkAndRotate correctly passes the current Swarm state
-// through to docker.GetLabeledServices and docker.RotateProjectCertificates.
-func TestSwarmMode(t *testing.T) {
-	t.Run("uses swarmEnabled hook when set", func(t *testing.T) {
-		watcher := &Watcher{swarmEnabled: func() bool { return true }}
-		if !watcher.swarmMode() {
-			t.Fatal("expected swarmMode() to return true")
+// fakeAPIClient is a minimal client.APIClient stub used to exercise checkAndRotateContext without
+// a live Docker daemon. It embeds the (nil) interface so it satisfies client.APIClient, and only
+// overrides the two calls certrotation actually needs: ContainerList for standalone Compose
+// discovery and ServiceList for Swarm discovery. Any other method call panics via the nil
+// embedded interface, which is intentional: it surfaces a test bug immediately rather than
+// silently doing nothing.
+type fakeAPIClient struct {
+	client.APIClient
+
+	containerList func(ctx context.Context, options client.ContainerListOptions) (client.ContainerListResult, error)
+	serviceList   func(ctx context.Context, options client.ServiceListOptions) (client.ServiceListResult, error)
+}
+
+func (c *fakeAPIClient) ContainerList(ctx context.Context, options client.ContainerListOptions) (client.ContainerListResult, error) {
+	if c.containerList == nil {
+		return client.ContainerListResult{}, nil
+	}
+
+	return c.containerList(ctx, options)
+}
+
+func (c *fakeAPIClient) ServiceList(ctx context.Context, options client.ServiceListOptions) (client.ServiceListResult, error) {
+	if c.serviceList == nil {
+		return client.ServiceListResult{}, nil
+	}
+
+	return c.serviceList(ctx, options)
+}
+
+// fakeCli is a minimal command.Cli stub that returns a fixed client.APIClient, for use as a
+// docker.ContextClient.Cli value in tests.
+type fakeCli struct {
+	command.Cli
+
+	apiClient client.APIClient
+}
+
+func (c fakeCli) Client() client.APIClient { return c.apiClient }
+
+// TestCheckAndRotate_ContextErrorIsolation verifies that a context which failed to resolve (e.g.
+// an unreachable remote Docker host) is logged and skipped without preventing the remaining,
+// healthy contexts from being checked. It also verifies the skipped context's display name (see
+// docker.DisplayContextName) is attached to the log entry.
+func TestCheckAndRotate_ContextErrorIsolation(t *testing.T) {
+	var buf bytes.Buffer
+
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	healthyClient := &fakeAPIClient{
+		containerList: func(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
+			return client.ContainerListResult{}, nil
+		},
+	}
+
+	results := []docker.ContextClientResult{
+		{
+			ContextClient: docker.ContextClient{Name: "broken"},
+			Err:           errors.New("connection refused"),
+		},
+		{
+			ContextClient: docker.ContextClient{Name: "", Cli: fakeCli{apiClient: healthyClient}, SwarmMode: false},
+		},
+	}
+
+	watcher := &Watcher{
+		log: log,
+		now: time.Now,
+		listContexts: func(context.Context) ([]docker.ContextClientResult, error) {
+			return results, nil
+		},
+	}
+
+	watcher.checkAndRotate(t.Context())
+
+	var sawBrokenContextSkipped bool
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("expected JSON log entry, got %q: %v", line, err)
 		}
 
-		watcher = &Watcher{swarmEnabled: func() bool { return false }}
-		if watcher.swarmMode() {
-			t.Fatal("expected swarmMode() to return false")
+		if entry["context"] == "broken" {
+			if msg, _ := entry["msg"].(string); strings.Contains(msg, "skipping docker context") {
+				sawBrokenContextSkipped = true
+			}
 		}
-	})
+	}
 
-	t.Run("falls back to swarm.GetModeEnabled when unset", func(t *testing.T) {
-		watcher := &Watcher{}
-		if watcher.swarmMode() != swarm.GetModeEnabled() {
-			t.Fatalf("expected swarmMode() to match swarm.GetModeEnabled() (%v)", swarm.GetModeEnabled())
+	if !sawBrokenContextSkipped {
+		t.Fatalf("expected a log entry noting the broken context was skipped, got logs:\n%s", buf.String())
+	}
+}
+
+// TestCheckAndRotate_UsesEachContextsOwnSwarmMode verifies that discovery for each context uses
+// that context's own SwarmMode (from docker.ContextClientResult), never a single shared/global
+// value: a standalone context must only ever be queried via ContainerList, and a Swarm context
+// only ever via ServiceList, even when both are checked in the same pass.
+func TestCheckAndRotate_UsesEachContextsOwnSwarmMode(t *testing.T) {
+	var containerCalls, serviceCalls int32
+
+	standaloneClient := &fakeAPIClient{
+		containerList: func(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
+			atomic.AddInt32(&containerCalls, 1)
+			return client.ContainerListResult{}, nil
+		},
+		serviceList: func(context.Context, client.ServiceListOptions) (client.ServiceListResult, error) {
+			t.Error("unexpected ServiceList call for a standalone (non-swarm) context")
+			return client.ServiceListResult{}, nil
+		},
+	}
+
+	swarmClient := &fakeAPIClient{
+		containerList: func(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
+			t.Error("unexpected ContainerList call for a swarm-mode context")
+			return client.ContainerListResult{}, nil
+		},
+		serviceList: func(context.Context, client.ServiceListOptions) (client.ServiceListResult, error) {
+			atomic.AddInt32(&serviceCalls, 1)
+			return client.ServiceListResult{}, nil
+		},
+	}
+
+	results := []docker.ContextClientResult{
+		{ContextClient: docker.ContextClient{Name: "", Cli: fakeCli{apiClient: standaloneClient}, SwarmMode: false}},
+		{ContextClient: docker.ContextClient{Name: "swarm-remote", Cli: fakeCli{apiClient: swarmClient}, SwarmMode: true}},
+	}
+
+	watcher := &Watcher{
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now: time.Now,
+		listContexts: func(context.Context) ([]docker.ContextClientResult, error) {
+			return results, nil
+		},
+	}
+
+	watcher.checkAndRotate(t.Context())
+
+	if containerCalls != 1 {
+		t.Errorf("expected exactly 1 ContainerList call, got %d", containerCalls)
+	}
+
+	if serviceCalls != 1 {
+		t.Errorf("expected exactly 1 ServiceList call, got %d", serviceCalls)
+	}
+}
+
+// TestCheckAndRotate_TagsLogsWithDisplayContextName verifies that log entries produced while
+// processing a context (both the discovery step and the per-project rotation attempt) carry that
+// context's display name (see docker.DisplayContextName), including for the default/local context
+// whose internal Name is empty but which must be logged as "default".
+func TestCheckAndRotate_TagsLogsWithDisplayContextName(t *testing.T) {
+	var buf bytes.Buffer
+
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	dueLabels := map[string]string{
+		api.ProjectLabel: "app",
+		api.ServiceLabel: "web",
+		docker.DocoCDLabels.Deployment.CertRotatable: "true",
+		docker.DocoCDLabels.Deployment.CertExpiry:    now.Add(1 * time.Hour).Format(time.RFC3339),
+	}
+
+	defaultClient := &fakeAPIClient{
+		containerList: func(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
+			return client.ContainerListResult{
+				Items: []container.Summary{{Names: []string{"/app_web_1"}, Labels: dueLabels}},
+			}, nil
+		},
+	}
+
+	results := []docker.ContextClientResult{
+		{ContextClient: docker.ContextClient{Name: "", Cli: fakeCli{apiClient: defaultClient}, SwarmMode: false}},
+	}
+
+	watcher := &Watcher{
+		log:       log,
+		threshold: 72 * time.Hour,
+		now:       func() time.Time { return now },
+		listContexts: func(context.Context) ([]docker.ContextClientResult, error) {
+			return results, nil
+		},
+	}
+
+	watcher.checkAndRotate(t.Context())
+
+	var sawDefaultContextEntry bool
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("expected JSON log entry, got %q: %v", line, err)
 		}
-	})
+
+		if entry["context"] == "default" && entry["project"] == "app" {
+			sawDefaultContextEntry = true
+		}
+	}
+
+	if !sawDefaultContextEntry {
+		t.Fatalf(`expected a log entry tagged context="default" for project "app", got logs:\n%s`, buf.String())
+	}
+}
+
+// TestCheckAndRotate_RotatesEachContextIndependently verifies that a due project discovered on
+// one context is rotated using that specific context's name and Docker client (via
+// docker.RotateProjectCertificates), and that a failure rotating one context's project does not
+// stop the other context's project from being attempted.
+func TestCheckAndRotate_RotatesEachContextIndependently(t *testing.T) {
+	dataMountPath := t.TempDir()
+	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
+	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+
+	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	dueLabelsFor := func(project string) map[string]string {
+		return map[string]string{
+			api.ProjectLabel: project,
+			api.ServiceLabel: "web",
+			docker.DocoCDLabels.Deployment.CertRotatable: "true",
+			docker.DocoCDLabels.Deployment.CertExpiry:    now.Add(1 * time.Hour).Format(time.RFC3339),
+		}
+	}
+
+	defaultClient := &fakeAPIClient{
+		containerList: func(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
+			return client.ContainerListResult{
+				Items: []container.Summary{{Names: []string{"/app-default_web_1"}, Labels: dueLabelsFor("app-default")}},
+			}, nil
+		},
+	}
+
+	remoteLabels := dueLabelsFor("app-remote")
+	remoteClient := &fakeAPIClient{
+		serviceList: func(context.Context, client.ServiceListOptions) (client.ServiceListResult, error) {
+			return client.ServiceListResult{
+				Items: []swarm.Service{{Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Name: "app-remote_web", Labels: remoteLabels}}}},
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	results := []docker.ContextClientResult{
+		{ContextClient: docker.ContextClient{Name: "", Cli: fakeCli{apiClient: defaultClient}, SwarmMode: false}},
+		{ContextClient: docker.ContextClient{Name: "remote", Cli: fakeCli{apiClient: remoteClient}, SwarmMode: true}},
+	}
+
+	watcher := &Watcher{
+		log:       log,
+		threshold: 72 * time.Hour,
+		now:       func() time.Time { return now },
+		listContexts: func(context.Context) ([]docker.ContextClientResult, error) {
+			return results, nil
+		},
+	}
+
+	watcher.checkAndRotate(t.Context())
+
+	// Both projects lack the on-disk deploy config RotateProjectCertificates needs to reload, so
+	// both rotation attempts are expected to fail; what this test verifies is that both contexts
+	// were independently attempted (each tagged with its own display context name) rather than
+	// one context's failure short-circuiting the other's.
+	seenContexts := map[string]bool{}
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("expected JSON log entry, got %q: %v", line, err)
+		}
+
+		if msg, _ := entry["msg"].(string); msg == "failed to rotate certificate" {
+			if ctxName, _ := entry["context"].(string); ctxName != "" {
+				seenContexts[ctxName] = true
+			}
+		}
+	}
+
+	if !seenContexts["default"] || !seenContexts["remote"] {
+		t.Fatalf("expected both contexts to be attempted independently, got contexts: %v (logs:\n%s)", seenContexts, buf.String())
+	}
 }

--- a/internal/certrotation/watcher_test.go
+++ b/internal/certrotation/watcher_test.go
@@ -487,11 +487,11 @@ func TestCheckAndRotate_ContextErrorIsolation(t *testing.T) {
 
 	results := []docker.ContextClientResult{
 		{
-			ContextClient: docker.ContextClient{Name: "broken"},
-			Err:           errors.New("connection refused"),
+			Name: "broken",
+			Err:  errors.New("connection refused"),
 		},
 		{
-			ContextClient: docker.ContextClient{Name: "", Cli: fakeCli{apiClient: healthyClient}, SwarmMode: false},
+			Name: "", Cli: fakeCli{apiClient: healthyClient}, SwarmMode: false,
 		},
 	}
 
@@ -507,7 +507,7 @@ func TestCheckAndRotate_ContextErrorIsolation(t *testing.T) {
 
 	var sawBrokenContextSkipped bool
 
-	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
 		var entry map[string]any
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
 			t.Fatalf("expected JSON log entry, got %q: %v", line, err)
@@ -555,8 +555,8 @@ func TestCheckAndRotate_UsesEachContextsOwnSwarmMode(t *testing.T) {
 	}
 
 	results := []docker.ContextClientResult{
-		{ContextClient: docker.ContextClient{Name: "", Cli: fakeCli{apiClient: standaloneClient}, SwarmMode: false}},
-		{ContextClient: docker.ContextClient{Name: "swarm-remote", Cli: fakeCli{apiClient: swarmClient}, SwarmMode: true}},
+		{Name: "", Cli: fakeCli{apiClient: standaloneClient}, SwarmMode: false},
+		{Name: "swarm-remote", Cli: fakeCli{apiClient: swarmClient}, SwarmMode: true},
 	}
 
 	watcher := &Watcher{
@@ -605,7 +605,7 @@ func TestCheckAndRotate_TagsLogsWithDisplayContextName(t *testing.T) {
 	}
 
 	results := []docker.ContextClientResult{
-		{ContextClient: docker.ContextClient{Name: "", Cli: fakeCli{apiClient: defaultClient}, SwarmMode: false}},
+		{Name: "", Cli: fakeCli{apiClient: defaultClient}, SwarmMode: false},
 	}
 
 	watcher := &Watcher{
@@ -621,7 +621,7 @@ func TestCheckAndRotate_TagsLogsWithDisplayContextName(t *testing.T) {
 
 	var sawDefaultContextEntry bool
 
-	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
 		var entry map[string]any
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
 			t.Fatalf("expected JSON log entry, got %q: %v", line, err)
@@ -679,8 +679,8 @@ func TestCheckAndRotate_RotatesEachContextIndependently(t *testing.T) {
 	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	results := []docker.ContextClientResult{
-		{ContextClient: docker.ContextClient{Name: "", Cli: fakeCli{apiClient: defaultClient}, SwarmMode: false}},
-		{ContextClient: docker.ContextClient{Name: "remote", Cli: fakeCli{apiClient: remoteClient}, SwarmMode: true}},
+		{Name: "", Cli: fakeCli{apiClient: defaultClient}, SwarmMode: false},
+		{Name: "remote", Cli: fakeCli{apiClient: remoteClient}, SwarmMode: true},
 	}
 
 	watcher := &Watcher{
@@ -700,7 +700,7 @@ func TestCheckAndRotate_RotatesEachContextIndependently(t *testing.T) {
 	// one context's failure short-circuiting the other's.
 	seenContexts := map[string]bool{}
 
-	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
 		var entry map[string]any
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
 			t.Fatalf("expected JSON log entry, got %q: %v", line, err)

--- a/internal/docker/cert_rotation_redeploy.go
+++ b/internal/docker/cert_rotation_redeploy.go
@@ -28,18 +28,26 @@ const certRotationTrigger = "cert.rotation"
 // (reissuing any pki-role certificates through the configured secret provider), and redeploys so
 // the fresh values take effect.
 //
+// contextName identifies the Docker context dockerCli was created for (empty for the local
+// default context, see NormalizeContextName/DisplayContextName); it is only used to namespace the
+// per-stack scheduler/deploy lock (see lock.StackKey) so that same-named stacks on different
+// Docker contexts don't block each other. Discovered resources need no extra "context" label of
+// their own for this: the caller (certrotation.Watcher) already knows which context's client
+// produced labels, since it scans one context's resources at a time.
+//
 // Compose deployments only recreate the services actually consuming a rotated certificate/key.
 // Swarm stacks redeploy the whole stack, but Swarm's own spec diffing (see
 // stableSwarmMetadataLabels) still limits recreation to the affected services.
 func RotateProjectCertificates(
 	ctx context.Context,
+	contextName string,
 	dockerCli command.Cli,
 	labels map[string]string,
 	secretProvider *secretprovider.SecretProvider,
 	swarmMode bool,
 ) error {
 	if swarmMode {
-		return rotateSwarmProjectCertificates(ctx, dockerCli, labels, secretProvider)
+		return rotateSwarmProjectCertificates(ctx, contextName, dockerCli, labels, secretProvider)
 	}
 
 	ref, err := composeScheduledServiceRefFromLabels(labels)
@@ -52,8 +60,10 @@ func RotateProjectCertificates(
 		stackName = ref.Project
 	}
 
-	lock.LockStack(stackName)
-	defer lock.UnlockStack(stackName)
+	stackLockKey := lock.StackKey(contextName, stackName)
+
+	lock.LockStack(stackLockKey)
+	defer lock.UnlockStack(stackLockKey)
 
 	project, deployConfig, err := loadComposeScheduledProjectAll(ctx, dockerCli, ref, secretProvider)
 	if err != nil {
@@ -97,8 +107,12 @@ func RotateProjectCertificates(
 // redeploys the whole stack. Unlike the standalone Compose path, no per-service selection is
 // needed: Swarm only recreates the tasks of services whose spec actually changed, so only the
 // services consuming the rotated certificate values end up being redeployed.
+//
+// contextName is used the same way as in RotateProjectCertificates: only to namespace the
+// per-stack lock so the same stack name on different Docker contexts never blocks each other.
 func rotateSwarmProjectCertificates(
 	ctx context.Context,
+	contextName string,
 	dockerCli command.Cli,
 	labels map[string]string,
 	secretProvider *secretprovider.SecretProvider,
@@ -108,8 +122,10 @@ func rotateSwarmProjectCertificates(
 		return fmt.Errorf("parse deployment labels for cert rotation: %w", err)
 	}
 
-	lock.LockStack(ref.Project)
-	defer lock.UnlockStack(ref.Project)
+	stackLockKey := lock.StackKey(contextName, ref.Project)
+
+	lock.LockStack(stackLockKey)
+	defer lock.UnlockStack(stackLockKey)
 
 	project, deployConfig, err := loadComposeScheduledProjectAll(ctx, dockerCli, ref, secretProvider)
 	if err != nil {

--- a/internal/docker/cert_rotation_redeploy_test.go
+++ b/internal/docker/cert_rotation_redeploy_test.go
@@ -11,21 +11,65 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/filesystem"
+	"github.com/kimdre/doco-cd/internal/lock"
 	"github.com/kimdre/doco-cd/internal/test"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
 
 func TestRotateProjectCertificates_MissingLabels(t *testing.T) {
-	err := RotateProjectCertificates(context.Background(), nil, map[string]string{}, nil, false)
+	err := RotateProjectCertificates(context.Background(), "", nil, map[string]string{}, nil, false)
 	if err == nil {
 		t.Fatal("expected an error for missing deployment labels")
 	}
 }
 
 func TestRotateProjectCertificates_SwarmMissingLabels(t *testing.T) {
-	err := RotateProjectCertificates(context.Background(), nil, map[string]string{}, nil, true)
+	err := RotateProjectCertificates(context.Background(), "", nil, map[string]string{}, nil, true)
 	if err == nil {
 		t.Fatal("expected an error for missing deployment labels in swarm mode")
+	}
+}
+
+// TestRotateProjectCertificates_ContextNamespacesLock verifies that RotateProjectCertificates
+// locks using lock.StackKey(contextName, stack), so a rotation on a named Docker context does not
+// serialize behind a same-named stack rotation on a different context (or the default context).
+// It uses the Swarm-labels path (composeScheduledServiceRefFromSwarmLabels) since it only requires
+// the doco-cd deployment name label to reach the lock acquisition, unlike the Compose path which
+// also requires the Compose service label.
+func TestRotateProjectCertificates_ContextNamespacesLock(t *testing.T) {
+	stackName := test.ConvertTestName(t.Name())
+
+	labels := map[string]string{
+		DocoCDLabels.Deployment.Name: stackName,
+	}
+
+	keyDefault := lock.StackKey("", stackName)
+	keyRemote := lock.StackKey("docker01", stackName)
+
+	if keyDefault == keyRemote {
+		t.Fatalf("expected different lock keys for default and remote contexts, both got %q", keyDefault)
+	}
+
+	lock.LockStack(keyDefault)
+	defer lock.UnlockStack(keyDefault)
+
+	// With the default-context lock held, RotateProjectCertificates for the same stack name on a
+	// different (remote) context must still be able to acquire its own (different) lock key. It
+	// will fail quickly afterwards because the deployment labels carry no working directory, but
+	// that failure must happen right after acquiring the lock, not be blocked by it.
+	done := make(chan error, 1)
+
+	go func() {
+		done <- RotateProjectCertificates(context.Background(), "docker01", nil, labels, nil, true)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error since the deployment labels carry no working directory")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out: rotation for a different context blocked on the default context's lock")
 	}
 }
 
@@ -444,7 +488,7 @@ external_secrets:
 		}
 	})
 
-	if err := RotateProjectCertificates(t.Context(), dockerCli, labels, provider, true); err != nil {
+	if err := RotateProjectCertificates(t.Context(), "", dockerCli, labels, provider, true); err != nil {
 		t.Fatalf("unexpected error rotating swarm project certificates: %v", err)
 	}
 

--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -655,6 +655,7 @@ func DeployStack(
 	startTime := time.Now()
 	repositoryLabel := resolveDeploymentMetricsRepositoryLabel(payload)
 	deploymentLabel := resolveDeploymentMetricsDeploymentLabel(deployConfig.Name)
+	contextLabel := DisplayContextName(deployConfig.Context)
 
 	stackLog := jobLog.
 		With(slog.String("stack", deployConfig.Name))
@@ -747,13 +748,13 @@ func DeployStack(
 		addSwarmSecretLabels(cfg, deployConfig, payload, externalWorkingDir, appVersion, timestamp, latestCommit)
 
 		if err = removeMismatchedRecreatableVolumes(*ctx, dockerCli.Client(), deployConfig.Name, project); err != nil {
-			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
+			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 			return fmt.Errorf("failed to remove mismatched recreatable volumes: %w", err)
 		}
 
 		err = DeploySwarmStack(*ctx, dockerCli, cfg, opts)
 		if err != nil {
-			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
+			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 
 			errMsg := "failed to deploy swarm stack " + deployConfig.Name
 
@@ -765,7 +766,7 @@ func DeployStack(
 
 			err = PruneStackConfigs(*ctx, dockerCli.Client(), deployConfig.Name, swarmConfigRetention)
 			if err != nil {
-				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
+				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 
 				errMsg := "failed to prune stack configs"
 
@@ -780,7 +781,7 @@ func DeployStack(
 
 			err = PruneStackSecrets(*ctx, dockerCli.Client(), deployConfig.Name, swarmSecretRetention)
 			if err != nil {
-				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
+				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 
 				errMsg := "failed to prune stack secrets"
 
@@ -797,7 +798,7 @@ func DeployStack(
 
 			err = RunImagePruneJob(*ctx, dockerCli)
 			if err != nil {
-				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
+				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 
 				errMsg := "failed to run image prune job"
 
@@ -841,7 +842,7 @@ func DeployStack(
 		err = deployCompose(*ctx, dockerCli, project, deployConfig, recreateMode,
 			forcedServices.ToSlice(), needSignal, deploymentPhase.Set)
 		if err != nil {
-			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
+			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 			return fmt.Errorf("failed to deploy stack: %w", err)
 		}
 	}
@@ -858,8 +859,8 @@ func DeployStack(
 		},
 	)
 
-	prometheus.DeploymentsTotal.WithLabelValues(repositoryLabel, deploymentLabel).Inc()
-	prometheus.DeploymentDuration.WithLabelValues(repositoryLabel, deploymentLabel).Observe(time.Since(startTime).Seconds())
+	prometheus.DeploymentsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
+	prometheus.DeploymentDuration.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Observe(time.Since(startTime).Seconds())
 
 	return nil
 }

--- a/internal/docker/context_registry.go
+++ b/internal/docker/context_registry.go
@@ -52,6 +52,7 @@ type ContextRegistry struct {
 	resolveSwarm func(context.Context, client.APIClient) (bool, error)
 }
 
+// NewContextRegistry creates a new ContextRegistry with the given baseCli and quiet flag.
 func NewContextRegistry(baseCli command.Cli, quiet bool) *ContextRegistry {
 	registry := &ContextRegistry{
 		baseCli:      baseCli,
@@ -71,6 +72,8 @@ func NewContextRegistry(baseCli command.Cli, quiet bool) *ContextRegistry {
 	return registry
 }
 
+// NormalizeContextName normalizes the given context name by trimming whitespace
+// and converting the default context name to an empty string.
 func NormalizeContextName(name string) string {
 	name = strings.TrimSpace(name)
 	if strings.EqualFold(name, DefaultContextName) {
@@ -80,6 +83,8 @@ func NormalizeContextName(name string) string {
 	return name
 }
 
+// DisplayContextName returns the display name for the given context name.
+// If the name is empty, it returns the default context name.
 func DisplayContextName(name string) string {
 	name = NormalizeContextName(name)
 	if name == "" {
@@ -89,6 +94,7 @@ func DisplayContextName(name string) string {
 	return name
 }
 
+// Refresh refreshes the list of available docker contexts in the registry.
 func (r *ContextRegistry) Refresh() error {
 	if r == nil {
 		return errors.New("docker context registry is required")
@@ -131,6 +137,7 @@ func (r *ContextRegistry) Refresh() error {
 	return nil
 }
 
+// Names returns the names of all available docker contexts in the registry.
 func (r *ContextRegistry) Names() ([]string, error) {
 	if err := r.Refresh(); err != nil {
 		return nil, err
@@ -151,6 +158,7 @@ func (r *ContextRegistry) Names() ([]string, error) {
 	return names, nil
 }
 
+// Get returns a ContextClient for the given context name.
 func (r *ContextRegistry) Get(ctx context.Context, name string) (ContextClient, error) {
 	name = NormalizeContextName(name)
 	if name != "" {
@@ -172,6 +180,7 @@ func (r *ContextRegistry) Get(ctx context.Context, name string) (ContextClient, 
 	return ContextClient{Name: name, Cli: cli, SwarmMode: swarmMode}, nil
 }
 
+// List returns a list of ContextClientResult for all available docker contexts in the registry.
 func (r *ContextRegistry) List(ctx context.Context) ([]ContextClientResult, error) {
 	names, err := r.Names()
 	if err != nil {
@@ -204,6 +213,7 @@ func (r *ContextRegistry) List(ctx context.Context) ([]ContextClientResult, erro
 	return results, nil
 }
 
+// clientForKnownContext returns a command.Cli for the given context name if it is known.
 func (r *ContextRegistry) clientForKnownContext(name string) (command.Cli, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -238,6 +248,7 @@ func (r *ContextRegistry) clientForKnownContext(name string) (command.Cli, error
 	return cli, nil
 }
 
+// Close closes all docker clients in the registry and marks the registry as closed.
 func (r *ContextRegistry) Close() error {
 	if r == nil {
 		return nil

--- a/internal/docker/context_registry.go
+++ b/internal/docker/context_registry.go
@@ -183,8 +183,8 @@ func (r *ContextRegistry) List(ctx context.Context) ([]ContextClientResult, erro
 		cli, cliErr := r.clientForKnownContext(name)
 		if cliErr != nil {
 			results = append(results, ContextClientResult{
-				ContextClient: ContextClient{Name: name},
-				Err:           cliErr,
+				Name: name,
+				Err:  cliErr,
 			})
 
 			continue
@@ -196,8 +196,8 @@ func (r *ContextRegistry) List(ctx context.Context) ([]ContextClientResult, erro
 		}
 
 		results = append(results, ContextClientResult{
-			ContextClient: ContextClient{Name: name, Cli: cli, SwarmMode: swarmMode},
-			Err:           swarmErr,
+			Name: name, Cli: cli, SwarmMode: swarmMode,
+			Err: swarmErr,
 		})
 	}
 

--- a/internal/docker/context_registry.go
+++ b/internal/docker/context_registry.go
@@ -1,0 +1,275 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/docker/cli/cli/command"
+	contextstore "github.com/docker/cli/cli/context/store"
+	"github.com/moby/moby/client"
+
+	dockerSwarm "github.com/kimdre/doco-cd/internal/docker/swarm"
+)
+
+const DefaultContextName = "default"
+
+var (
+	ErrDockerContextNotFound = errors.New("docker context not found")
+	ErrContextRegistryClosed = errors.New("docker context registry is closed")
+)
+
+type ContextClient struct {
+	Name      string
+	Cli       command.Cli
+	SwarmMode bool
+}
+
+func (c ContextClient) DisplayName() string {
+	return DisplayContextName(c.Name)
+}
+
+type ContextClientResult struct {
+	ContextClient
+	Err error
+}
+
+type ContextRegistry struct {
+	mu sync.RWMutex
+
+	baseCli command.Cli
+	quiet   bool
+	closed  bool
+
+	available map[string]struct{}
+	clients   map[string]command.Cli
+
+	listContexts func() ([]contextstore.Metadata, error)
+	createCli    func(bool, string) (command.Cli, error)
+	resolveSwarm func(context.Context, client.APIClient) (bool, error)
+}
+
+func NewContextRegistry(baseCli command.Cli, quiet bool) *ContextRegistry {
+	registry := &ContextRegistry{
+		baseCli:      baseCli,
+		quiet:        quiet,
+		available:    map[string]struct{}{"": {}},
+		clients:      make(map[string]command.Cli),
+		createCli:    CreateDockerCliWithContext,
+		resolveSwarm: dockerSwarm.ResolveModeEnabled,
+	}
+
+	if baseCli != nil {
+		registry.listContexts = func() ([]contextstore.Metadata, error) {
+			return baseCli.ContextStore().List()
+		}
+	}
+
+	return registry
+}
+
+func NormalizeContextName(name string) string {
+	name = strings.TrimSpace(name)
+	if strings.EqualFold(name, DefaultContextName) {
+		return ""
+	}
+
+	return name
+}
+
+func DisplayContextName(name string) string {
+	name = NormalizeContextName(name)
+	if name == "" {
+		return DefaultContextName
+	}
+
+	return name
+}
+
+func (r *ContextRegistry) Refresh() error {
+	if r == nil {
+		return errors.New("docker context registry is required")
+	}
+
+	r.mu.RLock()
+	closed := r.closed
+	listContexts := r.listContexts
+	r.mu.RUnlock()
+
+	if closed {
+		return ErrContextRegistryClosed
+	}
+
+	available := map[string]struct{}{"": {}}
+
+	if listContexts != nil {
+		contexts, err := listContexts()
+		if err != nil {
+			return fmt.Errorf("failed to list docker contexts: %w", err)
+		}
+
+		for _, metadata := range contexts {
+			name := NormalizeContextName(metadata.Name)
+			if name != "" {
+				available[name] = struct{}{}
+			}
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return ErrContextRegistryClosed
+	}
+
+	r.available = available
+
+	return nil
+}
+
+func (r *ContextRegistry) Names() ([]string, error) {
+	if err := r.Refresh(); err != nil {
+		return nil, err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.available))
+	for name := range r.available {
+		names = append(names, name)
+	}
+
+	sort.Slice(names, func(i, j int) bool {
+		return DisplayContextName(names[i]) < DisplayContextName(names[j])
+	})
+
+	return names, nil
+}
+
+func (r *ContextRegistry) Get(ctx context.Context, name string) (ContextClient, error) {
+	name = NormalizeContextName(name)
+	if name != "" {
+		if err := r.Refresh(); err != nil {
+			return ContextClient{}, err
+		}
+	}
+
+	cli, err := r.clientForKnownContext(name)
+	if err != nil {
+		return ContextClient{}, err
+	}
+
+	swarmMode, err := r.resolveSwarm(ctx, cli.Client())
+	if err != nil {
+		return ContextClient{}, fmt.Errorf("failed to check swarm mode for docker context %q: %w", DisplayContextName(name), err)
+	}
+
+	return ContextClient{Name: name, Cli: cli, SwarmMode: swarmMode}, nil
+}
+
+func (r *ContextRegistry) List(ctx context.Context) ([]ContextClientResult, error) {
+	names, err := r.Names()
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]ContextClientResult, 0, len(names))
+	for _, name := range names {
+		cli, cliErr := r.clientForKnownContext(name)
+		if cliErr != nil {
+			results = append(results, ContextClientResult{
+				ContextClient: ContextClient{Name: name},
+				Err:           cliErr,
+			})
+
+			continue
+		}
+
+		swarmMode, swarmErr := r.resolveSwarm(ctx, cli.Client())
+		if swarmErr != nil {
+			swarmErr = fmt.Errorf("failed to check swarm mode for docker context %q: %w", DisplayContextName(name), swarmErr)
+		}
+
+		results = append(results, ContextClientResult{
+			ContextClient: ContextClient{Name: name, Cli: cli, SwarmMode: swarmMode},
+			Err:           swarmErr,
+		})
+	}
+
+	return results, nil
+}
+
+func (r *ContextRegistry) clientForKnownContext(name string) (command.Cli, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return nil, ErrContextRegistryClosed
+	}
+
+	if _, ok := r.available[name]; !ok {
+		return nil, fmt.Errorf("%w: %s", ErrDockerContextNotFound, DisplayContextName(name))
+	}
+
+	if name == "" {
+		if r.baseCli == nil {
+			return nil, errors.New("default docker cli is required")
+		}
+
+		return r.baseCli, nil
+	}
+
+	if cli := r.clients[name]; cli != nil {
+		return cli, nil
+	}
+
+	cli, err := r.createCli(r.quiet, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create docker client for context %q: %w", name, err)
+	}
+
+	r.clients[name] = cli
+
+	return cli, nil
+}
+
+func (r *ContextRegistry) Close() error {
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+
+	r.closed = true
+
+	clients := make([]command.Cli, 0, len(r.clients))
+	for _, cli := range r.clients {
+		clients = append(clients, cli)
+	}
+
+	r.clients = nil
+	r.mu.Unlock()
+
+	var errs []error
+
+	for _, cli := range clients {
+		if cli == nil || cli.Client() == nil {
+			continue
+		}
+
+		if err := cli.Client().Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/docker/context_registry_test.go
+++ b/internal/docker/context_registry_test.go
@@ -1,0 +1,192 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/docker/cli/cli/command"
+	contextstore "github.com/docker/cli/cli/context/store"
+	"github.com/moby/moby/client"
+)
+
+type contextRegistryTestCli struct {
+	command.Cli
+	apiClient client.APIClient
+}
+
+func (c contextRegistryTestCli) Client() client.APIClient {
+	return c.apiClient
+}
+
+type contextRegistryTestClient struct {
+	client.APIClient
+	closed bool
+}
+
+func (c *contextRegistryTestClient) Info(context.Context, client.InfoOptions) (client.SystemInfoResult, error) {
+	return client.SystemInfoResult{}, nil
+}
+
+func (c *contextRegistryTestClient) Close() error {
+	c.closed = true
+	return nil
+}
+
+func TestContextName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input      string
+		normalized string
+		display    string
+	}{
+		{"", "", "default"},
+		{" default ", "", "default"},
+		{"DEFAULT", "", "default"},
+		{" remote ", "remote", "remote"},
+	}
+
+	for _, tt := range tests {
+		if got := NormalizeContextName(tt.input); got != tt.normalized {
+			t.Fatalf("NormalizeContextName(%q) = %q, want %q", tt.input, got, tt.normalized)
+		}
+
+		if got := DisplayContextName(tt.input); got != tt.display {
+			t.Fatalf("DisplayContextName(%q) = %q, want %q", tt.input, got, tt.display)
+		}
+	}
+}
+
+func TestContextRegistryListsAndCachesContexts(t *testing.T) {
+	t.Parallel()
+
+	defaultClient := &contextRegistryTestClient{}
+	remoteClient := &contextRegistryTestClient{}
+	baseCli := contextRegistryTestCli{apiClient: defaultClient}
+	remoteCli := contextRegistryTestCli{apiClient: remoteClient}
+
+	registry := NewContextRegistry(baseCli, true)
+	registry.listContexts = func() ([]contextstore.Metadata, error) {
+		return []contextstore.Metadata{{Name: "remote"}, {Name: "default"}}, nil
+	}
+
+	var createCalls int
+
+	registry.createCli = func(_ bool, name string) (command.Cli, error) {
+		createCalls++
+
+		if name != "remote" {
+			t.Fatalf("unexpected context creation: %s", name)
+		}
+
+		return remoteCli, nil
+	}
+	registry.resolveSwarm = func(_ context.Context, _ client.APIClient) (bool, error) {
+		return false, nil
+	}
+
+	names, err := registry.Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := []string{"", "remote"}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("Names() = %#v, want %#v", names, want)
+	}
+
+	for range 2 {
+		entry, getErr := registry.Get(t.Context(), "remote")
+		if getErr != nil {
+			t.Fatal(getErr)
+		}
+
+		if entry.Cli != remoteCli {
+			t.Fatal("expected cached remote cli")
+		}
+	}
+
+	if createCalls != 1 {
+		t.Fatalf("create calls = %d, want 1", createCalls)
+	}
+
+	if err = registry.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !remoteClient.closed {
+		t.Fatal("expected remote client to be closed")
+	}
+
+	if defaultClient.closed {
+		t.Fatal("default client must remain owned by the caller")
+	}
+}
+
+func TestContextRegistryIsolatesContextErrors(t *testing.T) {
+	t.Parallel()
+
+	baseCli := contextRegistryTestCli{apiClient: &contextRegistryTestClient{}}
+	registry := NewContextRegistry(baseCli, true)
+	registry.listContexts = func() ([]contextstore.Metadata, error) {
+		return []contextstore.Metadata{{Name: "broken"}}, nil
+	}
+
+	registry.createCli = func(_ bool, _ string) (command.Cli, error) {
+		return nil, errors.New("create failed")
+	}
+	registry.resolveSwarm = func(_ context.Context, _ client.APIClient) (bool, error) {
+		return false, nil
+	}
+
+	results, err := registry.List(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+
+	for _, result := range results {
+		switch result.Name {
+		case "":
+			if result.Err != nil {
+				t.Fatalf("default context unexpectedly failed: %v", result.Err)
+			}
+		case "broken":
+			if result.Err == nil {
+				t.Fatal("expected broken context error")
+			}
+		default:
+			t.Fatalf("unexpected context %q", result.Name)
+		}
+	}
+
+	if _, err = registry.Get(t.Context(), "missing"); !errors.Is(err, ErrDockerContextNotFound) {
+		t.Fatalf("expected ErrDockerContextNotFound, got %v", err)
+	}
+}
+
+func TestContextRegistryDefaultDoesNotRequireContextListing(t *testing.T) {
+	t.Parallel()
+
+	baseCli := contextRegistryTestCli{apiClient: &contextRegistryTestClient{}}
+	registry := NewContextRegistry(baseCli, true)
+	registry.listContexts = func() ([]contextstore.Metadata, error) {
+		return nil, errors.New("context store unavailable")
+	}
+	registry.resolveSwarm = func(_ context.Context, _ client.APIClient) (bool, error) {
+		return false, nil
+	}
+
+	entry, err := registry.Get(t.Context(), "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if entry.Cli != baseCli || entry.DisplayName() != "default" {
+		t.Fatalf("unexpected default entry: %#v", entry)
+	}
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -63,7 +63,7 @@ func getStackMutex(stackName string) *sync.Mutex {
 // certificate rotation watcher) stay mutually exclusive with its deployments.
 func StackKey(contextName, stackName string) string {
 	contextName = strings.TrimSpace(contextName)
-	if contextName == "" {
+	if contextName == "" || strings.EqualFold(contextName, "default") {
 		return stackName
 	}
 

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -293,6 +293,8 @@ func TestStackKey(t *testing.T) {
 	}{
 		{name: "default context keeps bare stack name", contextName: "", stackName: "telegraf", want: "telegraf"},
 		{name: "blank context is treated as default", contextName: "   ", stackName: "telegraf", want: "telegraf"},
+		{name: "explicit default context keeps bare stack name", contextName: "default", stackName: "telegraf", want: "telegraf"},
+		{name: "default context is case insensitive", contextName: " DEFAULT ", stackName: "telegraf", want: "telegraf"},
 		{name: "named context is namespaced", contextName: "docker01", stackName: "telegraf", want: "docker01/telegraf"},
 		{name: "context is trimmed", contextName: " docker02 ", stackName: "telegraf", want: "docker02/telegraf"},
 	}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -77,20 +77,21 @@ type appriseRequest struct {
 }
 
 type Metadata struct {
-	Repository          string
-	Stack               string
-	Context             string // Docker context the stack is deployed to (empty = default context)
-	Target              string // Custom webhook/poll target suffix (e.g., "prod-vm" for .doco-cd.prod-vm.yml)
-	Revision            string
-	JobID               string
-	TraceID             string
-	ReconciliationEvent string
-	AffectedActorKind   string
-	AffectedActorID     string
-	AffectedActorName   string
-	Commits             []git.CommitInfo // commits deployed since the last deploy; empty on first deploy/failure/OCI
-	Duration            time.Duration    // time from job start to the notification; zero when no deploy/destroy ran
-	ChangedServices     []string         // services force-recreated by this deploy, or whose image moved; empty on the first deployment of a stack
+	Repository               string
+	Stack                    string
+	Context                  string // Docker context the stack is deployed to (empty = default context)
+	Target                   string // Custom webhook/poll target suffix (e.g., "prod-vm" for .doco-cd.prod-vm.yml)
+	Revision                 string
+	JobID                    string
+	TraceID                  string
+	ReconciliationEvent      string
+	AffectedActorKind        string
+	AffectedActorID          string
+	AffectedActorName        string
+	Commits                  []git.CommitInfo // commits deployed since the last deploy; empty on first deploy/failure/OCI
+	Duration                 time.Duration    // time from job start to the notification; zero when no deploy/destroy ran
+	ChangedServices          []string         // services force-recreated by this deploy, or whose image moved; empty on the first deployment of a stack
+	DeploymentTargetObserver func(stack, context string)
 }
 
 // TemplateData is the data exposed to a user-configured notification body template.
@@ -491,6 +492,15 @@ func (d TemplateData) DefaultBody() string {
 
 	if m.Stack != "" {
 		fields["stack"] = m.Stack
+
+		contextName := strings.TrimSpace(m.Context)
+		if contextName == "" {
+			contextName = "default"
+		}
+
+		fields["context"] = contextName
+	} else if strings.TrimSpace(m.Context) != "" {
+		fields["context"] = strings.TrimSpace(m.Context)
 	}
 
 	if m.Revision != "" {

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -248,7 +248,21 @@ func TestDefaultBody(t *testing.T) {
 			AffectedActorID:     "abc123def456",
 			AffectedActorName:   "prod_api",
 		})
-		expected := "Deployment triggered\n\nrepository: acme/api\nstack: prod\nreconciliation:\n  event: unhealthy\n  service_id: abc123def456\n  service_name: prod_api\n  trace_id: trace-123"
+		expected := "Deployment triggered\n\ncontext: default\nrepository: acme/api\nstack: prod\nreconciliation:\n  event: unhealthy\n  service_id: abc123def456\n  service_name: prod_api\n  trace_id: trace-123"
+
+		if message != expected {
+			t.Errorf("expected %q, got %q", expected, message)
+		}
+	})
+
+	t.Run("named docker context is included", func(t *testing.T) {
+		t.Parallel()
+
+		message := defaultBody("Deployment completed", Metadata{
+			Stack:   "prod",
+			Context: "remote",
+		})
+		expected := "Deployment completed\n\ncontext: remote\nstack: prod"
 
 		if message != expected {
 			t.Errorf("expected %q, got %q", expected, message)

--- a/internal/prometheus/collectors.go
+++ b/internal/prometheus/collectors.go
@@ -75,18 +75,18 @@ var (
 		Namespace: MetricsNamespace,
 		Name:      "deployments_total",
 		Help:      "Total number of deployments processed",
-	}, []string{"repository", "deployment"})
+	}, []string{"repository", "deployment", "context"})
 	DeploymentErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "deployment_errors_total",
 		Help:      "Total number of errors during deployments",
-	}, []string{"repository", "deployment"})
+	}, []string{"repository", "deployment", "context"})
 	DeploymentDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: MetricsNamespace,
 		Name:      "deployment_duration_seconds",
 		Help:      "Duration of deployment operations in seconds",
 		Buckets:   prometheus.DefBuckets,
-	}, []string{"repository", "deployment"})
+	}, []string{"repository", "deployment", "context"})
 	DeploymentsActive = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "deployments_active",
@@ -101,28 +101,28 @@ var (
 		Namespace: MetricsNamespace,
 		Name:      "scheduled_runs_total",
 		Help:      "Total number of scheduled job runs processed",
-	}, []string{"stack", "job", "mode", "execution_mode"})
+	}, []string{"context", "stack", "job", "mode", "execution_mode"})
 	ScheduledRunErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "scheduled_run_errors_total",
 		Help:      "Total number of failed scheduled job runs",
-	}, []string{"stack", "job", "mode", "execution_mode"})
+	}, []string{"context", "stack", "job", "mode", "execution_mode"})
 	ScheduledRunSkippedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "scheduled_run_skipped_total",
 		Help:      "Total number of skipped scheduled job runs",
-	}, []string{"stack", "job", "mode", "execution_mode", "reason"})
+	}, []string{"context", "stack", "job", "mode", "execution_mode", "reason"})
 	ScheduledRunDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: MetricsNamespace,
 		Name:      "scheduled_run_duration_seconds",
 		Help:      "Duration of scheduled job runs in seconds",
 		Buckets:   prometheus.DefBuckets,
-	}, []string{"stack", "job", "mode", "execution_mode"})
+	}, []string{"context", "stack", "job", "mode", "execution_mode"})
 	ScheduledRunsActive = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: MetricsNamespace,
 		Name:      "scheduled_runs_active",
 		Help:      "Number of currently active scheduled job runs",
-	}, []string{"stack", "job", "mode", "execution_mode"})
+	}, []string{"context", "stack", "job", "mode", "execution_mode"})
 	/* --8<-- [end:collectors]
 	Add new collectors above this comment */
 )

--- a/internal/prometheus/metrics_test.go
+++ b/internal/prometheus/metrics_test.go
@@ -26,7 +26,7 @@ func TestServe(t *testing.T) {
 	}
 
 	AppInfo.WithLabelValues("test", appConfig.LogLevel, time.Now().Format(time.RFC3339)).Set(1)
-	ScheduledRunsTotal.WithLabelValues("test-stack", "backup", "container", "restart").Inc()
+	ScheduledRunsTotal.WithLabelValues("default", "test-stack", "backup", "container", "restart").Inc()
 
 	req, err := http.NewRequest("GET", MetricsPath, nil)
 	if err != nil {
@@ -61,10 +61,10 @@ func TestServe(t *testing.T) {
 	}
 }
 
-func TestDeploymentMetricsIncludeRepositoryAndDeploymentLabels(t *testing.T) {
+func TestDeploymentMetricsIncludeContextLabel(t *testing.T) {
 	t.Parallel()
 
-	DeploymentsTotal.WithLabelValues("github.com/example/repo", "test-stack").Inc()
+	DeploymentsTotal.WithLabelValues("github.com/example/repo", "test-stack", "remote").Inc()
 
 	req, err := http.NewRequest("GET", MetricsPath, nil)
 	if err != nil {
@@ -74,8 +74,8 @@ func TestDeploymentMetricsIncludeRepositoryAndDeploymentLabels(t *testing.T) {
 	rr := httptest.NewRecorder()
 	promhttp.Handler().ServeHTTP(rr, req)
 
-	linePattern := regexp.MustCompile(`doco_cd_deployments_total\{[^}]*deployment="test-stack"[^}]*repository="github.com/example/repo"[^}]*\}\s+1`)
+	linePattern := regexp.MustCompile(`doco_cd_deployments_total\{[^}]*context="remote"[^}]*deployment="test-stack"[^}]*repository="github.com/example/repo"[^}]*\}\s+1`)
 	if !linePattern.MatchString(rr.Body.String()) {
-		t.Fatalf("expected deployments_total with repository and deployment labels, got:\n%s", rr.Body.String())
+		t.Fatalf("expected deployments_total with context label, got:\n%s", rr.Body.String())
 	}
 }

--- a/internal/prometheus/scheduler_metrics_test.go
+++ b/internal/prometheus/scheduler_metrics_test.go
@@ -1,0 +1,51 @@
+package prometheus
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// TestScheduledRunMetrics_ContextLabel verifies that every scheduler metric
+// carries a "context" label (so runs on different Docker contexts can be
+// distinguished), and that the skipped-run metric still exposes "reason" as
+// its last label, per convention.
+func TestScheduledRunMetrics_ContextLabel(t *testing.T) {
+	t.Parallel()
+
+	ScheduledRunsTotal.WithLabelValues("remote", "test-context-stack", "backup", "container", "one_off").Inc()
+	ScheduledRunErrorsTotal.WithLabelValues("remote", "test-context-stack", "backup", "container", "one_off").Inc()
+	ScheduledRunSkippedTotal.WithLabelValues("remote", "test-context-stack", "backup", "container", "one_off", "still_running").Inc()
+	ScheduledRunDuration.WithLabelValues("remote", "test-context-stack", "backup", "container", "one_off").Observe(1)
+	ScheduledRunsActive.WithLabelValues("remote", "test-context-stack", "backup", "container", "one_off").Inc()
+
+	req, err := http.NewRequest(http.MethodGet, MetricsPath, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	promhttp.Handler().ServeHTTP(rr, req)
+
+	body, err := io.ReadAll(rr.Result().Body)
+	if err != nil {
+		t.Fatalf("failed to read metrics response body: %v", err)
+	}
+
+	out := string(body)
+
+	for _, want := range []string{
+		`doco_cd_scheduled_runs_total{context="remote",execution_mode="one_off",job="backup",mode="container",stack="test-context-stack"} 1`,
+		`doco_cd_scheduled_run_errors_total{context="remote",execution_mode="one_off",job="backup",mode="container",stack="test-context-stack"} 1`,
+		`doco_cd_scheduled_run_skipped_total{context="remote",execution_mode="one_off",job="backup",mode="container",reason="still_running",stack="test-context-stack"} 1`,
+		`doco_cd_scheduled_runs_active{context="remote",execution_mode="one_off",job="backup",mode="container",stack="test-context-stack"} 1`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected metrics output to contain %q, got:\n%s", want, out)
+		}
+	}
+}

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -32,6 +32,7 @@ func Deploy(ctx context.Context,
 	appConfig *app.Config,
 	dataMountPoint container.MountPoint,
 	dockerCli command.Cli,
+	contexts *docker.ContextRegistry,
 	secretProvider *secretprovider.SecretProvider,
 	metadata notification.Metadata,
 	jobTrigger stages.JobTrigger,
@@ -41,7 +42,7 @@ func Deploy(ctx context.Context,
 	testName string,
 ) error {
 	err := deploy(ctx, jobLog, appConfig,
-		dataMountPoint, dockerCli, secretProvider, metadata,
+		dataMountPoint, dockerCli, contexts, secretProvider, metadata,
 		jobTrigger, repoData, deployConfigs, payload, testName)
 
 	// Skip long-lived reconciliation listeners for test-triggered deployments.
@@ -52,6 +53,7 @@ func Deploy(ctx context.Context,
 			appConfig:      appConfig,
 			dataMountPoint: dataMountPoint,
 			dockerCli:      dockerCli,
+			contexts:       contexts,
 			secretProvider: secretProvider,
 			jobLog:         jobLog,
 			metadata:       metadata,
@@ -71,6 +73,7 @@ func deploy(ctx context.Context,
 	appConfig *app.Config,
 	dataMountPoint container.MountPoint,
 	dockerCli command.Cli,
+	contexts *docker.ContextRegistry,
 	secretProvider *secretprovider.SecretProvider,
 	metadata notification.Metadata,
 	jobTrigger stages.JobTrigger,
@@ -86,7 +89,7 @@ func deploy(ctx context.Context,
 	configsByContext := map[string][]*deployConfig.Config{}
 
 	for _, dc := range deployConfigs {
-		contextName := strings.TrimSpace(dc.Context)
+		contextName := docker.NormalizeContextName(dc.Context)
 		configsByContext[contextName] = append(configsByContext[contextName], dc)
 	}
 
@@ -96,51 +99,32 @@ func deploy(ctx context.Context,
 	}
 
 	for contextName, groupedConfigs := range configsByContext {
-		cleanupCli, closeFn, err := dockerCliForContext(dockerCli, dockerQuiet, contextName)
-		if err != nil {
+		entry := resolveDeployContext(ctx, contexts, dockerCli, dockerQuiet, contextName)
+		if entry.err != nil {
 			// Isolate per-context failures: an unreachable context must not block
 			// cleanup/deploy for other (healthy) contexts. handleDeploy below fails
 			// only the affected deployments.
 			jobLog.Error("failed to create docker client for context, skipping cleanup for it",
-				slog.String("context", contextName), logger.ErrAttr(err))
+				slog.String("context", docker.DisplayContextName(contextName)), logger.ErrAttr(entry.err))
 
 			continue
 		}
 
-		// For the default context use the globally cached swarm mode; for a custom
-		// context probe the remote daemon directly.
-		var cleanupSwarmMode bool
-		if contextName == "" {
-			cleanupSwarmMode = dockerSwarm.GetModeEnabled()
-		} else {
-			cleanupSwarmMode, err = dockerSwarm.ResolveModeEnabled(ctx, cleanupCli.Client())
-			if err != nil {
-				jobLog.Error("failed to check swarm mode for context, skipping cleanup for it",
-					slog.String("context", contextName), logger.ErrAttr(err))
-
-				if closeFn != nil {
-					closeFn()
-				}
-
-				continue
-			}
-		}
-
 		if err := cleanupObsoleteAutoDiscoveredContainers(ctx, jobLog,
-			cleanupCli, cleanupSwarmMode, contextName, repoData.SourceUrl,
+			entry.cli, entry.swarmMode, contextName, repoData.SourceUrl,
 			groupedConfigs,
 			metadata); err != nil {
 			jobLog.Error("failed to clean up obsolete auto-discovered containers for context",
-				slog.String("context", contextName), logger.ErrAttr(err))
+				slog.String("context", docker.DisplayContextName(contextName)), logger.ErrAttr(err))
 		}
 
-		if closeFn != nil {
-			closeFn()
+		if entry.closeFn != nil {
+			entry.closeFn()
 		}
 	}
 
 	return handleDeploy(ctx, jobLog, appConfig,
-		dataMountPoint, dockerCli, secretProvider, metadata.JobID, jobTrigger,
+		dataMountPoint, dockerCli, contexts, secretProvider, metadata.JobID, jobTrigger,
 		repoData, deployConfigs, payload, testName, metadata)
 }
 
@@ -149,6 +133,7 @@ func handleDeploy(ctx context.Context,
 	appConfig *app.Config,
 	dataMountPoint container.MountPoint,
 	dockerCli command.Cli,
+	contexts *docker.ContextRegistry,
 	secretProvider *secretprovider.SecretProvider,
 	jobID string,
 	jobTrigger stages.JobTrigger,
@@ -165,7 +150,7 @@ func handleDeploy(ctx context.Context,
 
 	// Build one Docker CLI per distinct context up front and share it across all
 	// deployments targeting that context, instead of creating a client per deployment.
-	contextCLIs := buildDeployContextCLIs(ctx, dockerCli, dockerQuiet, deployConfigs)
+	contextCLIs := buildDeployContextCLIs(ctx, contexts, dockerCli, dockerQuiet, deployConfigs)
 
 	defer func() {
 		for contextName, entry := range contextCLIs {
@@ -207,12 +192,14 @@ func handleDeploy(ctx context.Context,
 			defer wg.Done()
 			defer reconciliationHandler.finishStackDeployment(repoData.Name, dc.Context, dc.Name)
 
-			entry, ok := contextCLIs[strings.TrimSpace(dc.Context)]
+			contextName := docker.NormalizeContextName(dc.Context)
+
+			entry, ok := contextCLIs[contextName]
 			if !ok || entry.err != nil {
 				if ok && entry.err != nil {
 					resultCh <- entry.err
 				} else {
-					resultCh <- fmt.Errorf("no docker client available for context %q", strings.TrimSpace(dc.Context))
+					resultCh <- fmt.Errorf("no docker client available for context %q", docker.DisplayContextName(contextName))
 				}
 
 				return
@@ -273,41 +260,51 @@ type deployContextCLI struct {
 // The default context (empty string) reuses baseCli; custom contexts get a dedicated client whose
 // closeFn must be called by the caller. Errors are captured per context so only the affected
 // deployments fail rather than the whole batch.
-func buildDeployContextCLIs(ctx context.Context, baseCli command.Cli, quiet bool, deployConfigs []*deployConfig.Config) map[string]deployContextCLI {
+func buildDeployContextCLIs(ctx context.Context, contexts *docker.ContextRegistry, baseCli command.Cli, quiet bool, deployConfigs []*deployConfig.Config) map[string]deployContextCLI {
 	contextCLIs := make(map[string]deployContextCLI)
 
 	for _, dc := range deployConfigs {
-		contextName := strings.TrimSpace(dc.Context)
+		contextName := docker.NormalizeContextName(dc.Context)
 		if _, exists := contextCLIs[contextName]; exists {
 			continue
 		}
 
-		if contextName == "" {
-			contextCLIs[contextName] = deployContextCLI{cli: baseCli, swarmMode: dockerSwarm.GetModeEnabled()}
-			continue
-		}
-
-		cli, closeFn, err := dockerCliForContext(baseCli, quiet, contextName)
-		if err != nil {
-			contextCLIs[contextName] = deployContextCLI{err: err}
-			continue
-		}
-
-		swarmMode, err := dockerSwarm.ResolveModeEnabled(ctx, cli.Client())
-		if err != nil {
-			if closeFn != nil {
-				closeFn()
-			}
-
-			contextCLIs[contextName] = deployContextCLI{err: fmt.Errorf("failed to check if docker host is running in swarm mode: %w", err)}
-
-			continue
-		}
-
-		contextCLIs[contextName] = deployContextCLI{cli: cli, closeFn: closeFn, swarmMode: swarmMode}
+		contextCLIs[contextName] = resolveDeployContext(ctx, contexts, baseCli, quiet, contextName)
 	}
 
 	return contextCLIs
+}
+
+func resolveDeployContext(ctx context.Context, contexts *docker.ContextRegistry, baseCli command.Cli, quiet bool, contextName string) deployContextCLI {
+	contextName = docker.NormalizeContextName(contextName)
+	if contexts != nil {
+		cc, err := contexts.Get(ctx, contextName)
+		if err != nil {
+			return deployContextCLI{err: err}
+		}
+
+		return deployContextCLI{cli: cc.Cli, swarmMode: cc.SwarmMode}
+	}
+
+	if contextName == "" {
+		return deployContextCLI{cli: baseCli, swarmMode: dockerSwarm.GetModeEnabled()}
+	}
+
+	cli, closeFn, err := dockerCliForContext(baseCli, quiet, contextName)
+	if err != nil {
+		return deployContextCLI{err: err}
+	}
+
+	swarmMode, err := dockerSwarm.ResolveModeEnabled(ctx, cli.Client())
+	if err != nil {
+		if closeFn != nil {
+			closeFn()
+		}
+
+		return deployContextCLI{err: fmt.Errorf("failed to check if docker host is running in swarm mode: %w", err)}
+	}
+
+	return deployContextCLI{cli: cli, closeFn: closeFn, swarmMode: swarmMode}
 }
 
 func handleOneDeploy(ctx context.Context, deployLog *slog.Logger,
@@ -358,7 +355,7 @@ func handleOneDeploy(ctx context.Context, deployLog *slog.Logger,
 }
 
 func dockerCliForContext(baseCli command.Cli, quiet bool, contextName string) (command.Cli, func(), error) {
-	contextName = strings.TrimSpace(contextName)
+	contextName = docker.NormalizeContextName(contextName)
 	if contextName == "" {
 		return baseCli, nil, nil
 	}

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -44,6 +44,7 @@ func TestDeploy_RejectsUnverifiedOCIArtifact(t *testing.T) {
 		container.MountPoint{},
 		nil,
 		nil,
+		nil,
 		notification.Metadata{},
 		stages.JobTriggerWebhook,
 		stages.RepositoryData{
@@ -175,6 +176,7 @@ func TestDeploy(t *testing.T) {
 			Mode:        "rw",
 		},
 		dockerCli,
+		nil,
 		&secretProvider,
 		notification.Metadata{
 			JobID:      jobId,

--- a/internal/reconciliation/manager.go
+++ b/internal/reconciliation/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/config/app"
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 
+	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/graceful"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
@@ -44,6 +45,7 @@ type jobInfo struct {
 	appConfig      *app.Config
 	dataMountPoint container.MountPoint
 	dockerCli      command.Cli
+	contexts       *docker.ContextRegistry
 	secretProvider *secretprovider.SecretProvider
 
 	jobLog *slog.Logger
@@ -121,7 +123,7 @@ type reconciliation struct {
 
 	repoJobs              map[string]*job
 	deployingStacks       map[string]int
-	schedulerHeldServices map[string]schedulerHoldEntry // key = "project/service"
+	schedulerHeldServices map[string]schedulerHoldEntry // key = "context/project/service"
 }
 
 func newReconciliation() *reconciliation {
@@ -147,12 +149,15 @@ func (r *reconciliation) close() {
 }
 
 // MarkSchedulerStopHeld records that the scheduler has intentionally stopped the
-// given compose service (identified by its compose project and service name) so
-// that the reconciliation event listener does not try to restart it while the
-// scheduled job is running. The hold is refcounted to handle concurrent jobs
-// that stop the same service.
-func MarkSchedulerStopHeld(project, service string) {
-	reconciliationHandler.markSchedulerStopHeld(project, service)
+// given compose service (identified by its Docker context, compose project, and
+// service name) so that the reconciliation event listener does not try to
+// restart it while the scheduled job is running. The hold is refcounted to
+// handle concurrent jobs that stop the same service. contextName is the
+// normalized Docker context name (empty string = default context) the
+// service lives on; the same project/service name on two different contexts
+// are tracked independently.
+func MarkSchedulerStopHeld(contextName, project, service string) {
+	reconciliationHandler.markSchedulerStopHeld(contextName, project, service)
 }
 
 // UnmarkSchedulerStopHeld releases a hold previously registered via
@@ -160,20 +165,21 @@ func MarkSchedulerStopHeld(project, service string) {
 // grace period (see schedulerStopHoldGracePeriod) so that any Docker stop
 // event still buffered in the reconciliation channel does not trigger a
 // spurious restart.
-func UnmarkSchedulerStopHeld(project, service string) {
-	reconciliationHandler.unmarkSchedulerStopHeld(project, service)
+func UnmarkSchedulerStopHeld(contextName, project, service string) {
+	reconciliationHandler.unmarkSchedulerStopHeld(contextName, project, service)
 }
 
-func schedulerHeldServiceKey(project, service string) string {
-	return project + "/" + service
+func schedulerHeldServiceKey(contextName, project, service string) string {
+	contextName = docker.NormalizeContextName(contextName)
+	return contextName + "/" + project + "/" + service
 }
 
-func (r *reconciliation) markSchedulerStopHeld(project, service string) {
+func (r *reconciliation) markSchedulerStopHeld(contextName, project, service string) {
 	if project == "" || service == "" {
 		return
 	}
 
-	key := schedulerHeldServiceKey(project, service)
+	key := schedulerHeldServiceKey(contextName, project, service)
 
 	r.m.Lock()
 	entry := r.schedulerHeldServices[key]
@@ -183,12 +189,12 @@ func (r *reconciliation) markSchedulerStopHeld(project, service string) {
 	r.m.Unlock()
 }
 
-func (r *reconciliation) unmarkSchedulerStopHeld(project, service string) {
+func (r *reconciliation) unmarkSchedulerStopHeld(contextName, project, service string) {
 	if project == "" || service == "" {
 		return
 	}
 
-	key := schedulerHeldServiceKey(project, service)
+	key := schedulerHeldServiceKey(contextName, project, service)
 
 	r.m.Lock()
 	defer r.m.Unlock()
@@ -211,8 +217,9 @@ func (r *reconciliation) unmarkSchedulerStopHeld(project, service string) {
 
 // isServiceSchedulerStopHeld reports whether the container described by attrs is
 // currently held stopped by the job scheduler (or within the post-release grace
-// period). It uses the standard Docker Compose labels to identify the service.
-func (r *reconciliation) isServiceSchedulerStopHeld(attrs map[string]string) bool {
+// period) on the given Docker context. It uses the standard Docker Compose
+// labels to identify the service.
+func (r *reconciliation) isServiceSchedulerStopHeld(contextName string, attrs map[string]string) bool {
 	if attrs == nil {
 		return false
 	}
@@ -224,7 +231,7 @@ func (r *reconciliation) isServiceSchedulerStopHeld(attrs map[string]string) boo
 		return false
 	}
 
-	key := schedulerHeldServiceKey(project, service)
+	key := schedulerHeldServiceKey(contextName, project, service)
 
 	r.m.Lock()
 	defer r.m.Unlock()
@@ -253,6 +260,7 @@ func (r *reconciliation) isServiceSchedulerStopHeld(attrs map[string]string) boo
 // only guaranteed unique within a Docker context, so context is included to
 // avoid conflating same-named stacks deployed to different contexts.
 func stackDeploymentKey(repository, context, stack string) string {
+	context = docker.NormalizeContextName(context)
 	return repository + "/" + context + "/" + stack
 }
 

--- a/internal/reconciliation/manager_test.go
+++ b/internal/reconciliation/manager_test.go
@@ -1,0 +1,78 @@
+package reconciliation
+
+import (
+	"testing"
+
+	"github.com/docker/compose/v5/pkg/api"
+)
+
+// TestSchedulerStopHold_IsolatedAcrossContexts verifies that MarkSchedulerStopHeld/
+// UnmarkSchedulerStopHeld/isServiceSchedulerStopHeld key holds by Docker context, so
+// the same compose project/service name on two different Docker contexts are tracked
+// independently and never suppress each other's reconciliation events.
+func TestSchedulerStopHold_IsolatedAcrossContexts(t *testing.T) {
+	r := newReconciliation()
+
+	attrs := map[string]string{
+		api.ProjectLabel: "proj",
+		api.ServiceLabel: "db",
+	}
+
+	r.markSchedulerStopHeld("", "proj", "db")
+
+	if !r.isServiceSchedulerStopHeld("", attrs) {
+		t.Fatal("expected service to be held stopped on the default context")
+	}
+
+	if r.isServiceSchedulerStopHeld("remote", attrs) {
+		t.Fatal("expected hold on the default context to not be visible on the \"remote\" context")
+	}
+
+	r.markSchedulerStopHeld("remote", "proj", "db")
+
+	if !r.isServiceSchedulerStopHeld("remote", attrs) {
+		t.Fatal("expected service to be held stopped on the \"remote\" context")
+	}
+
+	// Releasing the default context's hold must not affect the remote context's hold.
+	// (unmarkSchedulerStopHeld keeps a short grace-period entry alive after the
+	// last release, so isServiceSchedulerStopHeld still reports true briefly —
+	// see schedulerStopHoldGracePeriod — but this must remain scoped to the
+	// default context and not leak into the remote context's independent hold.)
+	r.unmarkSchedulerStopHeld("", "proj", "db")
+
+	if !r.isServiceSchedulerStopHeld("remote", attrs) {
+		t.Fatal("expected remote context hold to remain held after releasing the unrelated default context hold")
+	}
+}
+
+// TestSchedulerHeldServiceKey_DiffersByContext ensures the internal key builder used
+// for the scheduler stop-hold map includes the Docker context, so same-named
+// project/service pairs on different contexts never collide in the map.
+func TestSchedulerHeldServiceKey_DiffersByContext(t *testing.T) {
+	defaultKey := schedulerHeldServiceKey("", "proj", "db")
+	explicitDefaultKey := schedulerHeldServiceKey("default", "proj", "db")
+	remoteKey := schedulerHeldServiceKey("remote", "proj", "db")
+
+	if defaultKey != explicitDefaultKey {
+		t.Fatalf("schedulerHeldServiceKey() produced different keys for default context aliases: %q and %q", defaultKey, explicitDefaultKey)
+	}
+
+	if defaultKey == remoteKey {
+		t.Fatalf("schedulerHeldServiceKey() produced the same key %q for different contexts", defaultKey)
+	}
+}
+
+func TestStackDeploymentKey_NormalizesDefaultContext(t *testing.T) {
+	defaultKey := stackDeploymentKey("repo", "", "stack")
+	explicitDefaultKey := stackDeploymentKey("repo", "default", "stack")
+	remoteKey := stackDeploymentKey("repo", "remote", "stack")
+
+	if defaultKey != explicitDefaultKey {
+		t.Fatalf("stackDeploymentKey() produced different keys for default context aliases: %q and %q", defaultKey, explicitDefaultKey)
+	}
+
+	if defaultKey == remoteKey {
+		t.Fatalf("stackDeploymentKey() produced the same key %q for different contexts", defaultKey)
+	}
+}

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -42,39 +42,29 @@ type contextualEvent struct {
 // initContextCLIs populates j.contextCLIs with a Docker CLI entry for the default context
 // and for every unique non-default context referenced in the job's deploy configs.
 func (j *job) initContextCLIs(ctx context.Context, quiet bool) {
-	contextCLIs := map[string]contextCLIEntry{
-		"": {cli: j.info.dockerCli, swarmMode: swarm.GetModeEnabled()},
-	}
+	contextCLIs := make(map[string]contextCLIEntry)
 
 	for _, dc := range j.info.deployConfigs {
-		ctxName := strings.TrimSpace(dc.Context)
-		if ctxName == "" {
-			continue
-		}
-
+		ctxName := docker.NormalizeContextName(dc.Context)
 		if _, already := contextCLIs[ctxName]; already {
 			continue
 		}
 
-		cli, closeFn, err := dockerCliForContext(j.info.dockerCli, quiet, ctxName)
-		if err != nil {
+		entry := resolveDeployContext(ctx, j.info.contexts, j.info.dockerCli, quiet, ctxName)
+		if entry.err != nil {
 			j.info.jobLog.Error("failed to create Docker CLI for context; skipping event listener for that context",
-				slog.String("context", ctxName),
-				logger.ErrAttr(err),
+				slog.String("context", docker.DisplayContextName(ctxName)),
+				logger.ErrAttr(entry.err),
 			)
 
 			continue
 		}
 
-		swarmMode, err := swarm.ResolveModeEnabled(ctx, cli.Client())
-		if err != nil {
-			j.info.jobLog.Warn("failed to determine swarm mode for context, assuming non-swarm",
-				slog.String("context", ctxName),
-				logger.ErrAttr(err),
-			)
+		contextCLIs[ctxName] = contextCLIEntry{
+			cli:       entry.cli,
+			closeFn:   entry.closeFn,
+			swarmMode: entry.swarmMode,
 		}
-
-		contextCLIs[ctxName] = contextCLIEntry{cli: cli, closeFn: closeFn, swarmMode: swarmMode}
 	}
 
 	j.contextCLIs = contextCLIs
@@ -83,7 +73,7 @@ func (j *job) initContextCLIs(ctx context.Context, quiet bool) {
 // cliForContext returns the Docker CLI for the given context name, falling back to the
 // default CLI if the context is not found.
 func (j *job) cliForContext(contextName string) command.Cli {
-	contextName = strings.TrimSpace(contextName)
+	contextName = docker.NormalizeContextName(contextName)
 	if j.contextCLIs != nil {
 		if e, ok := j.contextCLIs[contextName]; ok {
 			return e.cli
@@ -96,7 +86,7 @@ func (j *job) cliForContext(contextName string) command.Cli {
 // swarmModeForContext returns the swarm mode for the given context name, falling back to the
 // globally cached value for the default context.
 func (j *job) swarmModeForContext(contextName string) bool {
-	contextName = strings.TrimSpace(contextName)
+	contextName = docker.NormalizeContextName(contextName)
 	if j.contextCLIs != nil {
 		if e, ok := j.contextCLIs[contextName]; ok {
 			return e.swarmMode
@@ -429,7 +419,7 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 		return
 	}
 
-	if reconciliationHandler.isServiceSchedulerStopHeld(event.Actor.Attributes) {
+	if reconciliationHandler.isServiceSchedulerStopHeld(contextName, event.Actor.Attributes) {
 		jobLog.Debug("suppressing reconciliation event for service intentionally held stopped by job scheduler",
 			slog.String("event", action),
 			slog.String("stack", stackName),
@@ -575,7 +565,7 @@ func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConf
 
 	// handleDeploy accepts the base CLI; it handles per-context routing internally.
 	if err := handleDeploy(ctx, jobLog, j.info.appConfig,
-		j.info.dataMountPoint, j.info.dockerCli,
+		j.info.dataMountPoint, j.info.dockerCli, j.info.contexts,
 		j.info.secretProvider, metadata.JobID, j.info.jobTrigger,
 		j.info.repoData, reconcileDCs, j.info.payload, j.info.testName, metadata); err != nil {
 		jobLog.Error("failed to deploy", logger.ErrAttr(err))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -64,6 +64,9 @@ type scheduledJob struct {
 	containerState  string // Docker container state (container mode only), e.g. "running", "exited"
 	containerStatus string // Docker container status string (container mode only), e.g. "Exited (0) 2 hours ago"
 	running         bool   // An execution is currently active (e.g. a running one_off ephemeral container)
+	// context is the normalized Docker context name the job was discovered on
+	// (empty string means the default context). See docker.NormalizeContextName.
+	context string
 }
 
 type scheduledJobState struct {
@@ -76,7 +79,16 @@ type scheduledJobState struct {
 }
 
 type scheduler struct {
-	dockerCli      command.Cli
+	dockerCli command.Cli
+	// contextName is the normalized Docker context this worker operates on
+	// (empty string means the default context). See docker.NormalizeContextName.
+	contextName string
+	// swarmMode reflects the swarm mode of this worker's Docker context,
+	// resolved once via the context registry (or swarm.GetModeEnabled for the
+	// legacy single-context entry points). Using the per-context value instead
+	// of the process-global swarm.GetModeEnabled() lets each worker discover
+	// and schedule jobs correctly regardless of other contexts' modes.
+	swarmMode      bool
 	secretProvider *secretprovider.SecretProvider
 	log            *slog.Logger
 	wg             *sync.WaitGroup
@@ -101,8 +113,11 @@ type scheduler struct {
 }
 
 // stopHoldKey identifies a service that may be concurrently held stopped by
-// more than one scheduled job run.
+// more than one scheduled job run. context is the normalized Docker context
+// name the hold applies to, so that two workers operating on different
+// contexts never share a hold for a same-named project/service.
 type stopHoldKey struct {
+	context string
 	mode    scheduledJobMode
 	project string
 	service string
@@ -118,6 +133,7 @@ type stopHoldState struct {
 // JobInfo describes one scheduler-managed target and its runtime scheduling status.
 type JobInfo struct {
 	Name           string                  `json:"name"`
+	Context        string                  `json:"context"`
 	Enabled        bool                    `json:"enabled"`
 	Stack          string                  `json:"stack,omitempty"`
 	Mode           string                  `json:"mode"`
@@ -141,28 +157,52 @@ func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *syn
 		return
 	}
 
-	s := &scheduler{
-		dockerCli:      dockerCli,
+	s := newScheduler(docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}, log, wg, secretProvider)
+
+	s.run(ctx)
+}
+
+// newScheduler builds a scheduler worker bound to a single Docker context, as
+// resolved by a docker.ContextRegistry (or synthesised for the legacy
+// single-context entry points Start/ListJobs/TriggerNow). log and wg may be
+// nil for short-lived, one-shot workers (e.g. a single ListJobs/TriggerNow
+// call) that never call run().
+func newScheduler(cc docker.ContextClient, log *slog.Logger, wg *sync.WaitGroup, secretProvider *secretprovider.SecretProvider) *scheduler {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	contextName := docker.NormalizeContextName(cc.Name)
+
+	return &scheduler{
+		dockerCli:      cc.Cli,
+		contextName:    contextName,
+		swarmMode:      cc.SwarmMode,
 		secretProvider: secretProvider,
-		log:            log.With(slog.String("component", "scheduler")),
+		log:            log.With(slog.String("component", "scheduler"), slog.String("context", docker.DisplayContextName(contextName))),
 		wg:             wg,
 		startedAt:      schedulerNow(),
 		states:         map[string]scheduledJobState{},
 		running:        map[string]bool{},
 		stopHolds:      map[stopHoldKey]*stopHoldState{},
 	}
-
-	s.run(ctx)
 }
 
-// ListJobs returns all discovered scheduler jobs, optionally filtered by stack name.
+// ListJobs returns all discovered scheduler jobs on the default Docker context,
+// optionally filtered by stack name.
 func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]JobInfo, error) {
 	if dockerCli == nil {
 		return nil, errors.New("docker cli is required")
 	}
 
-	s := &scheduler{dockerCli: dockerCli}
+	s := newScheduler(docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}, nil, nil, nil)
 
+	return s.listJobs(ctx, stackName)
+}
+
+// listJobs returns all jobs discovered on this worker's Docker context,
+// optionally filtered by stack name.
+func (s *scheduler) listJobs(ctx context.Context, stackName string) ([]JobInfo, error) {
 	jobs, err := s.discoverJobs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover scheduled jobs: %w", err)
@@ -183,6 +223,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 
 		info := JobInfo{
 			Name:       job.name,
+			Context:    docker.DisplayContextName(job.context),
 			Stack:      stack,
 			Mode:       string(job.mode),
 			Repository: job.labels[docker.DocoCDLabels.Source.Name],
@@ -253,27 +294,25 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 	return result, nil
 }
 
-// TriggerNow executes one configured scheduled job immediately.
-// Job selection matches by container/service name and optional stack name.
+// TriggerNow executes one configured scheduled job immediately on the default
+// Docker context. Job selection matches by container/service name and
+// optional stack name.
 func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jobName, stackName string, secretProvider *secretprovider.SecretProvider) (string, error) {
 	if dockerCli == nil {
 		return "", errors.New("docker cli is required")
 	}
 
+	s := newScheduler(docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}, log, nil, secretProvider)
+
+	return s.triggerNow(ctx, jobName, stackName)
+}
+
+// triggerNow executes one configured scheduled job immediately on this
+// worker's Docker context. Job selection matches by container/service name
+// and optional stack name.
+func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (string, error) {
 	if strings.TrimSpace(jobName) == "" {
 		return "", errors.New("job name is required")
-	}
-
-	if log == nil {
-		log = slog.Default()
-	}
-
-	s := &scheduler{
-		dockerCli:      dockerCli,
-		log:            log.With(slog.String("component", "scheduler")),
-		running:        map[string]bool{},
-		stopHolds:      map[stopHoldKey]*stopHoldState{},
-		secretProvider: secretProvider,
 	}
 
 	jobs, err := s.discoverJobs(ctx)
@@ -317,7 +356,7 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 
 	// Lock the job's own stack plus any stacks referenced by stop_services (see lockStacks).
 	lockedStacks := append([]string{stack}, resolveStopServiceStacks(cfg.StopServices, stack)...)
-	unlockStacks := lockStacks(lockedStacks...)
+	unlockStacks := lockStacks(s.contextName, lockedStacks...)
 
 	defer unlockStacks()
 
@@ -341,6 +380,179 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 	s.sendRunNotification(job, cfg, runID, true, "Scheduled job completed", fmt.Sprintf("scheduled job '%s' completed successfully", job.name))
 
 	return runID, nil
+}
+
+// contextRefreshInterval controls how often Manager re-lists the Docker
+// context registry to pick up newly available contexts (e.g. one that was
+// previously unreachable) and start a worker for them. Contexts that are
+// already running a worker are left untouched.
+const contextRefreshInterval = time.Minute
+
+// Manager runs one scheduler worker per Docker context known to a
+// docker.ContextRegistry and exposes context-aware ListJobs/TriggerNow for
+// REST wiring. It can be constructed even when automatic scheduling is
+// disabled: Start only needs to be called to run the background workers,
+// while ListJobs/TriggerNow work standalone (discovering jobs on demand) as
+// long as the registry can resolve the requested context.
+type Manager struct {
+	registry       *docker.ContextRegistry
+	log            *slog.Logger
+	wg             *sync.WaitGroup
+	secretProvider *secretprovider.SecretProvider
+
+	mu      sync.Mutex
+	workers map[string]managedWorker // key = normalized context name
+}
+
+type managedWorker struct {
+	cancel    context.CancelFunc
+	swarmMode bool
+}
+
+// NewManager creates a scheduler Manager bound to registry. log and wg are
+// required for Start (running background workers) but may be omitted if the
+// Manager is only used for on-demand ListJobs/TriggerNow calls.
+func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.WaitGroup, secretProvider *secretprovider.SecretProvider) *Manager {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	return &Manager{
+		registry:       registry,
+		log:            log.With(slog.String("component", "scheduler_manager")),
+		wg:             wg,
+		secretProvider: secretProvider,
+		workers:        map[string]managedWorker{},
+	}
+}
+
+// Start launches one background scheduler worker per Docker context currently
+// known to the registry, and periodically re-lists the registry to start
+// workers for any contexts that become available later. Contexts that fail to
+// resolve (e.g. an unreachable remote daemon) are logged and skipped without
+// affecting already-running workers for other contexts.
+func (m *Manager) Start(ctx context.Context) {
+	if m == nil || m.registry == nil || m.wg == nil {
+		return
+	}
+
+	m.refreshWorkers(ctx)
+
+	graceful.SafeGo(m.wg, m.log, func() {
+		ticker := time.NewTicker(contextRefreshInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				m.refreshWorkers(ctx)
+			}
+		}
+	})
+}
+
+// refreshWorkers reconciles scheduler workers with the current context list.
+// Unavailable contexts do not disturb existing workers, while removed contexts
+// are stopped and swarm-mode changes restart only the affected worker.
+func (m *Manager) refreshWorkers(ctx context.Context) {
+	results, err := m.registry.List(ctx)
+	if err != nil {
+		m.log.Error("failed to list docker contexts for scheduler", logger.ErrAttr(err))
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	available := make(map[string]struct{}, len(results))
+	for _, result := range results {
+		name := docker.NormalizeContextName(result.Name)
+		available[name] = struct{}{}
+
+		running, hasWorker := m.workers[name]
+		if result.Err != nil {
+			if hasWorker {
+				continue
+			}
+
+			m.log.Warn("skipping unavailable docker context for scheduler",
+				slog.String("context", docker.DisplayContextName(name)),
+				logger.ErrAttr(result.Err),
+			)
+
+			continue
+		}
+
+		if hasWorker && running.swarmMode == result.SwarmMode {
+			continue
+		}
+
+		if hasWorker {
+			running.cancel()
+			delete(m.workers, name)
+			m.log.Info("restarting scheduler worker after Docker swarm mode changed",
+				slog.String("context", docker.DisplayContextName(name)),
+			)
+		}
+
+		worker := newScheduler(result.ContextClient, m.log, m.wg, m.secretProvider)
+		workerCtx, cancel := context.WithCancel(ctx)
+		m.workers[name] = managedWorker{
+			cancel:    cancel,
+			swarmMode: result.SwarmMode,
+		}
+
+		graceful.SafeGo(m.wg, m.log, func() {
+			worker.run(workerCtx)
+		})
+	}
+
+	for name, worker := range m.workers {
+		if _, ok := available[name]; ok {
+			continue
+		}
+
+		worker.cancel()
+		delete(m.workers, name)
+		clearRuntimeContext(name)
+		m.log.Info("stopped scheduler worker for removed Docker context",
+			slog.String("context", docker.DisplayContextName(name)),
+		)
+	}
+}
+
+// ListJobs returns all discovered scheduler jobs for the given Docker context
+// (normalized/display form accepted, empty means the default context),
+// optionally filtered by stack name.
+func (m *Manager) ListJobs(ctx context.Context, contextName, stackName string) ([]JobInfo, error) {
+	if m == nil || m.registry == nil {
+		return nil, errors.New("scheduler manager is not configured with a docker context registry")
+	}
+
+	cc, err := m.registry.Get(ctx, contextName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
+	}
+
+	return newScheduler(cc, m.log, nil, m.secretProvider).listJobs(ctx, stackName)
+}
+
+// TriggerNow executes one configured scheduled job immediately on the given
+// Docker context. Job selection matches by container/service name and
+// optional stack name.
+func (m *Manager) TriggerNow(ctx context.Context, contextName, jobName, stackName string, secretProvider *secretprovider.SecretProvider) (string, error) {
+	if m == nil || m.registry == nil {
+		return "", errors.New("scheduler manager is not configured with a docker context registry")
+	}
+
+	cc, err := m.registry.Get(ctx, contextName)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
+	}
+
+	return newScheduler(cc, m.log, nil, secretProvider).triggerNow(ctx, jobName, stackName)
 }
 
 func findRunnableJob(jobs []scheduledJob, jobName, stackName string) (scheduledJob, docker.JobScheduleConfig, error) {
@@ -532,7 +744,7 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 		nearestNextRun, _ = getNearestNextRun(s.states)
 	}
 
-	setRuntimeStatesSnapshot(s.states)
+	setRuntimeStatesSnapshot(s.contextName, s.states)
 
 	return nearestNextRun, !nearestNextRun.IsZero()
 }
@@ -545,7 +757,7 @@ func (s *scheduler) watchJobChanges(ctx context.Context) <-chan struct{} {
 
 		for ctx.Err() == nil {
 			filters := make(client.Filters)
-			if swarm.GetModeEnabled() {
+			if s.swarmMode {
 				filters.Add("type", "service")
 
 				for _, action := range []string{"create", "update", "remove"} {
@@ -610,7 +822,7 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 		return nil, nil
 	}
 
-	if swarm.GetModeEnabled() {
+	if s.swarmMode {
 		services, err := s.dockerCli.Client().ServiceList(ctx, client.ServiceListOptions{})
 		if err != nil {
 			return nil, err
@@ -626,11 +838,12 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 			labels := docker.SwarmJobLabels(svc)
 
 			result = append(result, scheduledJob{
-				key:    "swarm:" + svc.ID,
-				name:   svc.Spec.Name,
-				id:     svc.Spec.Name,
-				mode:   scheduledJobModeSwarm,
-				labels: labels,
+				key:     jobKeyPrefix(s.contextName) + "swarm:" + svc.ID,
+				name:    svc.Spec.Name,
+				id:      svc.Spec.Name,
+				mode:    scheduledJobModeSwarm,
+				labels:  labels,
+				context: s.contextName,
 			})
 		}
 
@@ -649,7 +862,7 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 	runningEphemeralByKey := make(map[string]bool)
 
 	for _, c := range containers.Items {
-		key := containerJobKey(c.ID, c.Labels)
+		key := jobKeyPrefix(s.contextName) + containerJobKey(c.ID, c.Labels)
 
 		// One_off runs execute in an ephemeral clone of the source container that
 		// carries the same compose project/service labels. It must not be treated
@@ -681,6 +894,7 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 			labels:          c.Labels,
 			containerState:  string(c.State),
 			containerStatus: c.Status,
+			context:         s.contextName,
 		}
 	}
 
@@ -746,7 +960,7 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 		lockedStacks := append([]string{stackName}, resolveStopServiceStacks(cfg.StopServices, stackName)...)
 
 		runLog.Debug("waiting for scheduler/deploy lock(s)", slog.Any("stacks", lockedStacks))
-		unlockStacks := lockStacks(lockedStacks...)
+		unlockStacks := lockStacks(s.contextName, lockedStacks...)
 
 		defer unlockStacks()
 
@@ -864,7 +1078,7 @@ const stopServicesTimeout = 30 * time.Second
 // already held stopped and must not stop it again or restore it until they
 // are the last holder to release it.
 func (s *scheduler) acquireStopHold(mode scheduledJobMode, project, service string) bool {
-	key := stopHoldKey{mode: mode, project: project, service: service}
+	key := stopHoldKey{context: s.contextName, mode: mode, project: project, service: service}
 
 	s.stopHoldsMu.Lock()
 	defer s.stopHoldsMu.Unlock()
@@ -883,7 +1097,7 @@ func (s *scheduler) acquireStopHold(mode scheduledJobMode, project, service stri
 // setStopHoldReplicas records the original swarm replica count for a held
 // service, so the last holder to release it can restore it.
 func (s *scheduler) setStopHoldReplicas(mode scheduledJobMode, project, service string, replicas uint64) {
-	key := stopHoldKey{mode: mode, project: project, service: service}
+	key := stopHoldKey{context: s.contextName, mode: mode, project: project, service: service}
 
 	s.stopHoldsMu.Lock()
 	defer s.stopHoldsMu.Unlock()
@@ -898,7 +1112,7 @@ func (s *scheduler) setStopHoldReplicas(mode scheduledJobMode, project, service 
 // holder, meaning the caller must actually perform the restart; otherwise
 // another concurrent run still needs the target held stopped.
 func (s *scheduler) releaseStopHold(mode scheduledJobMode, project, service string) (isLast bool, replicas uint64) {
-	key := stopHoldKey{mode: mode, project: project, service: service}
+	key := stopHoldKey{context: s.contextName, mode: mode, project: project, service: service}
 
 	s.stopHoldsMu.Lock()
 	defer s.stopHoldsMu.Unlock()
@@ -961,7 +1175,7 @@ func (s *scheduler) stopServicesForJob(ctx context.Context, mode scheduledJobMod
 			// Mark each service as scheduler-held so that the reconciliation
 			// event listener does not restart it while the job is running.
 			for _, svc := range toStop {
-				reconciliation.MarkSchedulerStopHeld(project, svc)
+				reconciliation.MarkSchedulerStopHeld(s.contextName, project, svc)
 			}
 
 			s.log.Info("stopping services before scheduled job",
@@ -1073,7 +1287,7 @@ func (s *scheduler) startServicesForJob(ctx context.Context, mode scheduledJobMo
 			// Unmark the scheduler hold before starting — if our start fails,
 			// reconciliation can step in and recover the service.
 			for _, svc := range toStart {
-				reconciliation.UnmarkSchedulerStopHeld(project, svc)
+				reconciliation.UnmarkSchedulerStopHeld(s.contextName, project, svc)
 			}
 
 			s.log.Info("restarting services after scheduled job",
@@ -1134,9 +1348,12 @@ func (s *scheduler) startServicesForJob(ctx context.Context, mode scheduledJobMo
 // caller-supplied order — prevents ABBA deadlocks when two scheduled runs
 // need to lock an overlapping set of stacks concurrently (e.g. a job's own
 // stack plus stacks referenced by its stop_services, which another run might
-// need to lock in the opposite order). It returns an unlock function that
-// releases all acquired locks; callers must call it exactly once.
-func lockStacks(stacks ...string) (unlock func()) {
+// need to lock in the opposite order). Stack names are only unique within a
+// Docker context (see lock.StackKey), so contextName is included in every
+// lock key to keep same-named stacks on different contexts from blocking each
+// other. It returns an unlock function that releases all acquired locks;
+// callers must call it exactly once.
+func lockStacks(contextName string, stacks ...string) (unlock func()) {
 	seen := make(map[string]struct{}, len(stacks))
 	unique := make([]string, 0, len(stacks))
 
@@ -1146,18 +1363,19 @@ func lockStacks(stacks ...string) (unlock func()) {
 			continue
 		}
 
-		if _, ok := seen[stack]; ok {
+		key := lock.StackKey(contextName, stack)
+		if _, ok := seen[key]; ok {
 			continue
 		}
 
-		seen[stack] = struct{}{}
-		unique = append(unique, stack)
+		seen[key] = struct{}{}
+		unique = append(unique, key)
 	}
 
 	sort.Strings(unique)
 
-	for _, stack := range unique {
-		lock.LockStack(stack)
+	for _, key := range unique {
+		lock.LockStack(key)
 	}
 
 	return func() {
@@ -1244,6 +1462,7 @@ func (s *scheduler) sendRunNotification(job scheduledJob, cfg docker.JobSchedule
 		Repository:        job.labels[docker.DocoCDLabels.Source.Name],
 		Stack:             job.labels[docker.DocoCDLabels.Deployment.Name],
 		Target:            job.labels[docker.DocoCDLabels.Deployment.ConfigTarget],
+		Context:           docker.DisplayContextName(job.context),
 		Revision:          notification.GetRevision("", job.labels[docker.DocoCDLabels.Deployment.CommitSHA]),
 		JobID:             runID,
 		AffectedActorKind: actorKind,
@@ -1311,7 +1530,7 @@ func shouldStopContainerForOneOffDeployRun(job scheduledJob, cfg docker.JobSched
 }
 
 func getScheduledRunMetricLabels(job scheduledJob, cfg docker.JobScheduleConfig, stackName string) []string {
-	return []string{stackName, job.name, string(job.mode), string(cfg.ExecutionMode)}
+	return []string{docker.DisplayContextName(job.context), stackName, job.name, string(job.mode), string(cfg.ExecutionMode)}
 }
 
 func nextScheduledRun(schedule gocron.Cron, scheduledAt, now time.Time) time.Time {
@@ -1461,6 +1680,20 @@ func isEphemeralScheduledContainer(labels map[string]string) bool {
 	return strings.EqualFold(strings.TrimSpace(labels[api.OneoffLabel]), "true")
 }
 
+// jobKeyPrefix returns the prefix applied to every scheduler job/runtime state
+// key discovered on contextName, so that the same compose project/service or
+// swarm service ID on two different Docker daemons never collide in the
+// (process-global) runtime state, run-status, or in-progress maps. The
+// default context keeps the historical unprefixed keys for compatibility with
+// state persisted before multi-context support existed.
+func jobKeyPrefix(contextName string) string {
+	if contextName == "" {
+		return ""
+	}
+
+	return contextName + "::"
+}
+
 // containerJobKey derives the stable scheduler key for a container from its
 // compose project/service labels, falling back to the container ID. An ephemeral
 // one_off clone shares the source's project/service labels, so it resolves to the
@@ -1550,13 +1783,18 @@ func schedulerNow() time.Time {
 	return time.Now().In(time.Local)
 }
 
-// setRuntimeStatesSnapshot merges in the loop's recomputed states, keeping
-// the newer lastRun so a manually triggered run isn't wiped by the next tick.
-func setRuntimeStatesSnapshot(states map[string]scheduledJobState) {
+// setRuntimeStatesSnapshot replaces one context's states while preserving all
+// other context partitions and newer manual-run timestamps.
+func setRuntimeStatesSnapshot(contextName string, states map[string]scheduledJobState) {
 	runtimeStatesMu.Lock()
 	defer runtimeStatesMu.Unlock()
 
-	merged := make(map[string]scheduledJobState, len(states))
+	merged := make(map[string]scheduledJobState, len(runtimeStates)+len(states))
+	for key, state := range runtimeStates {
+		if !runtimeKeyInContext(contextName, key) {
+			merged[key] = state
+		}
+	}
 
 	for key, state := range states {
 		if existing, ok := runtimeStates[key]; ok && existing.lastRun.After(state.lastRun) {
@@ -1567,6 +1805,37 @@ func setRuntimeStatesSnapshot(states map[string]scheduledJobState) {
 	}
 
 	runtimeStates = merged
+}
+
+func runtimeKeyInContext(contextName, key string) bool {
+	if contextName == "" {
+		return !strings.Contains(key, "::")
+	}
+
+	return strings.HasPrefix(key, jobKeyPrefix(contextName))
+}
+
+func clearRuntimeContext(contextName string) {
+	runtimeStatesMu.Lock()
+	defer runtimeStatesMu.Unlock()
+
+	for key := range runtimeStates {
+		if runtimeKeyInContext(contextName, key) {
+			delete(runtimeStates, key)
+		}
+	}
+
+	for key := range runtimeRunStatuses {
+		if runtimeKeyInContext(contextName, key) {
+			delete(runtimeRunStatuses, key)
+		}
+	}
+
+	for key := range runtimeRunningStates {
+		if runtimeKeyInContext(contextName, key) {
+			delete(runtimeRunningStates, key)
+		}
+	}
 }
 
 func getRuntimeStatesSnapshot() map[string]scheduledJobState {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -373,7 +374,7 @@ func TestSetRuntimeStatesSnapshot_PreservesNewerManualLastRun(t *testing.T) {
 	setRuntimeLastRun(key, manualRun)
 
 	// Simulate the loop's next refresh, unaware of the manual run.
-	setRuntimeStatesSnapshot(map[string]scheduledJobState{
+	setRuntimeStatesSnapshot("", map[string]scheduledJobState{
 		key: {nextRun: manualRun.Add(time.Hour)},
 	})
 
@@ -384,13 +385,84 @@ func TestSetRuntimeStatesSnapshot_PreservesNewerManualLastRun(t *testing.T) {
 
 	// A genuinely newer lastRun must still win.
 	newerRun := manualRun.Add(2 * time.Hour)
-	setRuntimeStatesSnapshot(map[string]scheduledJobState{
+	setRuntimeStatesSnapshot("", map[string]scheduledJobState{
 		key: {lastRun: newerRun},
 	})
 
 	got = getRuntimeStatesSnapshot()[key]
 	if !got.lastRun.Equal(newerRun) {
 		t.Fatalf("expected newer scheduler-tracked last run %v to win, got %v", newerRun, got.lastRun)
+	}
+}
+
+func TestSetRuntimeStatesSnapshotPreservesOtherContexts(t *testing.T) {
+	runtimeStatesMu.Lock()
+	runtimeStates = map[string]scheduledJobState{
+		"remote::container:shared/job": {deployment: "remote"},
+	}
+	runtimeStatesMu.Unlock()
+
+	setRuntimeStatesSnapshot("", map[string]scheduledJobState{
+		"container:shared/job": {deployment: "default"},
+	})
+
+	states := getRuntimeStatesSnapshot()
+	if len(states) != 2 {
+		t.Fatalf("expected both context partitions, got %#v", states)
+	}
+
+	setRuntimeStatesSnapshot("remote", map[string]scheduledJobState{})
+
+	states = getRuntimeStatesSnapshot()
+	if _, ok := states["remote::container:shared/job"]; ok {
+		t.Fatal("expected stale remote state to be removed")
+	}
+
+	if _, ok := states["container:shared/job"]; !ok {
+		t.Fatal("expected default state to be preserved")
+	}
+}
+
+func TestClearRuntimeContext(t *testing.T) {
+	t.Cleanup(func() {
+		runtimeStatesMu.Lock()
+		runtimeStates = map[string]scheduledJobState{}
+		runtimeRunStatuses = map[string]string{}
+		runtimeRunningStates = map[string]bool{}
+		runtimeStatesMu.Unlock()
+	})
+
+	runtimeStatesMu.Lock()
+	runtimeStates = map[string]scheduledJobState{
+		"container:shared/job":         {deployment: "default"},
+		"remote::container:shared/job": {deployment: "remote"},
+	}
+	runtimeRunStatuses = map[string]string{
+		"container:shared/job":         "running",
+		"remote::container:shared/job": "exited (0)",
+	}
+	runtimeRunningStates = map[string]bool{
+		"container:shared/job":         true,
+		"remote::container:shared/job": true,
+	}
+	runtimeStatesMu.Unlock()
+
+	clearRuntimeContext("remote")
+
+	if _, ok := getRuntimeStatesSnapshot()["remote::container:shared/job"]; ok {
+		t.Fatal("expected remote runtime state to be removed")
+	}
+
+	if _, ok := getRuntimeRunStatusesSnapshot()["remote::container:shared/job"]; ok {
+		t.Fatal("expected remote run status to be removed")
+	}
+
+	if _, ok := getRuntimeRunningStatesSnapshot()["remote::container:shared/job"]; ok {
+		t.Fatal("expected remote running state to be removed")
+	}
+
+	if _, ok := getRuntimeStatesSnapshot()["container:shared/job"]; !ok {
+		t.Fatal("expected default runtime state to be preserved")
 	}
 }
 
@@ -611,14 +683,40 @@ func TestLockStacks_DeduplicatesAndLocksSortedOrder(t *testing.T) {
 
 	// Repeated/empty entries must not cause a self-deadlock (locking the same
 	// stack twice) and must not be double-unlocked.
-	unlock := lockStacks("zeta", "alpha", "alpha", "", "zeta")
+	unlock := lockStacks("", "zeta", "alpha", "alpha", "", "zeta")
 	unlock()
 
 	// If dedup/unlock bookkeeping were broken, acquiring the same stacks again
 	// would deadlock (this call would hang forever), so a normal test timeout
 	// failure would catch it.
-	unlock2 := lockStacks("alpha", "zeta")
+	unlock2 := lockStacks("", "alpha", "zeta")
 	unlock2()
+}
+
+func TestLockStacks_SameStackDifferentContextsDoNotBlock(t *testing.T) {
+	t.Parallel()
+
+	// Two different Docker contexts using the same stack name must not share
+	// a lock (see lock.StackKey): locking "prod" on "context-a" must not block
+	// locking "prod" on "context-b" concurrently.
+	unlockA := lockStacks("context-a", "prod")
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		unlockB := lockStacks("context-b", "prod")
+		unlockB()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("lockStacks() for the same stack name on a different context blocked; expected independent locks")
+	}
+
+	unlockA()
 }
 
 func TestStopHold_RefCounting(t *testing.T) {
@@ -684,5 +782,95 @@ func TestStopHold_SwarmReplicasSurviveUntilLastRelease(t *testing.T) {
 
 	if replicas != 3 {
 		t.Fatalf("replicas = %d, want 3", replicas)
+	}
+}
+
+func TestStopHold_IsolatedAcrossContexts(t *testing.T) {
+	t.Parallel()
+
+	// Two scheduler workers on different Docker contexts must not share a
+	// stop hold for the same project/service name: a hold acquired on one
+	// context must not be visible to (or block) the other context's worker.
+	sDefault := &scheduler{contextName: "", stopHolds: map[stopHoldKey]*stopHoldState{}}
+	sRemote := &scheduler{contextName: "remote", stopHolds: map[stopHoldKey]*stopHoldState{}}
+
+	if isFirst := sDefault.acquireStopHold(scheduledJobModeContainer, "proj", "db"); !isFirst {
+		t.Fatal("expected first acquireStopHold() on default context to report isFirst=true")
+	}
+
+	// The same project/service on a different context must be an independent
+	// hold, so this must also report isFirst=true.
+	if isFirst := sRemote.acquireStopHold(scheduledJobModeContainer, "proj", "db"); !isFirst {
+		t.Fatal("expected first acquireStopHold() on remote context to report isFirst=true, holds leaked across contexts")
+	}
+
+	if isLast, _ := sRemote.releaseStopHold(scheduledJobModeContainer, "proj", "db"); !isLast {
+		t.Fatal("expected releaseStopHold() on remote context to report isLast=true")
+	}
+
+	// Releasing the remote context's hold must not have touched the default
+	// context's hold.
+	if isLast, _ := sDefault.releaseStopHold(scheduledJobModeContainer, "proj", "db"); !isLast {
+		t.Fatal("expected releaseStopHold() on default context to report isLast=true")
+	}
+}
+
+func TestJobKeyPrefix(t *testing.T) {
+	t.Parallel()
+
+	if got := jobKeyPrefix(""); got != "" {
+		t.Fatalf("jobKeyPrefix(\"\") = %q, want empty (default context keeps unprefixed keys)", got)
+	}
+
+	if got, want := jobKeyPrefix("remote"), "remote::"; got != want {
+		t.Fatalf("jobKeyPrefix(%q) = %q, want %q", "remote", got, want)
+	}
+}
+
+func TestGetScheduledRunMetricLabels_IncludesContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := docker.JobScheduleConfig{ExecutionMode: docker.JobExecutionModeOneOff}
+
+	defaultJob := scheduledJob{name: "backup", mode: scheduledJobModeContainer, context: ""}
+	if got, want := getScheduledRunMetricLabels(defaultJob, cfg, "stack"), []string{"default", "stack", "backup", "container", "one_off"}; !slices.Equal(got, want) {
+		t.Fatalf("getScheduledRunMetricLabels() = %v, want %v", got, want)
+	}
+
+	remoteJob := scheduledJob{name: "backup", mode: scheduledJobModeContainer, context: "remote"}
+	if got, want := getScheduledRunMetricLabels(remoteJob, cfg, "stack"), []string{"remote", "stack", "backup", "container", "one_off"}; !slices.Equal(got, want) {
+		t.Fatalf("getScheduledRunMetricLabels() = %v, want %v", got, want)
+	}
+}
+
+func TestJobInfo_ContextField(t *testing.T) {
+	t.Parallel()
+
+	// JobInfo.Context must use the external display value ("default"), not
+	// the internal normalized (empty-string) representation.
+	if got, want := docker.DisplayContextName(""), "default"; got != want {
+		t.Fatalf("docker.DisplayContextName(\"\") = %q, want %q", got, want)
+	}
+}
+
+func TestNewScheduler_NormalizesContextAndCarriesSwarmMode(t *testing.T) {
+	t.Parallel()
+
+	s := newScheduler(docker.ContextClient{Name: "Default", SwarmMode: true}, nil, nil, nil)
+	if s.contextName != "" {
+		t.Fatalf("newScheduler() contextName = %q, want empty string for the default context", s.contextName)
+	}
+
+	if !s.swarmMode {
+		t.Fatal("newScheduler() did not carry through SwarmMode=true from the context client")
+	}
+
+	remote := newScheduler(docker.ContextClient{Name: "remote", SwarmMode: false}, nil, nil, nil)
+	if remote.contextName != "remote" {
+		t.Fatalf("newScheduler() contextName = %q, want %q", remote.contextName, "remote")
+	}
+
+	if remote.swarmMode {
+		t.Fatal("newScheduler() reported swarmMode=true, want false")
 	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,15 @@
       "matchStrings": ["\\sgo (?<currentValue>.+?)\\s"],
       "depNameTemplate": "golang",
       "datasourceTemplate": "golang-version"
+    },
+    {
+      "customType": "regex",
+      "description": "Track Docker-in-Docker image tag used by e2e harness",
+      "managerFilePatterns": ["/test\\/e2e\\/harness\\.go$/"],
+      "matchStrings": [
+        "Image:\\s+\\\"(?<depName>docker):(?<currentValue>[0-9]+-dind)\\\""
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -46,7 +46,9 @@ scenarios/<name>/
 Each scenario gets its own Harness: its own docker network, its own
 gitserver and doco-cd containers, its own host-side git repo and worktree,
 and its own `/data` volume - so scenarios are isolated and can run in
-parallel (`t.Parallel()`).
+parallel (`t.Parallel()`). Scenarios that call `EnableRemoteContext` also
+receive a privileged Docker-in-Docker daemon registered as the `remote`
+context.
 
 The daemon polls `http://gitserver/<scenario>.git` every 10s (the minimum).
 Commits are written directly into the repo's storage directory via go-git,

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -260,8 +260,7 @@ func (h *Harness) startRemoteDocker() {
 	}
 
 	remoteDocker, err := client.New(
-		client.WithHost("tcp://"+net.JoinHostPort(host, port.Port())),
-		client.WithAPIVersionNegotiation(),
+		client.WithHost("tcp://" + net.JoinHostPort(host, port.Port())),
 	)
 	if err != nil {
 		_ = remote.Terminate(h.ctx)

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -9,6 +9,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,6 +49,11 @@ type Harness struct {
 	net    *testcontainers.DockerNetwork
 	gitSrv testcontainers.Container
 	daemon testcontainers.Container
+
+	remoteContext    bool
+	contextConfigDir string
+	remoteDaemon     testcontainers.Container
+	remoteDocker     *client.Client
 
 	teardownOnce sync.Once
 }
@@ -99,6 +105,13 @@ func NewHarness(t *testing.T, scenario string) *Harness {
 	return h
 }
 
+// EnableRemoteContext adds a second disposable Docker daemon exposed to doco-cd
+// as the named context "remote". Call before Start.
+func (h *Harness) EnableRemoteContext() {
+	h.t.Helper()
+	h.remoteContext = true
+}
+
 // Start creates the initial fixture commit, builds and starts the gitserver
 // + doco-cd containers, and waits for the daemon to become healthy.
 func (h *Harness) Start() {
@@ -123,6 +136,11 @@ func (h *Harness) Start() {
 	h.net = net
 
 	h.startGitServer()
+
+	if h.remoteContext {
+		h.startRemoteDocker()
+		h.writeDockerContextConfig()
+	}
 
 	pollPath := h.writePollConfig()
 	h.startDaemon(pollPath)
@@ -174,6 +192,7 @@ func (h *Harness) startDaemon(pollConfigPath string) {
 				"TZ":               "Etc/UTC",
 				"LOG_LEVEL":        "debug",
 				"POLL_CONFIG_FILE": "/config/poll.yaml",
+				"DOCKER_CONFIG":    "/root/.docker",
 			},
 			Mounts: testcontainers.ContainerMounts{
 				{Source: testcontainers.GenericVolumeMountSource{Name: h.dataVolume}, Target: "/data"},
@@ -183,6 +202,9 @@ func (h *Harness) startDaemon(pollConfigPath string) {
 					"/var/run/docker.sock:/var/run/docker.sock",
 					pollConfigPath+":/config/poll.yaml:ro",
 				)
+				if h.contextConfigDir != "" {
+					hc.Binds = append(hc.Binds, h.contextConfigDir+":/root/.docker:ro")
+				}
 			},
 			WaitingFor: wait.ForExec([]string{"/doco-cd", "healthcheck"}).
 				WithStartupTimeout(60 * time.Second).
@@ -198,6 +220,80 @@ func (h *Harness) startDaemon(pollConfigPath string) {
 
 	h.daemon = daemon
 	h.logContainerStart("doco-cd", daemon)
+}
+
+func (h *Harness) startRemoteDocker() {
+	h.t.Helper()
+
+	remote, err := testcontainers.GenericContainer(h.ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:          "docker:29-dind",
+			Name:           h.containerName("remote-docker"),
+			Networks:       []string{h.net.Name},
+			NetworkAliases: map[string][]string{h.net.Name: {"remote-docker"}},
+			Env:            map[string]string{"DOCKER_TLS_CERTDIR": ""},
+			Cmd:            []string{"--host=tcp://0.0.0.0:2375"},
+			ExposedPorts:   []string{"2375/tcp"},
+			HostConfigModifier: func(hc *container.HostConfig) {
+				hc.Privileged = true
+			},
+			WaitingFor: wait.ForListeningPort("2375/tcp").
+				WithStartupTimeout(90 * time.Second).
+				WithPollInterval(500 * time.Millisecond),
+		},
+		Started: true,
+	})
+	if err != nil {
+		h.t.Fatalf("start remote Docker daemon: %v", err)
+	}
+
+	host, err := remote.Host(h.ctx)
+	if err != nil {
+		_ = remote.Terminate(h.ctx)
+		h.t.Fatalf("resolve remote Docker host: %v", err)
+	}
+
+	port, err := remote.MappedPort(h.ctx, "2375/tcp")
+	if err != nil {
+		_ = remote.Terminate(h.ctx)
+		h.t.Fatalf("resolve remote Docker port: %v", err)
+	}
+
+	remoteDocker, err := client.New(
+		client.WithHost("tcp://"+net.JoinHostPort(host, port.Port())),
+		client.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		_ = remote.Terminate(h.ctx)
+		h.t.Fatalf("create remote Docker client: %v", err)
+	}
+
+	if _, err := remoteDocker.Ping(h.ctx, client.PingOptions{}); err != nil {
+		_ = remoteDocker.Close()
+		_ = remote.Terminate(h.ctx)
+		h.t.Fatalf("ping remote Docker daemon: %v", err)
+	}
+
+	h.remoteDaemon = remote
+	h.remoteDocker = remoteDocker
+	h.logContainerStart("remote-docker", remote)
+}
+
+func (h *Harness) writeDockerContextConfig() {
+	h.t.Helper()
+
+	configDir := filepath.Join(h.workDir, "docker-config")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		h.t.Fatalf("create Docker context config: %v", err)
+	}
+
+	cmd := exec.Command("docker", "--config", configDir, "context", "create", "remote",
+		"--docker", "host=tcp://remote-docker:2375")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		h.t.Fatalf("create remote Docker context: %v\n%s", err, out)
+	}
+
+	h.contextConfigDir = configDir
 }
 
 // prewarmImages starts both image builds in the background so repo, fixture
@@ -378,6 +474,14 @@ func (h *Harness) teardownInternal() {
 
 		h.cleanupStacks()
 
+		if h.remoteDocker != nil {
+			_ = h.remoteDocker.Close()
+		}
+
+		if h.remoteDaemon != nil {
+			_ = h.remoteDaemon.Terminate(h.ctx)
+		}
+
 		if h.gitSrv != nil {
 			_ = h.gitSrv.Terminate(h.ctx)
 		}
@@ -396,6 +500,11 @@ func (h *Harness) logFailure() {
 	if h.t.Failed() {
 		h.logf("--- daemon logs (last 100 lines) ---")
 		h.dumpTailLogs(h.daemon, 100)
+
+		if h.remoteDaemon != nil {
+			h.logf("--- remote Docker logs (last 100 lines) ---")
+			h.dumpTailLogs(h.remoteDaemon, 100)
+		}
 	}
 }
 

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -189,8 +189,26 @@ func (h *Harness) dumpTailLogs(c logsContainer, n int) {
 func (h *Harness) ContainerID(project, service string) string {
 	h.t.Helper()
 
+	return h.containerID(h.docker, h.isSwarmMode(), project, service)
+}
+
+// RemoteContainerID returns a Compose container from the disposable remote
+// Docker context enabled with EnableRemoteContext.
+func (h *Harness) RemoteContainerID(project, service string) string {
+	h.t.Helper()
+
+	if h.remoteDocker == nil {
+		h.t.Fatal("remote Docker context is not enabled")
+	}
+
+	return h.containerID(h.remoteDocker, false, project, service)
+}
+
+func (h *Harness) containerID(dockerClient *client.Client, swarmMode bool, project, service string) string {
+	h.t.Helper()
+
 	f := client.Filters{}
-	if h.isSwarmMode() {
+	if swarmMode {
 		f = f.
 			Add("label", "com.docker.stack.namespace="+project).
 			Add("label", "com.docker.swarm.service.name="+project+"_"+service)
@@ -200,7 +218,7 @@ func (h *Harness) ContainerID(project, service string) string {
 			Add("label", "com.docker.compose.service="+service)
 	}
 
-	containers, err := h.docker.ContainerList(h.ctx, client.ContainerListOptions{Filters: f})
+	containers, err := dockerClient.ContainerList(h.ctx, client.ContainerListOptions{Filters: f})
 	if err != nil {
 		h.t.Fatalf("list containers for %s/%s: %v", project, service, err)
 	}

--- a/test/e2e/multi_context_test.go
+++ b/test/e2e/multi_context_test.go
@@ -1,0 +1,23 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMultiContextSameNameDeployment(t *testing.T) {
+	t.Parallel()
+
+	h := NewHarness(t, "multi-context")
+	h.EnableRemoteContext()
+	h.Start()
+
+	h.WaitFor(2*time.Minute, "same-named stack deployed on default context", func() bool {
+		return h.ContainerID("e2e-multi-context", "app") != ""
+	})
+	h.WaitFor(2*time.Minute, "same-named stack deployed on remote context", func() bool {
+		return h.RemoteContainerID("e2e-multi-context", "app") != ""
+	})
+}

--- a/test/e2e/scenarios/multi-context/fixture/.doco-cd.yml
+++ b/test/e2e/scenarios/multi-context/fixture/.doco-cd.yml
@@ -1,0 +1,7 @@
+name: e2e-multi-context
+working_dir: deploy
+context: default
+---
+name: e2e-multi-context
+working_dir: deploy
+context: remote

--- a/test/e2e/scenarios/multi-context/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/multi-context/fixture/deploy/compose.yaml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine:3.22
+    command: ["sleep", "600"]

--- a/wiki/docs/Advanced/Docker-Contexts.md
+++ b/wiki/docs/Advanced/Docker-Contexts.md
@@ -168,6 +168,13 @@ working_dir: deploy
 Each deployment uses its own Docker context for deploy, destroy, and cleanup operations. 
 Stack/project names must be unique within a Docker context, but the same name can be used on different contexts.
 
+## Operational context support
+
+The scheduler and certificate-rotation watcher inspect DocoCD-managed resources on every context available in the mounted Docker CLI context store. Failures on one context do not stop processing on healthy contexts.
+
+Project, stack, and scheduled-job [REST API](../Endpoints/REST-API.md#docker-context-selection) endpoints accept `?context=<name>`. Omitting the parameter uses `default`. 
+Deployment and scheduled-job metrics include a `context` label, and deployment-run metadata reports each resolved context/stack target.
+
 ## Remote host limitations
 
 When deploying to a remote Docker context, the **remote daemon** executes the compose stack. This has important implications for bind mounts, configs, and secrets.

--- a/wiki/docs/Endpoints/REST-API.md
+++ b/wiki/docs/Endpoints/REST-API.md
@@ -22,6 +22,27 @@ Example:
 curl -H "x-api-key: your_api_key" http://example.com/v1/api/projects
 ```
 
+## Query Parameters
+
+Management endpoints support these common query parameters:
+
+| Query Parameter | Type    | Description                                                                          |
+|-----------------|---------|--------------------------------------------------------------------------------------|
+| `context`       | string  | Docker context for project, stack, and scheduled-job endpoints (default: `default`). |
+| `timeout`       | integer | Timeout in seconds (default: `30`).                                                  |
+
+## Docker context selection
+
+Project, stack, and scheduled-job endpoints accept one optional `context` query parameter. If it is omitted or set to `default`, the endpoint uses the default Docker context. 
+Named contexts must exist in the Docker CLI context store available to doco-cd.
+
+These endpoints return the selected external context name in the `X-Doco-CD-Context` response header. Their JSON response shapes do not change.
+
+```sh
+curl -i -H "x-api-key: your_api_key" \
+  "http://example.com/v1/api/projects?context=remote"
+```
+
 ## Endpoints
 
 
@@ -48,11 +69,12 @@ If the application is not healthy, the endpoint returns a `503` status code and 
 
 The API tracks deployment-related runs (for example webhook-triggered deployments and API-triggered poll runs) in memory.
 Use these endpoints to inspect the current status and recent history by `job_id`.
+Each run's `deployments` collection reports the resolved stack and Docker context targets. A single poll or webhook run can contain targets from multiple contexts.
 
-| Endpoint              | Method | Description                           | Query Parameters                                                                                                                                                        |
-|-----------------------|--------|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Endpoint              | Method | Description                           | Query Parameters                                                                                                                                                                                                 |
+|-----------------------|--------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `/v1/api/runs`        | GET    | List recent tracked deployment runs   | - `limit` (integer, default: `50`, max: `200`)<br/>- `status` (string, optional): `accepted`, `running`, `succeeded`, `failed`, `skipped`<br/>- `trigger` (string, optional): `webhook`, `poll`, `scheduled_job` |
-| `/v1/api/run/{jobID}` | GET    | Get details for a specific run/job ID |                                                                                                                                                                         |
+| `/v1/api/run/{jobID}` | GET    | Get details for a specific run/job ID |                                                                                                                                                                                                                  |
 
 #### Example Requests
 
@@ -135,6 +157,7 @@ curl --request POST \
     You can get the `jobName` from the scheduler logs (`"job":"..."`) or from `GET /v1/api/jobs`.
 
 - If multiple jobs share the same `jobName`, provide `stack` to disambiguate for the run endpoint.
+- If the same job and stack names exist on multiple Docker contexts, provide `context`.
 - If the matched job is disabled, the run endpoint returns a conflict response.
 
 **Common run endpoint outcomes**
@@ -197,14 +220,6 @@ curl --request POST \
 | `/v1/api/stack/{stackName}/scale`   | POST   | Rescale a Swarm stack or service                                                                                  | - `replicas` (integer): Scale to n replicas.<br/>- `service` (string, optional): Name of service to scale.<br/>- `wait` (boolean, default: `true`): Wait for service to be running/healthy | 
 | `/v1/api/stack/{stackName}/restart` | POST   | Restart/Redeploy a Swarm stack or service                                                                         | - `service` (string, optional): Name of service to restart.                                                                                                                                | 
 | `/v1/api/stack/{stackName}/run`     | POST   | Trigger one or all [jobs](https://docs.docker.com/reference/cli/docker/service/create/#running-as-a-job) in stack | - `service` (string, optional): Name of the job service to run.                                                                                                                            |
-
-## Query Parameters
-
-All endpoints that support query parameters accept the following common parameters:
-
-| Query Parameter | Type    | Description                         |
-|-----------------|---------|-------------------------------------|
-| `timeout`       | integer | Timeout in seconds (default: `30`). |
 
 ## Example Request
 


### PR DESCRIPTION
Closes #1730. Implements Docker multi-context parity by enabling one doco-cd instance to discover, schedule, deploy, and monitor across multiple Docker hosts/clusters simultaneously.

## Changes

### Core Infrastructure

- Add `ContextRegistry` in `internal/docker/context_registry.go`: centralized client lifecycle managing cached Docker CLI instances per context, swarm mode probing, and graceful shutdown.
- Normalize context names (`""` ↔ `"default"`) consistently across all subsystems; explicit `context: default` in configs now shares identity with implicit default context.

### Scheduler

- Introduce `scheduler.Manager` owning per-context worker goroutines; each worker discovers jobs, runs scheduled events, and maintains isolated state.
- Prefix all job keys with context (default context keeps unprefixed for backward compatibility); isolate runtime state, locks, and stop-hold tracking by context.
- Restart workers on swarm-mode changes; gracefully stop workers when contexts are removed.
- Add `Context` to `JobInfo` and pass context through logs, notifications, and metrics.

### Certificate Rotation

- Iterate all healthy contexts; isolate per-context probe and redeploy failures so unavailable daemons don't block others.
- Use context-aware stack locks to prevent concurrent certificate redeploys on same-named stacks across different contexts.

### Deployment & Reconciliation

- Wire `ContextRegistry` through deploy and reconciliation paths via `Deploy()`, `handleDeploy()`, and event listeners.
- Normalize deploy config contexts at entry points; reuse registry for consistent client/swarm-mode resolution.
- Make reconciliation scheduler-stop holds context-aware so same-named services on different daemons track independently.

### REST APIs

- Add `?context=` query parameter to project, stack, and scheduled-job endpoints; accept omitted/empty/`default` as implicit default.
- Return `X-Doco-CD-Context` response header with display name (external APIs use `"default"`, internal code uses `""`).
- Reject unknown contexts (400), duplicate params (400), and resolve failures (500); preserve existing error semantics.

### Observability

- Add `context` label to deployment and scheduler metrics; update all call sites to pass display context (`default` for internal `""`).
- Render context in failure/success notification bodies and reconciliation event logs.

### Deployment Runs

- Extend run metadata with deduplicated `deployments: [{stack, context}]` collection; keep repository/target/revision unchanged for compatibility.
- Thread deployment observer through config dispatch so concurrent multi-config runs from single poll/webhook deduplicate correctly.

### End-to-End Coverage

- Extend e2e harness to support disposable Docker-in-Docker daemon registered as named context `"remote"`.
- Add `TestMultiContextSameNameDeployment`: verifies identical stack names deploy independently to default and remote contexts (confirmed passing).

## Testing

- All affected packages pass focused tests (scheduler, certrotation, lock, reconciliation, prometheus, notification, docker, cmd/doco-cd).
- Repository-wide compilation passes (`go test ./... -run '^$'`).
- New multi-context e2e scenario passes (`TestMultiContextSameNameDeployment`).
- Full diff audit (code review) found no functional bugs, races, or regressions.

## Breaking Changes

None. Existing single-context deployments continue to work without modification. The internal default context (empty string `""`) maps to external APIs and logs as `"default"` for clarity.

**Prometheus Label Schema Change** (action required on dashboards):
- All deployment and scheduler metrics now include a `context` label.
- Existing dashboard queries must be updated to account for the new label dimension.
- Example: `deployments_total{service="api"}` → `deployments_total{context="default", service="api"}` or use `{service="api"}` to aggregate all contexts.

## Notes

- Prometheus label schema changes (context added); existing dashboard queries may need updates.
- No context labels added to Docker resources to avoid unnecessary container recreation.
- Scheduled jobs and certificate rotation still don't coordinate across multiple doco-cd instances; documented as-is.