### PR TITLE
refactor!: remove deprecated `one_shot` alias for jobs, deprecated labels, and PKCS#1 SSH support

### DIFF
--- a/internal/docker/auto_discovery_migration.go
+++ b/internal/docker/auto_discovery_migration.go
@@ -1,0 +1,180 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+
+	"github.com/moby/moby/client"
+)
+
+const (
+	// TODO: Remove these labels and this migration file in a future release.
+	legacyAutoDiscoverLabel        = "cd.doco.deployment.auto_discover"
+	legacyAutoDiscoverDeleteLabel  = "cd.doco.deployment.auto_discover.delete"
+	legacyAutoDiscoveryDeleteLabel = "cd.doco.deployment.auto_discovery.delete"
+)
+
+// GetAutoDiscoveryServices returns auto-discovered workloads and migrates legacy
+// auto-discovery labels to the current representation. Swarm service labels can be
+// updated in place; standalone containers persist the normalized labels during the
+// deployment that follows reconciliation.
+func GetAutoDiscoveryServices(ctx context.Context, cli client.APIClient, swarmMode bool) (map[Service]map[string]string, error) {
+	if swarmMode {
+		return getAndMigrateSwarmAutoDiscoveryServices(ctx, cli)
+	}
+
+	return getStandaloneAutoDiscoveryServices(ctx, cli)
+}
+
+func getAndMigrateSwarmAutoDiscoveryServices(ctx context.Context, cli client.APIClient) (map[Service]map[string]string, error) {
+	response, err := cli.ServiceList(ctx, client.ServiceListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services for auto-discovery label migration: %w", err)
+	}
+
+	result := make(map[Service]map[string]string)
+
+	for _, service := range response.Items {
+		labels := maps.Clone(service.Spec.Labels)
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+
+		if containerSpec := service.Spec.TaskTemplate.ContainerSpec; containerSpec != nil {
+			for key, value := range containerSpec.Labels {
+				if _, exists := labels[key]; !exists {
+					labels[key] = value
+				}
+			}
+		}
+
+		normalized, _ := normalizeAutoDiscoveryLabels(labels)
+		if normalized == nil {
+			continue
+		}
+
+		if needsSwarmAutoDiscoveryLabelMigration(service.Spec.Labels) {
+			spec := service.Spec
+
+			spec.Labels = maps.Clone(service.Spec.Labels)
+			if spec.Labels == nil {
+				spec.Labels = make(map[string]string)
+			}
+
+			spec.Labels[DocoCDLabels.Deployment.AutoDiscovery] = normalized[DocoCDLabels.Deployment.AutoDiscovery]
+			spec.Labels[DocoCDLabels.Deployment.AutoDiscoveryConfig] = normalized[DocoCDLabels.Deployment.AutoDiscoveryConfig]
+			delete(spec.Labels, legacyAutoDiscoverLabel)
+			delete(spec.Labels, legacyAutoDiscoverDeleteLabel)
+			delete(spec.Labels, legacyAutoDiscoveryDeleteLabel)
+
+			if spec.Mode.ReplicatedJob != nil || spec.Mode.GlobalJob != nil {
+				spec.UpdateConfig = nil
+				spec.RollbackConfig = nil
+			}
+
+			if _, err := cli.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{
+				Version: service.Version,
+				Spec:    spec,
+			}); err != nil {
+				return nil, fmt.Errorf("failed to migrate auto-discovery labels for service %s: %w", service.Spec.Name, err)
+			}
+		}
+
+		result[Service(service.Spec.Name)] = normalized
+	}
+
+	return result, nil
+}
+
+func needsSwarmAutoDiscoveryLabelMigration(labels map[string]string) bool {
+	if _, exists := labels[DocoCDLabels.Deployment.AutoDiscovery]; !exists {
+		return true
+	}
+
+	if _, exists := labels[DocoCDLabels.Deployment.AutoDiscoveryConfig]; !exists {
+		return true
+	}
+
+	for _, label := range []string{
+		legacyAutoDiscoverLabel,
+		legacyAutoDiscoverDeleteLabel,
+		legacyAutoDiscoveryDeleteLabel,
+	} {
+		if _, exists := labels[label]; exists {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getStandaloneAutoDiscoveryServices(ctx context.Context, cli client.APIClient) (map[Service]map[string]string, error) {
+	result := make(map[Service]map[string]string)
+
+	for _, label := range []string{DocoCDLabels.Deployment.AutoDiscovery, legacyAutoDiscoverLabel} {
+		services, err := GetLabeledServices(ctx, cli, false, label, "true")
+		if err != nil {
+			return nil, err
+		}
+
+		for service, labels := range services {
+			normalized, _ := normalizeAutoDiscoveryLabels(labels)
+			if normalized != nil {
+				result[service] = normalized
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func normalizeAutoDiscoveryLabels(labels map[string]string) (map[string]string, bool) {
+	enabledValue, hasCurrentEnabled := labels[DocoCDLabels.Deployment.AutoDiscovery]
+	if !hasCurrentEnabled {
+		enabledValue = labels[legacyAutoDiscoverLabel]
+	}
+
+	enabled, err := strconv.ParseBool(strings.TrimSpace(enabledValue))
+	if err != nil || !enabled {
+		return nil, false
+	}
+
+	normalized := maps.Clone(labels)
+	migrate := !hasCurrentEnabled
+
+	normalized[DocoCDLabels.Deployment.AutoDiscovery] = strconv.FormatBool(enabled)
+
+	if _, hasConfig := labels[DocoCDLabels.Deployment.AutoDiscoveryConfig]; !hasConfig {
+		cfg := ParseAutoDiscoveryConfig("")
+		cfg.Enabled = enabled
+
+		legacyDelete := labels[legacyAutoDiscoveryDeleteLabel]
+		if legacyDelete == "" {
+			legacyDelete = labels[legacyAutoDiscoverDeleteLabel]
+		}
+
+		if deleteEnabled, err := strconv.ParseBool(strings.TrimSpace(legacyDelete)); err == nil {
+			cfg.Delete = deleteEnabled
+		}
+
+		normalized[DocoCDLabels.Deployment.AutoDiscoveryConfig] = MarshalAutoDiscoveryConfig(cfg)
+		migrate = true
+	}
+
+	for _, label := range []string{
+		legacyAutoDiscoverLabel,
+		legacyAutoDiscoverDeleteLabel,
+		legacyAutoDiscoveryDeleteLabel,
+	} {
+		if _, exists := normalized[label]; exists {
+			delete(normalized, label)
+
+			migrate = true
+		}
+	}
+
+	return normalized, migrate
+}

--- a/internal/docker/auto_discovery_migration_test.go
+++ b/internal/docker/auto_discovery_migration_test.go
@@ -1,0 +1,127 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/kimdre/doco-cd/internal/config/deploy"
+)
+
+func TestNormalizeAutoDiscoveryLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		labels        map[string]string
+		want          deploy.AutoDiscoveryConfig
+		wantMigrated  bool
+		wantCandidate bool
+	}{
+		{
+			name: "oldest labels",
+			labels: map[string]string{
+				legacyAutoDiscoverLabel:       "true",
+				legacyAutoDiscoverDeleteLabel: "false",
+			},
+			want: deploy.AutoDiscoveryConfig{
+				Enabled:       true,
+				Delete:        false,
+				RemoveVolumes: false,
+				RemoveImages:  true,
+			},
+			wantMigrated:  true,
+			wantCandidate: true,
+		},
+		{
+			name: "pre-consolidation delete label",
+			labels: map[string]string{
+				DocoCDLabels.Deployment.AutoDiscovery: "true",
+				legacyAutoDiscoveryDeleteLabel:        "false",
+			},
+			want: deploy.AutoDiscoveryConfig{
+				Enabled:       true,
+				Delete:        false,
+				RemoveVolumes: false,
+				RemoveImages:  true,
+			},
+			wantMigrated:  true,
+			wantCandidate: true,
+		},
+		{
+			name: "current labels",
+			labels: map[string]string{
+				DocoCDLabels.Deployment.AutoDiscovery:       "true",
+				DocoCDLabels.Deployment.AutoDiscoveryConfig: "{enabled: true, delete: true, remove_images: false}",
+			},
+			want: deploy.AutoDiscoveryConfig{
+				Enabled:      true,
+				Delete:       true,
+				RemoveImages: false,
+			},
+			wantMigrated:  false,
+			wantCandidate: true,
+		},
+		{
+			name: "current disabled value takes precedence",
+			labels: map[string]string{
+				DocoCDLabels.Deployment.AutoDiscovery: "false",
+				legacyAutoDiscoverLabel:               "true",
+			},
+			wantCandidate: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, migrated := normalizeAutoDiscoveryLabels(tt.labels)
+			if (normalized != nil) != tt.wantCandidate {
+				t.Fatalf("candidate = %t, want %t", normalized != nil, tt.wantCandidate)
+			}
+
+			if migrated != tt.wantMigrated {
+				t.Fatalf("migrated = %t, want %t", migrated, tt.wantMigrated)
+			}
+
+			if !tt.wantCandidate {
+				return
+			}
+
+			for _, legacyLabel := range []string{
+				legacyAutoDiscoverLabel,
+				legacyAutoDiscoverDeleteLabel,
+				legacyAutoDiscoveryDeleteLabel,
+			} {
+				if _, exists := normalized[legacyLabel]; exists {
+					t.Errorf("legacy label %q was not removed", legacyLabel)
+				}
+			}
+
+			got := ParseAutoDiscoveryConfig(normalized[DocoCDLabels.Deployment.AutoDiscoveryConfig])
+			if got != tt.want {
+				t.Errorf("config = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNeedsSwarmAutoDiscoveryLabelMigration(t *testing.T) {
+	currentLabels := map[string]string{
+		DocoCDLabels.Deployment.AutoDiscovery:       "true",
+		DocoCDLabels.Deployment.AutoDiscoveryConfig: "{enabled: true}",
+	}
+
+	if needsSwarmAutoDiscoveryLabelMigration(currentLabels) {
+		t.Fatal("current labels should not require migration")
+	}
+
+	for _, labels := range []map[string]string{
+		{legacyAutoDiscoverLabel: "true"},
+		{DocoCDLabels.Deployment.AutoDiscovery: "true"},
+		{
+			DocoCDLabels.Deployment.AutoDiscovery:       "true",
+			DocoCDLabels.Deployment.AutoDiscoveryConfig: "{enabled: true}",
+			legacyAutoDiscoverLabel:                     "true",
+		},
+	} {
+		if !needsSwarmAutoDiscoveryLabelMigration(labels) {
+			t.Errorf("labels should require migration: %v", labels)
+		}
+	}
+}

--- a/internal/docker/job_schedule.go
+++ b/internal/docker/job_schedule.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"fmt"
-	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -15,12 +14,6 @@ type JobExecutionMode string
 const (
 	JobExecutionModeRestart JobExecutionMode = "restart"
 	JobExecutionModeOneOff  JobExecutionMode = "one_off"
-
-	// JobExecutionModeOneShotDeprecated is the deprecated alias for JobExecutionModeOneOff.
-	//
-	// Deprecated: still accepted for backward compatibility but will log a warning
-	// TODO: Remove in a future release.
-	JobExecutionModeOneShotDeprecated JobExecutionMode = "one_shot"
 )
 
 type JobNotifyOn string
@@ -81,14 +74,7 @@ func ParseJobScheduleExpression(spec string) (gocron.Cron, error) {
 	return schedule, nil
 }
 
-func ParseJobScheduleLabels(labels map[string]string, log ...*slog.Logger) (JobScheduleConfig, bool, error) {
-	var logger *slog.Logger
-	if len(log) > 0 && log[0] != nil {
-		logger = log[0]
-	} else {
-		logger = slog.Default()
-	}
-
+func ParseJobScheduleLabels(labels map[string]string) (JobScheduleConfig, bool, error) {
 	cfg := JobScheduleConfig{
 		ExecutionMode: JobExecutionModeRestart,
 		NotifyOn:      JobNotifyAll,
@@ -136,12 +122,6 @@ func ParseJobScheduleLabels(labels map[string]string, log ...*slog.Logger) (JobS
 		switch mode {
 		case JobExecutionModeRestart, JobExecutionModeOneOff:
 			cfg.ExecutionMode = mode
-		case JobExecutionModeOneShotDeprecated:
-			logger.Warn(
-				fmt.Sprintf("label %s: value %q is deprecated, use %q instead", docoCDJobLabelNames.JobExecutionMode, JobExecutionModeOneShotDeprecated, JobExecutionModeOneOff),
-				slog.String("label", docoCDJobLabelNames.JobExecutionMode),
-			)
-			cfg.ExecutionMode = JobExecutionModeOneOff
 		default:
 			return cfg, false, fmt.Errorf("invalid %s label value %q", docoCDJobLabelNames.JobExecutionMode, modeRaw)
 		}

--- a/internal/docker/job_schedule_test.go
+++ b/internal/docker/job_schedule_test.go
@@ -101,24 +101,16 @@ func TestParseJobScheduleLabels(t *testing.T) {
 	}
 }
 
-func TestParseJobScheduleLabels_OneShotDeprecatedAlias(t *testing.T) {
+func TestParseJobScheduleLabels_RejectsOneShotExecutionMode(t *testing.T) {
 	t.Parallel()
 
-	cfg, enabled, err := ParseJobScheduleLabels(map[string]string{
+	_, _, err := ParseJobScheduleLabels(map[string]string{
 		docoCDJobLabelNames.JobEnabled:       "true",
 		docoCDJobLabelNames.JobSchedule:      "0 * * * *",
-		docoCDJobLabelNames.JobExecutionMode: string(JobExecutionModeOneShotDeprecated),
+		docoCDJobLabelNames.JobExecutionMode: "one_shot",
 	})
-	if err != nil {
-		t.Fatalf("ParseJobScheduleLabels() failed with deprecated one_shot alias: %v", err)
-	}
-
-	if !enabled {
-		t.Fatalf("expected enabled=true")
-	}
-
-	if cfg.ExecutionMode != JobExecutionModeOneOff {
-		t.Fatalf("expected execution mode to be normalized to %q, got %q", JobExecutionModeOneOff, cfg.ExecutionMode)
+	if err == nil {
+		t.Fatal("expected one_shot execution mode to be rejected")
 	}
 }
 

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -75,21 +75,6 @@ var DocoCDLabels = docoCdLabelNames{
 	},
 }
 
-/*
-DeprecatedAutoDiscoverLabel and DeprecatedAutoDiscoverDeleteLabel are the old label names
-kept for backwards-compatible reads. New deployments only write the new labels.
-
-Deprecated: Use DocoCDLabels.Deployment.AutoDiscovery and DocoCDLabels.Deployment.AutoDiscoveryConfig instead.
-
-TODO: Remove in a future release.
-*/
-const (
-	DeprecatedAutoDiscoverLabel       = "cd.doco.deployment.auto_discover"
-	DeprecatedAutoDiscoverDeleteLabel = "cd.doco.deployment.auto_discover.delete"
-	// DeprecatedAutoDiscoveryDeleteLabel is the pre-consolidation scalar label for the delete setting.
-	DeprecatedAutoDiscoveryDeleteLabel = "cd.doco.deployment.auto_discovery.delete" //nolint:staticcheck
-)
-
 // jobLabelPrefix is the common prefix of all labels that configure scheduled jobs.
 const jobLabelPrefix = "cd.doco.job."
 

--- a/internal/docker/service_utils.go
+++ b/internal/docker/service_utils.go
@@ -252,7 +252,6 @@ const (
 	ServiceMismatchReasonSwarmMode   = "swarm mode mismatch"
 	ServiceMismatchReasonReplicas    = "replicas mismatch"
 	oneOffServiceNameSeparator       = "-doco-job-"
-	legacyOneShotExecutionMode       = "one_shot"
 )
 
 type ServiceMismatch struct {
@@ -401,7 +400,7 @@ func isEphemeralOneOffService(name string, status ServiceStatus, declaredService
 	}
 
 	mode := strings.TrimSpace(labels[DocoCDJobLabels.JobExecutionMode])
-	if mode != string(JobExecutionModeOneOff) && mode != legacyOneShotExecutionMode {
+	if mode != string(JobExecutionModeOneOff) {
 		return false
 	}
 

--- a/internal/docker/service_utils_test.go
+++ b/internal/docker/service_utils_test.go
@@ -1036,7 +1036,7 @@ func TestCheckServiceMismatch(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "swarmMode=true, ignore unnecessary scheduler ephemeral by legacy name fallback",
+			name: "swarmMode=true, ignore unnecessary scheduler ephemeral by execution mode",
 			deployed: map[Service]ServiceStatus{
 				"foo": {Replicas: 1, SwarmMode: swarm.DeployModeReplicated},
 				"foo-doco-job-1730000000000000000": {

--- a/internal/docker/swarm_job.go
+++ b/internal/docker/swarm_job.go
@@ -166,11 +166,6 @@ func RunSwarmJob(ctx context.Context, dockerCLI command.Cli, mode swarm.DeployMo
 		}
 	}
 
-	// defer func() {
-	//	// Remove the service after completion
-	//	_ = apiClient.ServiceRemove(ctx, response.ID)
-	// }()
-
 	// Wait for container to complete
 	err = swarm.WaitOnServices(ctx, dockerCLI, []string{serviceId})
 	if err != nil {

--- a/internal/docker/swarm_labels_test.go
+++ b/internal/docker/swarm_labels_test.go
@@ -226,19 +226,6 @@ func TestSwarmServiceLabels(t *testing.T) {
 			want: Labels{DocoCDLabels.Deployment.Name: "stack"},
 		},
 		{
-			name: "container spec labels of a stack deployed by an earlier version",
-			service: swarmTypes.Service{
-				Spec: swarmTypes.ServiceSpec{
-					TaskTemplate: swarmTypes.TaskSpec{
-						ContainerSpec: &swarmTypes.ContainerSpec{
-							Labels: map[string]string{DocoCDLabels.Deployment.Name: "legacy"},
-						},
-					},
-				},
-			},
-			want: Labels{DocoCDLabels.Deployment.Name: "legacy"},
-		},
-		{
 			name: "service spec labels take precedence",
 			service: swarmTypes.Service{
 				Spec: swarmTypes.ServiceSpec{
@@ -257,7 +244,6 @@ func TestSwarmServiceLabels(t *testing.T) {
 			},
 			want: Labels{
 				DocoCDLabels.Deployment.Timestamp: "new",
-				DocoCDJobLabels.JobEnabled:        "true",
 			},
 		},
 		{

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,28 +65,13 @@ func (l Labels) getDeploymentComposeHash() (string, bool) {
 	return l.Get(DocoCDLabels.Deployment.ComposeHash)
 }
 
-// SwarmServiceLabels returns the labels of a swarm service, merged from the task
-// template and the service spec.
+// SwarmServiceLabels returns the labels of a swarm service.
 //
 // Deployment metadata is stored in the service spec labels, because labels in the
 // task template are part of the service definition and changing them makes swarm
 // recreate all tasks of the service on every deployment.
-//
-// Stacks deployed by earlier versions carry the metadata in the container spec
-// instead, so both label sets are merged, with the service spec taking precedence.
-// Note that this only helps sites that read labels from an inspected service:
-// server-side filtered listings (e.g. GetServicesByLabel) match service spec labels
-// only, so legacy stacks stay invisible to them until they are redeployed once.
-// The container spec fallback can be dropped in a future release, once stacks have
-// been redeployed at least once.
 func SwarmServiceLabels(service swarm.Service) Labels {
-	containerLabels := swarmContainerLabels(service)
-
-	labels := make(Labels, len(containerLabels)+len(service.Spec.Labels))
-	maps.Copy(labels, containerLabels)
-	maps.Copy(labels, service.Spec.Labels)
-
-	return labels
+	return service.Spec.Labels
 }
 
 // SwarmJobLabels returns the labels of a swarm service with the job configuration
@@ -101,10 +85,7 @@ func SwarmServiceLabels(service swarm.Service) Labels {
 // Job runtime metadata (last/next run timestamps) is written by doco-cd itself to the
 // service spec, so it is exempt from this rule.
 func SwarmJobLabels(service swarm.Service) Labels {
-	containerLabels := swarmContainerLabels(service)
-
-	labels := make(Labels, len(containerLabels)+len(service.Spec.Labels))
-	maps.Copy(labels, containerLabels)
+	labels := make(Labels, len(service.Spec.Labels))
 
 	for key, value := range service.Spec.Labels {
 		if isJobConfigLabel(key) {
@@ -112,6 +93,14 @@ func SwarmJobLabels(service swarm.Service) Labels {
 		}
 
 		labels[key] = value
+	}
+
+	if containerSpec := service.Spec.TaskTemplate.ContainerSpec; containerSpec != nil {
+		for key, value := range containerSpec.Labels {
+			if isJobConfigLabel(key) {
+				labels[key] = value
+			}
+		}
 	}
 
 	return labels
@@ -125,14 +114,6 @@ func isJobConfigLabel(key string) bool {
 	}
 
 	return key != docoCDJobLabelNames.JobLastRun && key != docoCDJobLabelNames.JobNextRun
-}
-
-func swarmContainerLabels(service swarm.Service) map[string]string {
-	if service.Spec.TaskTemplate.ContainerSpec == nil {
-		return nil
-	}
-
-	return service.Spec.TaskTemplate.ContainerSpec.Labels
 }
 
 // GetServiceLabels retrieves the Labels for each Service in a given stack.

--- a/internal/git/auth.go
+++ b/internal/git/auth.go
@@ -370,8 +370,6 @@ func SSHAuth(privateKey, keyPassphrase string) (transport.AuthMethod, error) {
 		return nil, fmt.Errorf("failed to create SSH public keys: %w", err)
 	}
 
-	// auth.HostKeyCallback = ssh2.InsecureIgnoreHostKey()
-
 	return auth, nil
 }
 

--- a/internal/git/ssh/ssh_agent.go
+++ b/internal/git/ssh/ssh_agent.go
@@ -185,14 +185,6 @@ func getRawPrivateKey(pemBytes []byte, passphrase string) (any, error) {
 	}
 
 	switch block.Type {
-	case "ENCRYPTED PRIVATE KEY":
-		// Deprecated, but we still use it for compatibility
-		der, err := x509.DecryptPEMBlock(block, []byte(passphrase)) // nolint:staticcheck
-		if err != nil {
-			return nil, err
-		}
-
-		return x509.ParsePKCS8PrivateKey(der)
 	case "PRIVATE KEY":
 		return x509.ParsePKCS8PrivateKey(block.Bytes)
 	default:

--- a/internal/git/ssh/ssh_agent_test.go
+++ b/internal/git/ssh/ssh_agent_test.go
@@ -215,68 +215,6 @@ func TestGetRawPrivateKey(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name: "Encrypted ED25519 key with correct passphrase",
-			generateKey: func() ([]byte, error) {
-				_, privateKey, err := ed25519.GenerateKey(rand.Reader)
-				if err != nil {
-					return nil, err
-				}
-
-				privateKeyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
-				if err != nil {
-					return nil, err
-				}
-
-				block, err := x509.EncryptPEMBlock( // nolint:staticcheck
-					rand.Reader,
-					"ENCRYPTED PRIVATE KEY",
-					privateKeyDER,
-					[]byte("testpass"),
-					x509.PEMCipherAES256,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				privateKeyPEM := pem.EncodeToMemory(block)
-
-				return privateKeyPEM, nil
-			},
-			keyPassphrase: "testpass",
-			wantErr:       false,
-		},
-		{
-			name: "Encrypted ED25519 key with incorrect passphrase",
-			generateKey: func() ([]byte, error) {
-				_, privateKey, err := ed25519.GenerateKey(rand.Reader)
-				if err != nil {
-					return nil, err
-				}
-
-				privateKeyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
-				if err != nil {
-					return nil, err
-				}
-
-				block, err := x509.EncryptPEMBlock( // nolint:staticcheck
-					rand.Reader,
-					"PRIVATE KEY",
-					privateKeyDER,
-					[]byte("testpass"),
-					x509.PEMCipherAES256,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				privateKeyPEM := pem.EncodeToMemory(block)
-
-				return privateKeyPEM, nil
-			},
-			keyPassphrase: "wrongpass",
-			wantErr:       true,
-		},
-		{
 			name: "Malformed private key",
 			generateKey: func() ([]byte, error) {
 				return []byte("malformed key data"), nil

--- a/internal/reconciliation/clean.go
+++ b/internal/reconciliation/clean.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/docker/cli/cli/command"
@@ -44,30 +42,12 @@ func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.L
 
 	var processedStacks []string
 
-	// Query both new and deprecated labels. We keep reading the deprecated label to
-	// handle containers deployed before the label rename.
 	newServiceLabels, err := docker.GetLabeledServices(ctx, dockerCli.Client(), swarmMode, docker.DocoCDLabels.Deployment.AutoDiscovery, "true")
 	if err != nil {
 		return fmt.Errorf("failed to retrieve containers for auto-discovery cleanup: %w", err)
 	}
 
-	deprecatedServiceLabels, err := docker.GetLabeledServices(ctx, dockerCli.Client(), swarmMode, docker.DeprecatedAutoDiscoverLabel, "true") //nolint:staticcheck // fallback for pre-rename containers
-	if err != nil {
-		return fmt.Errorf("failed to retrieve containers for auto-discovery cleanup: %w", err)
-	}
-
-	if len(deprecatedServiceLabels) > 0 {
-		jobLog.Warn("found containers with deprecated label, please recreate them to migrate to the new label",
-			slog.String("deprecated_label", docker.DeprecatedAutoDiscoverLabel), //nolint:staticcheck // include deprecated label key in warning for migration clarity
-			slog.String("new_label", docker.DocoCDLabels.Deployment.AutoDiscovery),
-		)
-	}
-
-	// Merge label maps and prefer the new label set when a service appears in both.
-	serviceLabels := make(map[docker.Service]map[string]string, len(deprecatedServiceLabels)+len(newServiceLabels))
-	maps.Copy(serviceLabels, deprecatedServiceLabels)
-
-	maps.Copy(serviceLabels, newServiceLabels)
+	serviceLabels := newServiceLabels
 
 	for _, labels := range serviceLabels {
 		stackName := labels[docker.DocoCDLabels.Deployment.Name]
@@ -120,23 +100,7 @@ func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.L
 
 			stackLog.Debug("checking auto-discovered stack for obsolescence")
 
-			// Parse the auto-discovery config from the new JSON label.
-			// Fall back to the old scalar labels for containers deployed before this change.
 			autoDiscoverCfg := docker.ParseAutoDiscoveryConfig(labels[docker.DocoCDLabels.Deployment.AutoDiscoveryConfig])
-
-			// If the new label was absent, try the legacy scalar delete label.
-			if labels[docker.DocoCDLabels.Deployment.AutoDiscoveryConfig] == "" {
-				legacyDelete := labels[docker.DeprecatedAutoDiscoveryDeleteLabel] //nolint:staticcheck // fallback for pre-consolidation containers
-				if legacyDelete == "" {
-					legacyDelete = labels[docker.DeprecatedAutoDiscoverDeleteLabel] //nolint:staticcheck // fallback for pre-rename containers
-				}
-
-				if legacyDelete != "" {
-					if parsed, err := strconv.ParseBool(legacyDelete); err == nil {
-						autoDiscoverCfg.Delete = parsed
-					}
-				}
-			}
 
 			if !autoDiscoverCfg.Delete {
 				stackLog.Debug("skipping removal of obsolete auto-discovered stack as per configuration")

--- a/internal/reconciliation/clean.go
+++ b/internal/reconciliation/clean.go
@@ -42,12 +42,10 @@ func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.L
 
 	var processedStacks []string
 
-	newServiceLabels, err := docker.GetLabeledServices(ctx, dockerCli.Client(), swarmMode, docker.DocoCDLabels.Deployment.AutoDiscovery, "true")
+	serviceLabels, err := docker.GetAutoDiscoveryServices(ctx, dockerCli.Client(), swarmMode)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve containers for auto-discovery cleanup: %w", err)
 	}
-
-	serviceLabels := newServiceLabels
 
 	for _, labels := range serviceLabels {
 		stackName := labels[docker.DocoCDLabels.Deployment.Name]

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -238,7 +238,7 @@ func (s *scheduler) listJobs(ctx context.Context, stackName string) ([]JobInfo, 
 		// mid-run for this job.
 		running := job.running || runningStates[job.key]
 
-		cfg, enabled, parseErr := parseJobConfig(job, s.log)
+		cfg, enabled, parseErr := parseJobConfig(job)
 		if parseErr != nil {
 			info.Valid = false
 			info.ScheduleError = parseErr.Error()
@@ -646,7 +646,7 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 	for _, job := range jobs {
 		discoveredByKey[job.key] = job
 
-		cfg, enabled, parseErr := parseJobConfig(job, s.log)
+		cfg, enabled, parseErr := parseJobConfig(job)
 		if parseErr != nil {
 			s.log.Warn("ignoring job with invalid schedule labels",
 				slog.String("job", job.name),
@@ -1631,8 +1631,8 @@ func jobOwnIdentity(job scheduledJob) (project, service string) {
 // (rather than in docker.ParseJobScheduleLabels) lets the self-reference
 // check use the correct own-identity resolution for both compose and Swarm
 // jobs; see jobOwnIdentity.
-func parseJobConfig(job scheduledJob, log ...*slog.Logger) (docker.JobScheduleConfig, bool, error) {
-	cfg, enabled, err := docker.ParseJobScheduleLabels(job.labels, log...)
+func parseJobConfig(job scheduledJob) (docker.JobScheduleConfig, bool, error) {
+	cfg, enabled, err := docker.ParseJobScheduleLabels(job.labels)
 	if err != nil || !enabled || len(cfg.StopServices) == 0 {
 		return cfg, enabled, err
 	}

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -141,10 +141,6 @@ be created for each scheduled run and removed after completion.
     | `restart`                    | Existing service     | Unchanged              |
     | `one_off`                    | Temporary clone      | Source unchanged       |
 
-??? warning "Deprecated: `one_shot` has been renamed to `one_off`"
-    `one_shot` has been renamed to `one_off` and will be removed in a future release.
-    Use `one_off` instead. The old value is still accepted for backward compatibility but will log a warning.
-
 ## Configuration
 
 ??? example "How to set service labels in a docker compose file"


### PR DESCRIPTION
This PR removes three deprecated features that have reached end-of-life.

## Breaking Changes

1. **Job execution mode**: the `one_shot` alias is no longer supported.
   Use `one_off` instead; `one_shot` values are rejected during parsing.

2. **Auto-discovery labels**: legacy label formats are retired:
   - `cd.doco.deployment.auto_discover`
   - `cd.doco.deployment.auto_discover.delete`
   - `cd.doco.deployment.auto_discovery.delete`

   New deployments use `cd.doco.deployment.auto_discovery` and the JSON configuration label `cd.doco.deployment.auto_discovery.config`.

3. **SSH private keys**: PKCS#1 `ENCRYPTED PRIVATE KEY` support is removed because
   it relied on the deprecated Go `x509.DecryptPEMBlock()` API. Use modern OpenSSH
   or unencrypted PEM key formats.

## Automatic migration

Existing deployments using legacy auto-discovery labels are migrated automatically:

- Swarm service labels are converted in place without restarting tasks.
- Legacy delete settings are preserved in the new JSON configuration label.
- Standalone containers remain discoverable during the transition and receive the
  current labels on their next deployment.

## User actions

- Change `one_shot` to `one_off` in job definitions.
- Convert password-protected SSH keys to a supported modern format.
- No manual relabeling is required for existing auto-discovered deployments.
