### PR TITLE
feat(config): add service autostart control label

### DIFF
--- a/internal/docker/compose.go
+++ b/internal/docker/compose.go
@@ -476,7 +476,23 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 		QuietPull:            true,
 	}
 
-	startServices, err := getStartServicesForDeploy(project)
+	autostartDisabledServices, err := getAutostartDisabledServices(project)
+	if err != nil {
+		return err
+	}
+
+	runningServices := set.New[string]()
+
+	if autostartDisabledServices.Len() > 0 {
+		containers, err := GetProjectContainers(ctx, dockerCli, project.Name)
+		if err != nil {
+			return fmt.Errorf("failed to inspect existing services before deployment: %w", err)
+		}
+
+		runningServices = getRunningServices(containers)
+	}
+
+	startServices, err := getStartServicesForDeploy(project, autostartDisabledServices, runningServices)
 	if err != nil {
 		return err
 	}
@@ -485,6 +501,8 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 	if err != nil {
 		return err
 	}
+
+	stoppedAutostartServices := autostartDisabledServices.Difference(runningServices)
 
 	// Remove mismatched recreatable volumes (tmpfs, NFS, CIFS mounts) before create.
 	// Docker Compose then recreates them with the desired configuration during service.Create.
@@ -506,9 +524,8 @@ func deployCompose(ctx context.Context, dockerCli command.Cli, project *types.Pr
 
 		// Docker Compose's Start ignores StartOptions.Services and starts every
 		// service in the passed project (including containers in the "created" or
-		// "exited" state). Scheduled job services must not run at deploy time, so
-		// narrow the project to non-job services before starting.
-		startProject, err := projectForStart(project, jobServices)
+		// "exited" state), so narrow the project to services allowed to start.
+		startProject, err := projectForStart(project, jobServices, stoppedAutostartServices)
 		if err != nil {
 			return err
 		}
@@ -1716,7 +1733,47 @@ func DecryptProjectFiles(repoPath string, p *types.Project) ([]string, error) {
 	return decryptedFiles, nil
 }
 
-func getStartServicesForDeploy(project *types.Project) ([]string, error) {
+func getAutostartDisabledServices(project *types.Project) (set.Set[string], error) {
+	disabled := set.New[string]()
+	if project == nil {
+		return disabled, nil
+	}
+
+	for serviceName, svc := range project.Services {
+		raw, ok := getServiceSchedulerLabels(svc)[DocoCDLabels.Deployment.Autostart]
+		if !ok {
+			continue
+		}
+
+		enabled, err := strconv.ParseBool(strings.TrimSpace(raw))
+		if err != nil {
+			return nil, fmt.Errorf("service %s: invalid %s label value %q",
+				serviceName, DocoCDLabels.Deployment.Autostart, raw)
+		}
+
+		if !enabled {
+			disabled.Add(serviceName)
+		}
+	}
+
+	return disabled, nil
+}
+
+func getRunningServices(containers []api.ContainerSummary) set.Set[string] {
+	running := set.New[string]()
+
+	for _, cont := range containers {
+		if strings.EqualFold(strings.TrimSpace(string(cont.State)), "running") {
+			if serviceName := strings.TrimSpace(cont.Labels[api.ServiceLabel]); serviceName != "" {
+				running.Add(serviceName)
+			}
+		}
+	}
+
+	return running
+}
+
+func getStartServicesForDeploy(project *types.Project, autostartDisabledServices, runningServices set.Set[string]) ([]string, error) {
 	startServices := make([]string, 0, len(project.Services))
 	completedDependencyServices := getServiceCompletedDependencies(project)
 
@@ -1739,6 +1796,10 @@ func getStartServicesForDeploy(project *types.Project) ([]string, error) {
 		}
 
 		if svc.GetScale() == 0 {
+			continue
+		}
+
+		if autostartDisabledServices.Contains(serviceName) && !runningServices.Contains(serviceName) {
 			continue
 		}
 
@@ -1812,16 +1873,15 @@ func getNonJobServices(startServices []string, jobServices set.Set[string]) set.
 	return nonJobServices
 }
 
-// projectForStart returns a copy of the project containing only the services
-// that should be started at deploy time, i.e. all services except scheduled job
-// services. Docker Compose's Start starts every service present in the project
-// (ignoring StartOptions.Services), so job services must be removed from the
-// project to keep them from running on deployment.
-func projectForStart(project *types.Project, jobServices set.Set[string]) (*types.Project, error) {
+// projectForStart returns a copy containing only services that may start during deployment.
+// Docker Compose's Start ignores StartOptions.Services and starts every service in the project.
+func projectForStart(project *types.Project, jobServices, stoppedAutostartServices set.Set[string]) (*types.Project, error) {
 	nonJobServiceNames := make([]string, 0, len(project.Services))
 
 	for serviceName, svc := range project.Services {
-		if jobServices.Contains(serviceName) || (svc.Name != "" && jobServices.Contains(svc.Name)) {
+		if jobServices.Contains(serviceName) || (svc.Name != "" && jobServices.Contains(svc.Name)) ||
+			stoppedAutostartServices.Contains(serviceName) ||
+			(svc.Name != "" && stoppedAutostartServices.Contains(svc.Name)) {
 			continue
 		}
 

--- a/internal/docker/compose_start_services_test.go
+++ b/internal/docker/compose_start_services_test.go
@@ -54,7 +54,7 @@ func TestGetStartServicesForDeploy(t *testing.T) {
 		},
 	}
 
-	services, err := getStartServicesForDeploy(project)
+	services, err := getStartServicesForDeploy(project, set.New[string](), set.New[string]())
 	if err != nil {
 		t.Fatalf("getStartServicesForDeploy() failed: %v", err)
 	}
@@ -79,8 +79,121 @@ func TestGetStartServicesForDeploy_InvalidLabels(t *testing.T) {
 		},
 	}
 
-	if _, err := getStartServicesForDeploy(project); err == nil {
+	if _, err := getStartServicesForDeploy(project, set.New[string](), set.New[string]()); err == nil {
 		t.Fatalf("expected error for invalid schedule labels")
+	}
+}
+
+func TestGetAutostartDisabledServices(t *testing.T) {
+	t.Parallel()
+
+	project := &types.Project{
+		Services: types.Services{
+			"default": {Name: "default"},
+			"enabled": {
+				Name: "enabled",
+				Labels: map[string]string{
+					DocoCDLabels.Deployment.Autostart: "true",
+				},
+			},
+			"disabled": {
+				Name: "disabled",
+				Labels: map[string]string{
+					DocoCDLabels.Deployment.Autostart: "false",
+				},
+			},
+			"custom-disabled": {
+				Name: "custom-disabled",
+				CustomLabels: map[string]string{
+					DocoCDLabels.Deployment.Autostart: " FALSE ",
+				},
+			},
+		},
+	}
+
+	disabled, err := getAutostartDisabledServices(project)
+	if err != nil {
+		t.Fatalf("getAutostartDisabledServices() failed: %v", err)
+	}
+
+	if !disabled.Contains("disabled") || !disabled.Contains("custom-disabled") {
+		t.Fatalf("expected disabled services, got %v", disabled.ToSlice())
+	}
+
+	if disabled.Contains("default") || disabled.Contains("enabled") {
+		t.Fatalf("unexpected disabled services: %v", disabled.ToSlice())
+	}
+}
+
+func TestGetAutostartDisabledServices_InvalidValue(t *testing.T) {
+	t.Parallel()
+
+	project := &types.Project{
+		Services: types.Services{
+			"bad": {
+				Name: "bad",
+				Labels: map[string]string{
+					DocoCDLabels.Deployment.Autostart: "sometimes",
+				},
+			},
+		},
+	}
+
+	if _, err := getAutostartDisabledServices(project); err == nil {
+		t.Fatalf("expected invalid autostart label to fail")
+	}
+}
+
+func TestGetStartServicesForDeploy_PreservesAutostartState(t *testing.T) {
+	t.Parallel()
+
+	project := &types.Project{
+		Services: types.Services{
+			"api":     {Name: "api"},
+			"running": {Name: "running"},
+			"stopped": {Name: "stopped"},
+		},
+	}
+
+	services, err := getStartServicesForDeploy(
+		project,
+		set.New[string]("running", "stopped"),
+		set.New[string]("running"),
+	)
+	if err != nil {
+		t.Fatalf("getStartServicesForDeploy() failed: %v", err)
+	}
+
+	got := set.New[string](services...)
+	if !got.Contains("api") || !got.Contains("running") {
+		t.Fatalf("expected normal and previously running services to start, got %v", services)
+	}
+
+	if got.Contains("stopped") {
+		t.Fatalf("previously stopped service must not start, got %v", services)
+	}
+}
+
+func TestGetRunningServices(t *testing.T) {
+	t.Parallel()
+
+	services := getRunningServices([]api.ContainerSummary{
+		{
+			State:  "running",
+			Labels: map[string]string{api.ServiceLabel: "api"},
+		},
+		{
+			State:  "exited",
+			Labels: map[string]string{api.ServiceLabel: "stopped"},
+		},
+		{
+			State:  "running",
+			Labels: map[string]string{},
+		},
+	})
+
+	if !services.Contains("api") || services.Contains("stopped") || services.Contains("") {
+		t.Fatalf("unexpected running services: %v", services.ToSlice())
 	}
 }
 
@@ -109,7 +222,7 @@ func TestGetStartServicesForDeploy_ExcludesCompletedDependencyServices(t *testin
 		},
 	}
 
-	services, err := getStartServicesForDeploy(project)
+	services, err := getStartServicesForDeploy(project, set.New[string](), set.New[string]())
 	if err != nil {
 		t.Fatalf("getStartServicesForDeploy() failed: %v", err)
 	}
@@ -196,7 +309,7 @@ func TestProjectForStart_ExcludesJobServices(t *testing.T) {
 		t.Fatalf("getJobServices() failed: %v", err)
 	}
 
-	startProject, err := projectForStart(project, jobServices)
+	startProject, err := projectForStart(project, jobServices, set.New[string]())
 	if err != nil {
 		t.Fatalf("projectForStart() failed: %v", err)
 	}
@@ -244,7 +357,7 @@ func TestProjectForStart_DependencyOnJobServiceStripped(t *testing.T) {
 		t.Fatalf("getJobServices() failed: %v", err)
 	}
 
-	startProject, err := projectForStart(project, jobServices)
+	startProject, err := projectForStart(project, jobServices, set.New[string]())
 	if err != nil {
 		t.Fatalf("projectForStart() failed: %v", err)
 	}
@@ -279,13 +392,49 @@ func TestProjectForStart_OnlyJobServices(t *testing.T) {
 		t.Fatalf("getJobServices() failed: %v", err)
 	}
 
-	startProject, err := projectForStart(project, jobServices)
+	startProject, err := projectForStart(project, jobServices, set.New[string]())
 	if err != nil {
 		t.Fatalf("projectForStart() failed: %v", err)
 	}
 
 	if len(startProject.Services) != 0 {
 		t.Fatalf("expected no services to start when only job services exist, got: %v", startProject.ServiceNames())
+	}
+}
+
+func TestProjectForStart_ExcludesStoppedAutostartServices(t *testing.T) {
+	t.Parallel()
+
+	project := &types.Project{
+		Name: "stack",
+		Services: types.Services{
+			"api": {
+				Name: "api",
+				DependsOn: types.DependsOnConfig{
+					"on-demand": {Condition: "service_started"},
+				},
+			},
+			"on-demand": {
+				Name: "on-demand",
+			},
+		},
+	}
+
+	startProject, err := projectForStart(
+		project,
+		set.New[string](),
+		set.New[string]("on-demand"),
+	)
+	if err != nil {
+		t.Fatalf("projectForStart() failed: %v", err)
+	}
+
+	if _, ok := startProject.Services["on-demand"]; ok {
+		t.Fatalf("stopped autostart service must be excluded from start project")
+	}
+
+	if _, ok := startProject.Services["api"].DependsOn["on-demand"]; ok {
+		t.Fatalf("dependency on stopped autostart service must be stripped")
 	}
 }
 

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -21,6 +21,7 @@ type docoCdLabelNamesDeployment struct {
 	ConfigHash           string // SHA256 hash of the deploy-config used during deployment
 	AutoDiscovery        string // Whether the deployment was auto-discovered
 	AutoDiscoveryConfig  string // JSON-serialized AutoDiscoveryConfig settings
+	Autostart            string // Whether deployment should start the service automatically
 	RecreateIgnore       string // Whether the deployment file changes should ignore recreate
 	RecreateIgnoreSignal string // Signal service when deployment file changes and ignore recreate
 	CertExpiry           string // RFC3339 timestamp of the earliest expiry among the deployment's cert-bearing external secrets
@@ -60,6 +61,7 @@ var DocoCDLabels = docoCdLabelNames{
 		ConfigHash:           "cd.doco.deployment.config.sha",
 		AutoDiscovery:        "cd.doco.deployment.auto_discovery",
 		AutoDiscoveryConfig:  "cd.doco.deployment.auto_discovery.config",
+		Autostart:            "cd.doco.deployment.autostart",
 		RecreateIgnore:       "cd.doco.deployment.recreate.ignore",
 		RecreateIgnoreSignal: "cd.doco.deployment.recreate.ignore.signal",
 		CertExpiry:           "cd.doco.deployment.cert.expiry",

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -487,6 +487,36 @@ See [Go Regular Expressions](https://pkg.go.dev/regexp/syntax) for more informat
 
             E.g. `refs/heads/main` (without `^` and `$`) also allows `refs/heads/main-something`
 
+### Preserve a service's running state
+
+Docker Compose services are started automatically after they are created or updated. 
+To let an external tool control a service's lifecycle, set the `cd.doco.deployment.autostart` service label to `false`.
+
+```yaml title="docker-compose.yml"
+services:
+  on-demand:
+    image: example/on-demand:latest
+    labels:
+      cd.doco.deployment.autostart: "false"
+```
+
+The label defaults to `true`. When it is `false`:
+
+- A service without an existing container is created but not started.
+- A stopped service remains stopped when it is recreated or updated.
+- A running service is restarted normally when it is recreated or updated.
+- A service that remains stopped is excluded from deployment readiness checks.
+
+The label controls only deployment-triggered startup; 
+manual actions, restart policies, reconciliation, and external lifecycle tools can still start or stop the service.
+
+Dependencies on an opted-out stopped service are not started or waited for during deployment. 
+Ensure dependent services can tolerate that service being unavailable until an external tool starts it.
+
+!!! note
+    This label applies to Docker (Standalone) deployments. 
+    In Docker Swarm mode, use `deploy.replicas: 0` to deploy a managed service without running tasks.
+
 ### Prevent recreation on config, secret or bind mount changes
 
 When using docker compose with configs, secrets or bind mounts, changes to these resources will trigger a recreation of the service containers by default.


### PR DESCRIPTION
Docker Compose services are started automatically after they are created or updated. 
To let an external tool control a service's lifecycle, set the `cd.doco.deployment.autostart` service label to `false`.

```yaml title="docker-compose.yml"
services:
  on-demand:
    image: example/on-demand:latest
    labels:
      cd.doco.deployment.autostart: "false"
```

The label defaults to `true`. When it is `false`:

- A service without an existing container is created but not started.
- A stopped service remains stopped when it is recreated or updated.
- A running service is restarted normally when it is recreated or updated.
- A service that remains stopped is excluded from deployment readiness checks.

The label controls only deployment-triggered startup; 
manual actions, restart policies, reconciliation, and external lifecycle tools can still start or stop the service.

Dependencies on an opted-out stopped service are not started or waited for during deployment. 
Ensure dependent services can tolerate that service being unavailable until an external tool starts it.

> [!NOTE]
> This label applies to Docker (Standalone) deployments. 
> In Docker Swarm mode, use `deploy.replicas: 0` to deploy a managed service without running tasks.