### PR TITLE
feat(deploy): support per-deployment swarm mode

### DIFF
--- a/internal/certrotation/watcher.go
+++ b/internal/certrotation/watcher.go
@@ -142,12 +142,28 @@ func (w *Watcher) checkAndRotateContext(ctx context.Context, result docker.Conte
 		return
 	}
 
+	// A Swarm manager can also host ordinary Compose deployments. Scan both
+	// resource kinds independently so rotation redeploys with the same mode
+	// the project was deployed with.
+	modes := []bool{false}
+	if result.SwarmMode {
+		modes = append(modes, true)
+	}
+
+	for _, swarmMode := range modes {
+		w.checkAndRotateContextMode(ctx, result, contextLog, swarmMode)
+	}
+}
+
+func (w *Watcher) checkAndRotateContextMode(ctx context.Context, result docker.ContextClientResult, contextLog *slog.Logger, swarmMode bool) {
 	services, err := docker.GetLabeledServices(
-		ctx, result.Cli.Client(), result.SwarmMode,
+		ctx, result.Cli.Client(), swarmMode,
 		docker.DocoCDLabels.Deployment.CertRotatable, "true",
 	)
 	if err != nil {
-		contextLog.Error("failed to list certificate-rotatable deployments", logger.ErrAttr(err))
+		contextLog.Error("failed to list certificate-rotatable deployments",
+			slog.Bool("swarm_mode", swarmMode), logger.ErrAttr(err))
+
 		return
 	}
 
@@ -164,18 +180,23 @@ func (w *Watcher) checkAndRotateContext(ctx context.Context, result docker.Conte
 		contextLog.Info("certificate needs rotation",
 			slog.String("project", project),
 			slog.String("reason", strings.Join(reasons[project], ",")),
+			slog.Bool("swarm_mode", swarmMode),
 		)
 
-		if err := docker.RotateProjectCertificates(ctx, result.Name, result.Cli, labels, w.secretProvider, result.SwarmMode); err != nil {
+		if err := docker.RotateProjectCertificates(ctx, result.Name, result.Cli, labels, w.secretProvider, swarmMode); err != nil {
 			contextLog.Error("failed to rotate certificate",
 				slog.String("project", project),
+				slog.Bool("swarm_mode", swarmMode),
 				logger.ErrAttr(err),
 			)
 
 			continue
 		}
 
-		contextLog.Info("certificate rotation redeploy completed", slog.String("project", project))
+		contextLog.Info("certificate rotation redeploy completed",
+			slog.String("project", project),
+			slog.Bool("swarm_mode", swarmMode),
+		)
 	}
 }
 

--- a/internal/certrotation/watcher_test.go
+++ b/internal/certrotation/watcher_test.go
@@ -527,8 +527,8 @@ func TestCheckAndRotate_ContextErrorIsolation(t *testing.T) {
 
 // TestCheckAndRotate_UsesEachContextsOwnSwarmMode verifies that discovery for each context uses
 // that context's own SwarmMode (from docker.ContextClientResult), never a single shared/global
-// value: a standalone context must only ever be queried via ContainerList, and a Swarm context
-// only ever via ServiceList, even when both are checked in the same pass.
+// value: a standalone context is queried via ContainerList, while a Swarm manager is queried
+// via both ContainerList and ServiceList so it can rotate Compose and Swarm deployments.
 func TestCheckAndRotate_UsesEachContextsOwnSwarmMode(t *testing.T) {
 	var containerCalls, serviceCalls int32
 
@@ -545,7 +545,7 @@ func TestCheckAndRotate_UsesEachContextsOwnSwarmMode(t *testing.T) {
 
 	swarmClient := &fakeAPIClient{
 		containerList: func(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
-			t.Error("unexpected ContainerList call for a swarm-mode context")
+			atomic.AddInt32(&containerCalls, 1)
 			return client.ContainerListResult{}, nil
 		},
 		serviceList: func(context.Context, client.ServiceListOptions) (client.ServiceListResult, error) {
@@ -569,8 +569,8 @@ func TestCheckAndRotate_UsesEachContextsOwnSwarmMode(t *testing.T) {
 
 	watcher.checkAndRotate(t.Context())
 
-	if containerCalls != 1 {
-		t.Errorf("expected exactly 1 ContainerList call, got %d", containerCalls)
+	if containerCalls != 2 {
+		t.Errorf("expected exactly 2 ContainerList calls, got %d", containerCalls)
 	}
 
 	if serviceCalls != 1 {

--- a/internal/config/deploy/auto_discovery.go
+++ b/internal/config/deploy/auto_discovery.go
@@ -253,6 +253,11 @@ func autoDiscoveryCacheKey(repoRoot string, baseConfig *Config) (string, bool) {
 	composeFiles := append([]string(nil), baseConfig.ComposeFiles...)
 	sort.Strings(composeFiles)
 
+	swarmEnabled := "auto"
+	if baseConfig.Swarm.Enabled != nil {
+		swarmEnabled = strconv.FormatBool(*baseConfig.Swarm.Enabled)
+	}
+
 	return strings.Join([]string{
 		repoRoot,
 		head.Hash().String(),
@@ -263,6 +268,7 @@ func autoDiscoveryCacheKey(repoRoot string, baseConfig *Config) (string, bool) {
 		strconv.FormatBool(baseConfig.AutoDiscovery.RemoveVolumes),
 		strconv.FormatBool(baseConfig.AutoDiscovery.RemoveImages),
 		baseConfig.Name,
+		swarmEnabled,
 	}, "|"), true
 }
 

--- a/internal/config/deploy/auto_discovery_test.go
+++ b/internal/config/deploy/auto_discovery_test.go
@@ -308,6 +308,19 @@ func TestMergeConfig(t *testing.T) {
 			t.Errorf("RestartWindow should remain 300, got %d", base.Reconciliation.RestartWindow)
 		}
 	})
+
+	t.Run("MergeSwarmEnabled_NestedStruct", func(t *testing.T) {
+		t.Parallel()
+
+		base := &Config{Swarm: SwarmConfig{Enabled: new(true)}}
+		override := &Config{Swarm: SwarmConfig{Enabled: new(false)}}
+
+		mergeConfig(base, override)
+
+		if base.Swarm.Enabled == nil || *base.Swarm.Enabled {
+			t.Fatalf("expected nested swarm.enabled override to be false, got %v", base.Swarm.Enabled)
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -609,6 +622,21 @@ func TestAutoDiscoverDeployments_CacheKeyedByHeadAndSettings(t *testing.T) {
 
 	if len(second) != 1 {
 		t.Fatalf("expected cached result with 1 config when HEAD is unchanged, got %d", len(second))
+	}
+
+	if err := createTestFile(t, filepath.Join(serviceDir, "compose.yaml"), "services:\n  app:\n    image: nginx"); err != nil {
+		t.Fatal(err)
+	}
+
+	baseConfig.Swarm.Enabled = new(false)
+
+	modeChanged, err := autoDiscoverDeployments(repoRoot, baseConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(modeChanged) != 1 || modeChanged[0].Swarm.Enabled == nil || *modeChanged[0].Swarm.Enabled {
+		t.Fatalf("expected swarm.enabled change to invalidate the cache, got %#v", modeChanged)
 	}
 
 	if err := createTestFile(t, filepath.Join(serviceDir, "compose.yaml"), "services:\n  app:\n    image: nginx:alpine"); err != nil {

--- a/internal/config/deploy/deploy.go
+++ b/internal/config/deploy/deploy.go
@@ -38,6 +38,7 @@ var (
 	ErrKeyNotFound                   = errors.New("key not found")
 	ErrInvalidFilePath               = errors.New("invalid file path")
 	ErrMultipleYAMLDocuments         = errors.New("nested .doco-cd configuration file must contain only a single YAML document")
+	ErrSwarmModeUnavailable          = errors.New("docker swarm mode is not available for this deployment")
 )
 
 // Config is the structure of the deployment configuration file.
@@ -79,8 +80,9 @@ type Config struct {
 
 // SwarmConfig contains Docker Swarm-specific deployment settings.
 type SwarmConfig struct {
-	ConfigRetention *int `yaml:"config_retention,omitempty" json:"config_retention,omitempty"` // ConfigRetention is the number of old Swarm config revisions to keep per resource (excluding the active one). -1 disables automatic pruning. If unset, global DOCKER_SWARM_CONFIG_RETENTION is used.
-	SecretRetention *int `yaml:"secret_retention,omitempty" json:"secret_retention,omitempty"` // SecretRetention is the number of old Swarm secret revisions to keep per resource (excluding the active one). -1 disables automatic pruning. If unset, global DOCKER_SWARM_SECRET_RETENTION is used.
+	Enabled         *bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`                   // Enabled explicitly selects Swarm deployment mode. When unset, the Docker context determines the mode.
+	ConfigRetention *int  `yaml:"config_retention,omitempty" json:"config_retention,omitempty"` // ConfigRetention is the number of old Swarm config revisions to keep per resource (excluding the active one). -1 disables automatic pruning. If unset, global DOCKER_SWARM_CONFIG_RETENTION is used.
+	SecretRetention *int  `yaml:"secret_retention,omitempty" json:"secret_retention,omitempty"` // SecretRetention is the number of old Swarm secret revisions to keep per resource (excluding the active one). -1 disables automatic pruning. If unset, global DOCKER_SWARM_SECRET_RETENTION is used.
 }
 
 // ResolveGitDepth returns the effective git clone depth.
@@ -116,6 +118,21 @@ func (c *Config) ResolveSwarmSecretRetention(globalRetention int) int {
 	}
 
 	return globalRetention
+}
+
+// ResolveSwarmMode returns the deployment mode selected by this config. When
+// swarm.enabled is omitted, the mode detected for the Docker context is used.
+// An explicit Swarm request must not silently fall back to Compose.
+func (c *Config) ResolveSwarmMode(swarmAvailable bool) (bool, error) {
+	if c.Swarm.Enabled == nil {
+		return swarmAvailable, nil
+	}
+
+	if *c.Swarm.Enabled && !swarmAvailable {
+		return false, ErrSwarmModeUnavailable
+	}
+
+	return *c.Swarm.Enabled, nil
 }
 
 // New creates a Config with default values.

--- a/internal/config/deploy/deploy_test.go
+++ b/internal/config/deploy/deploy_test.go
@@ -291,6 +291,41 @@ func TestConfig_Validate_SwarmRetention(t *testing.T) {
 	})
 }
 
+func TestConfig_ResolveSwarmMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		enabled        *bool
+		swarmAvailable bool
+		want           bool
+		wantErr        error
+	}{
+		{name: "inherits available swarm mode", swarmAvailable: true, want: true},
+		{name: "inherits unavailable swarm mode", swarmAvailable: false, want: false},
+		{name: "explicit compose on swarm", enabled: new(false), swarmAvailable: true, want: false},
+		{name: "explicit swarm when available", enabled: new(true), swarmAvailable: true, want: true},
+		{name: "explicit swarm when unavailable", enabled: new(true), swarmAvailable: false, wantErr: ErrSwarmModeUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{Swarm: SwarmConfig{Enabled: tt.enabled}}
+
+			got, err := cfg.ResolveSwarmMode(tt.swarmAvailable)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+
+			if got != tt.want {
+				t.Fatalf("expected swarm mode %t, got %t", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestGetConfigs_MissingDefaultConfigFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/docker/commands.go
+++ b/internal/docker/commands.go
@@ -10,6 +10,10 @@ import (
 )
 
 func Exec(apiClient client.APIClient, containerID string, cmd ...string) (out string, err error) {
+	return ExecContext(context.Background(), apiClient, containerID, cmd...)
+}
+
+func ExecContext(ctx context.Context, apiClient client.APIClient, containerID string, cmd ...string) (out string, err error) {
 	// EXEC COMMAND
 	execConfig := client.ExecCreateOptions{
 		Cmd:          cmd,
@@ -17,13 +21,13 @@ func Exec(apiClient client.APIClient, containerID string, cmd ...string) (out st
 		AttachStderr: true,
 	}
 
-	res, err := apiClient.ExecCreate(context.Background(), containerID, execConfig)
+	res, err := apiClient.ExecCreate(ctx, containerID, execConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to exec command with error: %w", err)
 	}
 
 	// ATTACH TO EXEC PROCESS
-	resp, err := apiClient.ExecAttach(context.Background(), res.ID, client.ExecAttachOptions{})
+	resp, err := apiClient.ExecAttach(ctx, res.ID, client.ExecAttachOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to attach to exec process: %w", err)
 	}

--- a/internal/docker/deployment_mode_migration.go
+++ b/internal/docker/deployment_mode_migration.go
@@ -1,0 +1,148 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/moby/moby/client"
+
+	"github.com/kimdre/doco-cd/internal/config/app"
+	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
+	"github.com/kimdre/doco-cd/internal/lock"
+)
+
+// ErrDeploymentModeConflict means resources in the old deployment mode cannot
+// safely be replaced because doco-cd cannot prove that it owns them.
+var ErrDeploymentModeConflict = errors.New("deployment mode migration conflicts with existing resources")
+
+// MigrateDeploymentMode removes a previous deployment in the other runtime mode,
+// but only after proving every discovered resource belongs to this doco-cd deployment.
+// Volumes are deliberately retained for the new mode.
+func MigrateDeploymentMode(ctx context.Context, log *slog.Logger, dockerCli command.Cli, contextName, stackName, source string, swarmMode, swarmAvailable bool) error {
+	if dockerCli == nil {
+		return errors.New("docker cli is required")
+	}
+
+	// Without Swarm capability there is no second mode to migrate between: the
+	// context is either a standalone engine or has Swarm features globally
+	// disabled, in which case its Swarm API must not be probed at all.
+	if !swarmAvailable {
+		return nil
+	}
+
+	stackLockKey := lock.StackKey(contextName, stackName)
+
+	lock.LockStack(stackLockKey)
+	defer lock.UnlockStack(stackLockKey)
+
+	previousMode := !swarmMode
+
+	labelsByService, err := deploymentModeLabels(ctx, dockerCli.Client(), stackName, previousMode)
+	if err != nil {
+		return fmt.Errorf("failed to inspect %s resources for deployment mode migration: %w", deploymentModeName(previousMode), err)
+	}
+
+	if len(labelsByService) == 0 {
+		return nil
+	}
+
+	expectedSources := buildRepositoryLabelCandidates(source)
+	if err = validateMigrationOwnership(labelsByService, expectedSources, previousMode, stackName); err != nil {
+		return err
+	}
+
+	// A partial earlier migration may have resources in both modes. Do not
+	// remove the verified old mode if the selected mode is occupied by an
+	// unmanaged same-named deployment.
+	selectedLabels, err := deploymentModeLabels(ctx, dockerCli.Client(), stackName, swarmMode)
+	if err != nil {
+		return fmt.Errorf("failed to inspect %s resources for deployment mode migration: %w", deploymentModeName(swarmMode), err)
+	}
+
+	if err := validateMigrationOwnership(selectedLabels, expectedSources, swarmMode, stackName); err != nil {
+		return err
+	}
+
+	if log == nil {
+		log = slog.Default()
+	}
+
+	log.Info("removing previous deployment mode before migration",
+		slog.String("stack", stackName),
+		slog.String("from", deploymentModeName(previousMode)),
+		slog.String("to", deploymentModeName(swarmMode)),
+	)
+
+	removeConfig := deployConfig.New(stackName, "")
+	removeConfig.RemoveOrphans = true
+	removeConfig.Destroy.Enabled = true
+	removeConfig.Destroy.RemoveVolumes = false
+	removeConfig.Destroy.RemoveImages = false
+
+	if err := DestroyStack(log, &ctx, &dockerCli, removeConfig, previousMode); err != nil {
+		return fmt.Errorf("failed to remove previous %s deployment: %w", deploymentModeName(previousMode), err)
+	}
+
+	return nil
+}
+
+func deploymentModeLabels(ctx context.Context, dockerClient client.APIClient, stackName string, swarmMode bool) (map[Service]Labels, error) {
+	if swarmMode {
+		return GetServiceLabels(ctx, dockerClient, true, stackName)
+	}
+
+	containers, err := GetLabeledContainers(ctx, dockerClient, api.ProjectLabel, stackName, true)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := make(map[Service]Labels, len(containers))
+	for _, container := range containers {
+		name := container.ID
+		if len(container.Names) > 0 {
+			name = container.Names[0]
+		}
+
+		labels[Service(name)] = container.Labels
+	}
+
+	return labels, nil
+}
+
+func validateMigrationOwnership(labelsByService map[Service]Labels, expectedSources map[string]struct{}, mode bool, stackName string) error {
+	for service, labels := range labelsByService {
+		if labels[DocoCDLabels.Metadata.Manager] != app.Name ||
+			!migrationSourceMatches(labels, expectedSources) {
+			return fmt.Errorf("%w: %s %q exists for stack %q and is not managed by this deployment source",
+				ErrDeploymentModeConflict, deploymentModeName(mode), service, stackName)
+		}
+	}
+
+	return nil
+}
+
+func migrationSourceMatches(labels Labels, expectedSources map[string]struct{}) bool {
+	for _, source := range []string{
+		labels[DocoCDLabels.Source.Name],
+		labels[DocoCDLabels.Source.URL],
+	} {
+		source = normalizeRepositoryForLabelMatch(source)
+		if _, ok := expectedSources[source]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func deploymentModeName(swarmMode bool) string {
+	if swarmMode {
+		return "swarm"
+	}
+
+	return "compose"
+}

--- a/internal/docker/deployment_mode_migration.go
+++ b/internal/docker/deployment_mode_migration.go
@@ -24,16 +24,17 @@ var ErrDeploymentModeConflict = errors.New("deployment mode migration conflicts 
 // MigrateDeploymentMode removes a previous deployment in the other runtime mode,
 // but only after proving every discovered resource belongs to this doco-cd deployment.
 // Volumes are deliberately retained for the new mode.
-func MigrateDeploymentMode(ctx context.Context, log *slog.Logger, dockerCli command.Cli, contextName, stackName, source string, swarmMode, swarmAvailable bool) error {
+// It reports whether previous-mode resources were removed.
+func MigrateDeploymentMode(ctx context.Context, log *slog.Logger, dockerCli command.Cli, contextName, stackName, source string, swarmMode, swarmAvailable bool) (bool, error) {
 	if dockerCli == nil {
-		return errors.New("docker cli is required")
+		return false, errors.New("docker cli is required")
 	}
 
 	// Without Swarm capability there is no second mode to migrate between: the
 	// context is either a standalone engine or has Swarm features globally
 	// disabled, in which case its Swarm API must not be probed at all.
 	if !swarmAvailable {
-		return nil
+		return false, nil
 	}
 
 	stackLockKey := lock.StackKey(contextName, stackName)
@@ -45,16 +46,16 @@ func MigrateDeploymentMode(ctx context.Context, log *slog.Logger, dockerCli comm
 
 	labelsByService, err := deploymentModeLabels(ctx, dockerCli.Client(), stackName, previousMode)
 	if err != nil {
-		return fmt.Errorf("failed to inspect %s resources for deployment mode migration: %w", deploymentModeName(previousMode), err)
+		return false, fmt.Errorf("failed to inspect %s resources for deployment mode migration: %w", deploymentModeName(previousMode), err)
 	}
 
 	if len(labelsByService) == 0 {
-		return nil
+		return false, nil
 	}
 
 	expectedSources := migrationSourceCandidates(source)
 	if err = validateMigrationOwnership(labelsByService, expectedSources, previousMode, stackName); err != nil {
-		return err
+		return false, err
 	}
 
 	// A partial earlier migration may have resources in both modes. Do not
@@ -62,11 +63,11 @@ func MigrateDeploymentMode(ctx context.Context, log *slog.Logger, dockerCli comm
 	// unmanaged same-named deployment.
 	selectedLabels, err := deploymentModeLabels(ctx, dockerCli.Client(), stackName, swarmMode)
 	if err != nil {
-		return fmt.Errorf("failed to inspect %s resources for deployment mode migration: %w", deploymentModeName(swarmMode), err)
+		return false, fmt.Errorf("failed to inspect %s resources for deployment mode migration: %w", deploymentModeName(swarmMode), err)
 	}
 
 	if err := validateMigrationOwnership(selectedLabels, expectedSources, swarmMode, stackName); err != nil {
-		return err
+		return false, err
 	}
 
 	if log == nil {
@@ -86,10 +87,10 @@ func MigrateDeploymentMode(ctx context.Context, log *slog.Logger, dockerCli comm
 	removeConfig.Destroy.RemoveImages = false
 
 	if err := DestroyStack(log, &ctx, &dockerCli, removeConfig, previousMode); err != nil {
-		return fmt.Errorf("failed to remove previous %s deployment: %w", deploymentModeName(previousMode), err)
+		return false, fmt.Errorf("failed to remove previous %s deployment: %w", deploymentModeName(previousMode), err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // deploymentModeLabels returns a map of service names to their labels for the given stack in the specified deployment mode.

--- a/internal/docker/deployment_mode_migration.go
+++ b/internal/docker/deployment_mode_migration.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/config/app"
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
+	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/lock"
 )
 
@@ -132,6 +133,10 @@ func migrationSourceMatches(labels Labels, expectedSources map[string]struct{}) 
 	} {
 		source = normalizeRepositoryForLabelMatch(source)
 		if _, ok := expectedSources[source]; ok {
+			return true
+		}
+
+		if _, ok := expectedSources[git.GetFullName(source)]; ok {
 			return true
 		}
 	}

--- a/internal/docker/deployment_mode_migration.go
+++ b/internal/docker/deployment_mode_migration.go
@@ -147,17 +147,30 @@ func migrationSourceMatches(labels Labels, expectedSources map[string]struct{}) 
 
 // migrationSourceCandidates returns a set of normalized source candidates for matching against existing resources.
 func migrationSourceCandidates(source string) map[string]struct{} {
+	normalized := normalizeRepositoryForLabelMatch(source)
 	candidates := map[string]struct{}{
-		normalizeRepositoryForLabelMatch(source): {},
+		normalized: {},
 	}
 
 	source = strings.TrimSpace(source)
 	if strings.Contains(source, "://") ||
-		(strings.Contains(source, "@") && strings.Contains(source, ":")) {
-		candidates[normalizeRepositoryForLabelMatch(git.GetFullName(source))] = struct{}{}
+		(strings.Contains(source, "@") && strings.Contains(source, ":")) ||
+		hasRepositoryHostPrefix(normalized) {
+		candidates[normalizeRepositoryForLabelMatch(git.GetFullName(normalized))] = struct{}{}
 	}
 
 	return candidates
+}
+
+func hasRepositoryHostPrefix(repository string) bool {
+	parts := strings.Split(repository, "/")
+	if len(parts) < 3 {
+		return false
+	}
+
+	host := parts[0]
+
+	return host == "localhost" || strings.ContainsAny(host, ".:")
 }
 
 // deploymentModeName returns a human-readable name for the deployment mode.

--- a/internal/docker/deployment_mode_migration.go
+++ b/internal/docker/deployment_mode_migration.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v5/pkg/api"
@@ -51,7 +52,7 @@ func MigrateDeploymentMode(ctx context.Context, log *slog.Logger, dockerCli comm
 		return nil
 	}
 
-	expectedSources := buildRepositoryLabelCandidates(source)
+	expectedSources := migrationSourceCandidates(source)
 	if err = validateMigrationOwnership(labelsByService, expectedSources, previousMode, stackName); err != nil {
 		return err
 	}
@@ -91,6 +92,7 @@ func MigrateDeploymentMode(ctx context.Context, log *slog.Logger, dockerCli comm
 	return nil
 }
 
+// deploymentModeLabels returns a map of service names to their labels for the given stack in the specified deployment mode.
 func deploymentModeLabels(ctx context.Context, dockerClient client.APIClient, stackName string, swarmMode bool) (map[Service]Labels, error) {
 	if swarmMode {
 		return GetServiceLabels(ctx, dockerClient, true, stackName)
@@ -114,6 +116,7 @@ func deploymentModeLabels(ctx context.Context, dockerClient client.APIClient, st
 	return labels, nil
 }
 
+// validateMigrationOwnership checks that all discovered resources are owned by this deployment source.
 func validateMigrationOwnership(labelsByService map[Service]Labels, expectedSources map[string]struct{}, mode bool, stackName string) error {
 	for service, labels := range labelsByService {
 		if labels[DocoCDLabels.Metadata.Manager] != app.Name ||
@@ -126,24 +129,38 @@ func validateMigrationOwnership(labelsByService map[Service]Labels, expectedSour
 	return nil
 }
 
+// migrationSourceMatches returns true if any of the source labels match the expected sources.
 func migrationSourceMatches(labels Labels, expectedSources map[string]struct{}) bool {
 	for _, source := range []string{
 		labels[DocoCDLabels.Source.Name],
 		labels[DocoCDLabels.Source.URL],
 	} {
-		source = normalizeRepositoryForLabelMatch(source)
-		if _, ok := expectedSources[source]; ok {
-			return true
-		}
-
-		if _, ok := expectedSources[git.GetFullName(source)]; ok {
-			return true
+		for candidate := range migrationSourceCandidates(source) {
+			if _, ok := expectedSources[candidate]; ok {
+				return true
+			}
 		}
 	}
 
 	return false
 }
 
+// migrationSourceCandidates returns a set of normalized source candidates for matching against existing resources.
+func migrationSourceCandidates(source string) map[string]struct{} {
+	candidates := map[string]struct{}{
+		normalizeRepositoryForLabelMatch(source): {},
+	}
+
+	source = strings.TrimSpace(source)
+	if strings.Contains(source, "://") ||
+		(strings.Contains(source, "@") && strings.Contains(source, ":")) {
+		candidates[normalizeRepositoryForLabelMatch(git.GetFullName(source))] = struct{}{}
+	}
+
+	return candidates
+}
+
+// deploymentModeName returns a human-readable name for the deployment mode.
 func deploymentModeName(swarmMode bool) string {
 	if swarmMode {
 		return "swarm"

--- a/internal/docker/deployment_mode_migration_test.go
+++ b/internal/docker/deployment_mode_migration_test.go
@@ -63,7 +63,7 @@ func TestMigrateDeploymentMode_RejectsUnmanagedPreviousMode(t *testing.T) {
 		}},
 	}}
 
-	err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "github.com/acme/example", true, true)
+	_, err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "github.com/acme/example", true, true)
 	if !errors.Is(err, ErrDeploymentModeConflict) {
 		t.Fatalf("MigrateDeploymentMode() error = %v, want ErrDeploymentModeConflict", err)
 	}
@@ -88,7 +88,7 @@ func TestMigrateDeploymentMode_RejectsUnmanagedSelectedMode(t *testing.T) {
 	}
 	dockerCli := deploymentModeMigrationCLI{apiClient: apiClient}
 
-	err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "owner/repo", true, true)
+	_, err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "owner/repo", true, true)
 	if !errors.Is(err, ErrDeploymentModeConflict) {
 		t.Fatalf("MigrateDeploymentMode() error = %v, want ErrDeploymentModeConflict", err)
 	}
@@ -104,8 +104,13 @@ func TestMigrateDeploymentMode_SkipsMigrationWhenSwarmUnavailable(t *testing.T) 
 	apiClient := &deploymentModeMigrationClient{}
 	dockerCli := deploymentModeMigrationCLI{apiClient: apiClient}
 
-	if err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "owner/repo", false, false); err != nil {
+	migrated, err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "owner/repo", false, false)
+	if err != nil {
 		t.Fatalf("MigrateDeploymentMode() error = %v, want nil", err)
+	}
+
+	if migrated {
+		t.Fatal("MigrateDeploymentMode() migrated without Swarm availability")
 	}
 
 	if apiClient.containerListCalls != 0 || apiClient.serviceListCalls != 0 {
@@ -291,8 +296,13 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 			sourceContainerID := migrationServiceContainerID(ctx, t, apiClient, stackName, tt.sourceMode)
 			writeMigrationVolumeMarker(ctx, t, apiClient, sourceContainerID)
 
-			if err := MigrateDeploymentMode(ctx, nil, dockerCli, "", stackName, "owner/repo", !tt.sourceMode, true); err != nil {
+			migrated, err := MigrateDeploymentMode(ctx, nil, dockerCli, "", stackName, "owner/repo", !tt.sourceMode, true)
+			if err != nil {
 				t.Fatalf("MigrateDeploymentMode() error = %v", err)
+			}
+
+			if !migrated {
+				t.Fatal("MigrateDeploymentMode() did not report removing the source deployment")
 			}
 
 			if err := tt.assertGone(stackName); err != nil {

--- a/internal/docker/deployment_mode_migration_test.go
+++ b/internal/docker/deployment_mode_migration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/docker/cli/cli/command"
@@ -70,6 +71,16 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 
 	if !swarmAvailable {
 		t.Skip("Swarm mode is not enabled, skipping migration integration test")
+	}
+
+	imageReader, err := apiClient.ImagePull(ctx, "busybox:latest", client.ImagePullOptions{})
+	if err != nil {
+		t.Skipf("cannot pull busybox test image: %v", err)
+	}
+	defer imageReader.Close()
+
+	if _, err := io.Copy(io.Discard, imageReader); err != nil {
+		t.Fatalf("failed to pull busybox test image: %v", err)
 	}
 
 	for _, tt := range []struct {

--- a/internal/docker/deployment_mode_migration_test.go
+++ b/internal/docker/deployment_mode_migration_test.go
@@ -141,6 +141,12 @@ func TestMigrationSourceMatches(t *testing.T) {
 			want:           true,
 		},
 		{
+			name:           "canonical host path expected",
+			expectedSource: "github.com/owner/repo",
+			labels:         Labels{DocoCDLabels.Source.Name: "owner/repo"},
+			want:           true,
+		},
+		{
 			name:           "different repository",
 			expectedSource: "owner/repo",
 			labels:         Labels{DocoCDLabels.Source.Name: "owner/other"},

--- a/internal/docker/deployment_mode_migration_test.go
+++ b/internal/docker/deployment_mode_migration_test.go
@@ -1,0 +1,48 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
+)
+
+type deploymentModeMigrationClient struct {
+	client.APIClient
+	containers []container.Summary
+}
+
+func (c deploymentModeMigrationClient) ContainerList(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
+	return client.ContainerListResult{Items: c.containers}, nil
+}
+
+type deploymentModeMigrationCLI struct {
+	command.Cli
+	apiClient client.APIClient
+}
+
+func (c deploymentModeMigrationCLI) Client() client.APIClient {
+	return c.apiClient
+}
+
+func TestMigrateDeploymentMode_RejectsUnmanagedPreviousMode(t *testing.T) {
+	t.Parallel()
+
+	dockerCli := deploymentModeMigrationCLI{apiClient: deploymentModeMigrationClient{
+		containers: []container.Summary{{
+			Names: []string{"/example_web_1"},
+			Labels: map[string]string{
+				api.ProjectLabel: "example",
+			},
+		}},
+	}}
+
+	err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "github.com/acme/example", true, true)
+	if !errors.Is(err, ErrDeploymentModeConflict) {
+		t.Fatalf("MigrateDeploymentMode() error = %v, want ErrDeploymentModeConflict", err)
+	}
+}

--- a/internal/docker/deployment_mode_migration_test.go
+++ b/internal/docker/deployment_mode_migration_test.go
@@ -3,17 +3,24 @@ package docker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v5/pkg/api"
-	"github.com/moby/moby/api/types/container"
+	containerTypes "github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
+	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
+
+	"github.com/kimdre/doco-cd/internal/config/app"
+	"github.com/kimdre/doco-cd/internal/docker/swarm"
+	"github.com/kimdre/doco-cd/internal/test"
 )
 
 type deploymentModeMigrationClient struct {
 	client.APIClient
-	containers []container.Summary
+	containers []containerTypes.Summary
 }
 
 func (c deploymentModeMigrationClient) ContainerList(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
@@ -33,7 +40,7 @@ func TestMigrateDeploymentMode_RejectsUnmanagedPreviousMode(t *testing.T) {
 	t.Parallel()
 
 	dockerCli := deploymentModeMigrationCLI{apiClient: deploymentModeMigrationClient{
-		containers: []container.Summary{{
+		containers: []containerTypes.Summary{{
 			Names: []string{"/example_web_1"},
 			Labels: map[string]string{
 				api.ProjectLabel: "example",
@@ -44,5 +51,140 @@ func TestMigrateDeploymentMode_RejectsUnmanagedPreviousMode(t *testing.T) {
 	err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "github.com/acme/example", true, true)
 	if !errors.Is(err, ErrDeploymentModeConflict) {
 		t.Fatalf("MigrateDeploymentMode() error = %v, want ErrDeploymentModeConflict", err)
+	}
+}
+
+func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
+	dockerCli, err := CreateDockerCli(false)
+	if err != nil {
+		t.Skipf("docker unavailable: %v", err)
+	}
+
+	ctx := t.Context()
+	apiClient := dockerCli.Client()
+
+	swarmAvailable, err := swarm.ResolveModeEnabled(ctx, apiClient)
+	if err != nil {
+		t.Skipf("failed to determine swarm availability: %v", err)
+	}
+
+	if !swarmAvailable {
+		t.Skip("Swarm mode is not enabled, skipping migration integration test")
+	}
+
+	for _, tt := range []struct {
+		name       string
+		sourceMode bool
+		create     func(string, string) (func(), error)
+		assertGone func(string) error
+	}{
+		{
+			name:       "compose to swarm",
+			sourceMode: false,
+			create: func(stackName, volumeName string) (func(), error) {
+				result, createErr := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
+					Config: &containerTypes.Config{Image: "busybox:latest", Labels: migrationTestLabels(stackName)},
+					HostConfig: &containerTypes.HostConfig{Mounts: []mount.Mount{{
+						Type: mount.TypeVolume, Source: volumeName, Target: "/data",
+					}}},
+					Name: stackName + "-service-1",
+				})
+				if createErr != nil {
+					return nil, createErr
+				}
+
+				return func() { //nolint:contextcheck // cleanup must run after the test context is cancelled.
+					_, _ = apiClient.ContainerRemove(context.Background(), result.ID, client.ContainerRemoveOptions{Force: true})
+				}, nil
+			},
+			assertGone: func(stackName string) error {
+				containers, listErr := GetLabeledContainers(ctx, apiClient, api.ProjectLabel, stackName, true)
+				if listErr != nil {
+					return listErr
+				}
+
+				if len(containers) != 0 {
+					return fmt.Errorf("expected Compose project to be removed, found %d containers", len(containers))
+				}
+
+				return nil
+			},
+		},
+		{
+			name:       "swarm to compose",
+			sourceMode: true,
+			create: func(stackName, volumeName string) (func(), error) {
+				replicas := uint64(0)
+
+				result, createErr := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{Spec: swarmTypes.ServiceSpec{
+					Annotations: swarmTypes.Annotations{Name: stackName + "_service", Labels: migrationTestLabels(stackName)},
+					TaskTemplate: swarmTypes.TaskSpec{ContainerSpec: &swarmTypes.ContainerSpec{
+						Image:  "busybox:latest",
+						Mounts: []mount.Mount{{Type: mount.TypeVolume, Source: volumeName, Target: "/data"}},
+					}},
+					Mode: swarmTypes.ServiceMode{Replicated: &swarmTypes.ReplicatedService{Replicas: &replicas}},
+				}})
+				if createErr != nil {
+					return nil, createErr
+				}
+
+				return func() { //nolint:contextcheck // cleanup must run after the test context is cancelled.
+					_, _ = apiClient.ServiceRemove(context.Background(), result.ID, client.ServiceRemoveOptions{})
+				}, nil
+			},
+			assertGone: func(stackName string) error {
+				services, listErr := GetServiceLabels(ctx, apiClient, true, stackName)
+				if listErr != nil {
+					return listErr
+				}
+
+				if len(services) != 0 {
+					return fmt.Errorf("expected Swarm stack to be removed, found %d services", len(services))
+				}
+
+				return nil
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stackName := test.ConvertTestName(t.Name())
+
+			volumeName := stackName + "-data"
+			if _, err := apiClient.VolumeCreate(ctx, client.VolumeCreateOptions{Name: volumeName}); err != nil {
+				t.Fatalf("failed to create named volume: %v", err)
+			}
+
+			t.Cleanup(func() { //nolint:contextcheck // cleanup must run after the test context is cancelled.
+				_, _ = apiClient.VolumeRemove(context.Background(), volumeName, client.VolumeRemoveOptions{Force: true})
+			})
+
+			cleanupResource, err := tt.create(stackName, volumeName)
+			if err != nil {
+				t.Fatalf("failed to create source deployment: %v", err)
+			}
+
+			t.Cleanup(cleanupResource)
+
+			if err := MigrateDeploymentMode(ctx, nil, dockerCli, "", stackName, "owner/repo", !tt.sourceMode, true); err != nil {
+				t.Fatalf("MigrateDeploymentMode() error = %v", err)
+			}
+
+			if err := tt.assertGone(stackName); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := apiClient.VolumeInspect(ctx, volumeName, client.VolumeInspectOptions{}); err != nil {
+				t.Fatalf("expected named volume to survive migration: %v", err)
+			}
+		})
+	}
+}
+
+func migrationTestLabels(stackName string) map[string]string {
+	return map[string]string{
+		api.ProjectLabel:              stackName,
+		swarm.StackNamespaceLabel:     stackName,
+		DocoCDLabels.Metadata.Manager: app.Name,
+		DocoCDLabels.Source.Name:      "owner/repo",
 	}
 }

--- a/internal/docker/deployment_mode_migration_test.go
+++ b/internal/docker/deployment_mode_migration_test.go
@@ -86,27 +86,30 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 	for _, tt := range []struct {
 		name       string
 		sourceMode bool
-		create     func(string, string) (func(), error)
+		create     func(*testing.T, string, string) error
 		assertGone func(string) error
 	}{
 		{
 			name:       "compose to swarm",
 			sourceMode: false,
-			create: func(stackName, volumeName string) (func(), error) {
-				result, createErr := apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
-					Config: &containerTypes.Config{Image: "busybox:latest", Labels: migrationTestLabels(stackName)},
-					HostConfig: &containerTypes.HostConfig{Mounts: []mount.Mount{{
-						Type: mount.TypeVolume, Source: volumeName, Target: "/data",
-					}}},
-					Name: stackName + "-service-1",
-				})
-				if createErr != nil {
-					return nil, createErr
-				}
+			create: func(t *testing.T, stackName, volumeName string) error {
+				test.ComposeUp(ctx, t,
+					test.WithName(stackName),
+					test.WithYAML(fmt.Sprintf(`services:
+  service:
+    image: busybox:latest
+    command: ["sh", "-c", "while true; do sleep 3600; done"]
+    volumes:
+      - data:/data
+volumes:
+  data:
+    external: true
+    name: %s
+`, volumeName)),
+					test.WithCustomLabel(migrationTestOwnershipLabels()),
+				)
 
-				return func() { //nolint:contextcheck // cleanup must run after the test context is cancelled.
-					_, _ = apiClient.ContainerRemove(context.Background(), result.ID, client.ContainerRemoveOptions{Force: true})
-				}, nil
+				return nil
 			},
 			assertGone: func(stackName string) error {
 				containers, listErr := GetLabeledContainers(ctx, apiClient, api.ProjectLabel, stackName, true)
@@ -124,11 +127,11 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 		{
 			name:       "swarm to compose",
 			sourceMode: true,
-			create: func(stackName, volumeName string) (func(), error) {
+			create: func(t *testing.T, stackName, volumeName string) error {
 				replicas := uint64(0)
 
 				result, createErr := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{Spec: swarmTypes.ServiceSpec{
-					Annotations: swarmTypes.Annotations{Name: stackName + "_service", Labels: migrationTestLabels(stackName)},
+					Annotations: swarmTypes.Annotations{Name: stackName + "_service", Labels: swarmMigrationTestLabels(stackName)},
 					TaskTemplate: swarmTypes.TaskSpec{ContainerSpec: &swarmTypes.ContainerSpec{
 						Image:  "busybox:latest",
 						Mounts: []mount.Mount{{Type: mount.TypeVolume, Source: volumeName, Target: "/data"}},
@@ -136,12 +139,14 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 					Mode: swarmTypes.ServiceMode{Replicated: &swarmTypes.ReplicatedService{Replicas: &replicas}},
 				}})
 				if createErr != nil {
-					return nil, createErr
+					return createErr
 				}
 
-				return func() { //nolint:contextcheck // cleanup must run after the test context is cancelled.
+				t.Cleanup(func() { //nolint:contextcheck // cleanup must run after the test context is cancelled.
 					_, _ = apiClient.ServiceRemove(context.Background(), result.ID, client.ServiceRemoveOptions{})
-				}, nil
+				})
+
+				return nil
 			},
 			assertGone: func(stackName string) error {
 				services, listErr := GetServiceLabels(ctx, apiClient, true, stackName)
@@ -169,12 +174,9 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 				_, _ = apiClient.VolumeRemove(context.Background(), volumeName, client.VolumeRemoveOptions{Force: true})
 			})
 
-			cleanupResource, err := tt.create(stackName, volumeName)
-			if err != nil {
+			if err := tt.create(t, stackName, volumeName); err != nil {
 				t.Fatalf("failed to create source deployment: %v", err)
 			}
-
-			t.Cleanup(cleanupResource)
 
 			if err := MigrateDeploymentMode(ctx, nil, dockerCli, "", stackName, "owner/repo", !tt.sourceMode, true); err != nil {
 				t.Fatalf("MigrateDeploymentMode() error = %v", err)
@@ -191,11 +193,16 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 	}
 }
 
-func migrationTestLabels(stackName string) map[string]string {
+func migrationTestOwnershipLabels() map[string]string {
 	return map[string]string{
-		api.ProjectLabel:              stackName,
-		swarm.StackNamespaceLabel:     stackName,
 		DocoCDLabels.Metadata.Manager: app.Name,
 		DocoCDLabels.Source.Name:      "owner/repo",
 	}
+}
+
+func swarmMigrationTestLabels(stackName string) map[string]string {
+	labels := migrationTestOwnershipLabels()
+	labels[swarm.StackNamespaceLabel] = stackName
+
+	return labels
 }

--- a/internal/docker/deployment_mode_migration_test.go
+++ b/internal/docker/deployment_mode_migration_test.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/avast/retry-go/v5"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v5/pkg/api"
 	containerTypes "github.com/moby/moby/api/types/container"
@@ -21,11 +24,22 @@ import (
 
 type deploymentModeMigrationClient struct {
 	client.APIClient
-	containers []containerTypes.Summary
+	containers         []containerTypes.Summary
+	services           []swarmTypes.Service
+	containerListCalls int
+	serviceListCalls   int
 }
 
-func (c deploymentModeMigrationClient) ContainerList(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
+func (c *deploymentModeMigrationClient) ContainerList(context.Context, client.ContainerListOptions) (client.ContainerListResult, error) {
+	c.containerListCalls++
+
 	return client.ContainerListResult{Items: c.containers}, nil
+}
+
+func (c *deploymentModeMigrationClient) ServiceList(context.Context, client.ServiceListOptions) (client.ServiceListResult, error) {
+	c.serviceListCalls++
+
+	return client.ServiceListResult{Items: c.services}, nil
 }
 
 type deploymentModeMigrationCLI struct {
@@ -40,7 +54,7 @@ func (c deploymentModeMigrationCLI) Client() client.APIClient {
 func TestMigrateDeploymentMode_RejectsUnmanagedPreviousMode(t *testing.T) {
 	t.Parallel()
 
-	dockerCli := deploymentModeMigrationCLI{apiClient: deploymentModeMigrationClient{
+	dockerCli := deploymentModeMigrationCLI{apiClient: &deploymentModeMigrationClient{
 		containers: []containerTypes.Summary{{
 			Names: []string{"/example_web_1"},
 			Labels: map[string]string{
@@ -52,6 +66,84 @@ func TestMigrateDeploymentMode_RejectsUnmanagedPreviousMode(t *testing.T) {
 	err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "github.com/acme/example", true, true)
 	if !errors.Is(err, ErrDeploymentModeConflict) {
 		t.Fatalf("MigrateDeploymentMode() error = %v, want ErrDeploymentModeConflict", err)
+	}
+}
+
+func TestMigrateDeploymentMode_RejectsUnmanagedSelectedMode(t *testing.T) {
+	t.Parallel()
+
+	apiClient := &deploymentModeMigrationClient{
+		containers: []containerTypes.Summary{{
+			Names:  []string{"/example_web_1"},
+			Labels: migrationTestOwnershipLabels(),
+		}},
+		services: []swarmTypes.Service{{
+			Spec: swarmTypes.ServiceSpec{
+				Annotations: swarmTypes.Annotations{
+					Name:   "example_web",
+					Labels: map[string]string{swarm.StackNamespaceLabel: "example"},
+				},
+			},
+		}},
+	}
+	dockerCli := deploymentModeMigrationCLI{apiClient: apiClient}
+
+	err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "owner/repo", true, true)
+	if !errors.Is(err, ErrDeploymentModeConflict) {
+		t.Fatalf("MigrateDeploymentMode() error = %v, want ErrDeploymentModeConflict", err)
+	}
+
+	if apiClient.containerListCalls != 1 || apiClient.serviceListCalls != 1 {
+		t.Fatalf("unexpected migration API calls: ContainerList=%d ServiceList=%d", apiClient.containerListCalls, apiClient.serviceListCalls)
+	}
+}
+
+func TestMigrateDeploymentMode_SkipsMigrationWhenSwarmUnavailable(t *testing.T) {
+	t.Parallel()
+
+	apiClient := &deploymentModeMigrationClient{}
+	dockerCli := deploymentModeMigrationCLI{apiClient: apiClient}
+
+	if err := MigrateDeploymentMode(t.Context(), nil, dockerCli, "", "example", "owner/repo", false, false); err != nil {
+		t.Fatalf("MigrateDeploymentMode() error = %v, want nil", err)
+	}
+
+	if apiClient.containerListCalls != 0 || apiClient.serviceListCalls != 0 {
+		t.Fatalf("expected no Docker API calls, got ContainerList=%d ServiceList=%d", apiClient.containerListCalls, apiClient.serviceListCalls)
+	}
+}
+
+func TestMigrationSourceMatches(t *testing.T) {
+	t.Parallel()
+
+	expectedSources := buildRepositoryLabelCandidates("owner/repo")
+
+	for _, tt := range []struct {
+		name   string
+		labels Labels
+		want   bool
+	}{
+		{
+			name:   "source name",
+			labels: Labels{DocoCDLabels.Source.Name: "owner/repo"},
+			want:   true,
+		},
+		{
+			name:   "source URL",
+			labels: Labels{DocoCDLabels.Source.URL: "https://github.com/owner/repo.git"},
+			want:   true,
+		},
+		{
+			name:   "different repository",
+			labels: Labels{DocoCDLabels.Source.Name: "owner/other"},
+			want:   false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := migrationSourceMatches(tt.labels, expectedSources); got != tt.want {
+				t.Fatalf("migrationSourceMatches() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -95,17 +187,7 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 			create: func(t *testing.T, stackName, volumeName string) error {
 				test.ComposeUp(ctx, t,
 					test.WithName(stackName),
-					test.WithYAML(fmt.Sprintf(`services:
-  service:
-    image: busybox:latest
-    command: ["sh", "-c", "while true; do sleep 3600; done"]
-    volumes:
-      - data:/data
-volumes:
-  data:
-    external: true
-    name: %s
-`, volumeName)),
+					test.WithYAML(migrationVolumeServiceYAML(volumeName)),
 					test.WithCustomLabel(migrationTestOwnershipLabels()),
 				)
 
@@ -128,13 +210,14 @@ volumes:
 			name:       "swarm to compose",
 			sourceMode: true,
 			create: func(t *testing.T, stackName, volumeName string) error {
-				replicas := uint64(0)
+				replicas := uint64(1)
 
 				result, createErr := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{Spec: swarmTypes.ServiceSpec{
 					Annotations: swarmTypes.Annotations{Name: stackName + "_service", Labels: swarmMigrationTestLabels(stackName)},
 					TaskTemplate: swarmTypes.TaskSpec{ContainerSpec: &swarmTypes.ContainerSpec{
-						Image:  "busybox:latest",
-						Mounts: []mount.Mount{{Type: mount.TypeVolume, Source: volumeName, Target: "/data"}},
+						Image:   "busybox:latest",
+						Command: []string{"sh", "-c", "while true; do sleep 3600; done"},
+						Mounts:  []mount.Mount{{Type: mount.TypeVolume, Source: volumeName, Target: "/data"}},
 					}},
 					Mode: swarmTypes.ServiceMode{Replicated: &swarmTypes.ReplicatedService{Replicas: &replicas}},
 				}})
@@ -178,6 +261,9 @@ volumes:
 				t.Fatalf("failed to create source deployment: %v", err)
 			}
 
+			sourceContainerID := migrationServiceContainerID(ctx, t, apiClient, stackName, tt.sourceMode)
+			writeMigrationVolumeMarker(ctx, t, apiClient, sourceContainerID)
+
 			if err := MigrateDeploymentMode(ctx, nil, dockerCli, "", stackName, "owner/repo", !tt.sourceMode, true); err != nil {
 				t.Fatalf("MigrateDeploymentMode() error = %v", err)
 			}
@@ -189,7 +275,130 @@ volumes:
 			if _, err := apiClient.VolumeInspect(ctx, volumeName, client.VolumeInspectOptions{}); err != nil {
 				t.Fatalf("expected named volume to survive migration: %v", err)
 			}
+
+			var targetContainerID string
+
+			if tt.sourceMode {
+				targetStack := test.ComposeUp(ctx, t,
+					test.WithName(stackName),
+					test.WithYAML(migrationVolumeServiceYAML(volumeName)),
+					test.WithCustomLabel(migrationTestOwnershipLabels()),
+				)
+				targetContainerID = targetStack.ServiceContainerID(ctx, t, "service")
+			} else {
+				createMigrationSwarmVolumeService(ctx, t, apiClient, stackName, volumeName)
+				targetContainerID = migrationServiceContainerID(ctx, t, apiClient, stackName, true)
+			}
+
+			readMigrationVolumeMarker(ctx, t, apiClient, targetContainerID)
 		})
+	}
+}
+
+func migrationVolumeServiceYAML(volumeName string) string {
+	return fmt.Sprintf(`services:
+  service:
+    image: busybox:latest
+    command: ["sh", "-c", "while true; do sleep 3600; done"]
+    volumes:
+      - data:/data
+volumes:
+  data:
+    external: true
+    name: %s
+`, volumeName)
+}
+
+func createMigrationSwarmVolumeService(ctx context.Context, t *testing.T, apiClient client.APIClient, stackName, volumeName string) {
+	t.Helper()
+
+	replicas := uint64(1)
+
+	result, err := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{Spec: swarmTypes.ServiceSpec{
+		Annotations: swarmTypes.Annotations{Name: stackName + "_service", Labels: swarmMigrationTestLabels(stackName)},
+		TaskTemplate: swarmTypes.TaskSpec{ContainerSpec: &swarmTypes.ContainerSpec{
+			Image:   "busybox:latest",
+			Command: []string{"sh", "-c", "while true; do sleep 3600; done"},
+			Mounts:  []mount.Mount{{Type: mount.TypeVolume, Source: volumeName, Target: "/data"}},
+		}},
+		Mode: swarmTypes.ServiceMode{Replicated: &swarmTypes.ReplicatedService{Replicas: &replicas}},
+	}})
+	if err != nil {
+		t.Fatalf("failed to create target Swarm deployment: %v", err)
+	}
+
+	t.Cleanup(func() { //nolint:contextcheck // cleanup must run after the test context is cancelled.
+		_, _ = apiClient.ServiceRemove(context.Background(), result.ID, client.ServiceRemoveOptions{})
+	})
+}
+
+func migrationServiceContainerID(ctx context.Context, t *testing.T, apiClient client.APIClient, stackName string, swarmMode bool) string {
+	t.Helper()
+
+	var containerID string
+
+	err := retry.New(
+		retry.Attempts(21),
+		retry.Delay(250*time.Millisecond),
+		retry.DelayType(retry.FixedDelay),
+	).Do(func() error {
+		if swarmMode {
+			tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
+				Filters: make(client.Filters).Add("label", swarm.StackNamespaceLabel+"="+stackName),
+			})
+			if err != nil {
+				return err
+			}
+
+			for _, task := range tasks.Items {
+				if task.Status.ContainerStatus != nil && task.Status.ContainerStatus.ContainerID != "" {
+					containerID = task.Status.ContainerStatus.ContainerID
+
+					return nil
+				}
+			}
+
+			return fmt.Errorf("no running Swarm task container for stack %q", stackName)
+		}
+
+		containers, err := GetLabeledContainers(ctx, apiClient, api.ProjectLabel, stackName, false)
+		if err != nil {
+			return err
+		}
+
+		if len(containers) != 1 {
+			return fmt.Errorf("expected one Compose container for stack %q, got %d", stackName, len(containers))
+		}
+
+		containerID = containers[0].ID
+
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return containerID
+}
+
+func writeMigrationVolumeMarker(ctx context.Context, t *testing.T, apiClient client.APIClient, containerID string) {
+	t.Helper()
+
+	if _, err := ExecContext(ctx, apiClient, containerID, "sh", "-c", "printf migration-data >/data/migration-marker"); err != nil {
+		t.Fatalf("failed to write named-volume marker: %v", err)
+	}
+}
+
+func readMigrationVolumeMarker(ctx context.Context, t *testing.T, apiClient client.APIClient, containerID string) {
+	t.Helper()
+
+	output, err := ExecContext(ctx, apiClient, containerID, "cat", "/data/migration-marker")
+	if err != nil {
+		t.Fatalf("failed to read named-volume marker: %v", err)
+	}
+
+	if strings.TrimSpace(output) != "migration-data" {
+		t.Fatalf("named-volume marker = %q, want %q", output, "migration-data")
 	}
 }
 

--- a/internal/docker/deployment_mode_migration_test.go
+++ b/internal/docker/deployment_mode_migration_test.go
@@ -116,30 +116,45 @@ func TestMigrateDeploymentMode_SkipsMigrationWhenSwarmUnavailable(t *testing.T) 
 func TestMigrationSourceMatches(t *testing.T) {
 	t.Parallel()
 
-	expectedSources := buildRepositoryLabelCandidates("owner/repo")
-
 	for _, tt := range []struct {
-		name   string
-		labels Labels
-		want   bool
+		name           string
+		expectedSource string
+		labels         Labels
+		want           bool
 	}{
 		{
-			name:   "source name",
-			labels: Labels{DocoCDLabels.Source.Name: "owner/repo"},
-			want:   true,
+			name:           "source name",
+			expectedSource: "owner/repo",
+			labels:         Labels{DocoCDLabels.Source.Name: "owner/repo"},
+			want:           true,
 		},
 		{
-			name:   "source URL",
-			labels: Labels{DocoCDLabels.Source.URL: "https://github.com/owner/repo.git"},
-			want:   true,
+			name:           "source URL label",
+			expectedSource: "owner/repo",
+			labels:         Labels{DocoCDLabels.Source.URL: "https://github.com/owner/repo.git"},
+			want:           true,
 		},
 		{
-			name:   "different repository",
-			labels: Labels{DocoCDLabels.Source.Name: "owner/other"},
-			want:   false,
+			name:           "source URL expected",
+			expectedSource: "git@github.com:owner/repo.git",
+			labels:         Labels{DocoCDLabels.Source.Name: "owner/repo"},
+			want:           true,
+		},
+		{
+			name:           "different repository",
+			expectedSource: "owner/repo",
+			labels:         Labels{DocoCDLabels.Source.Name: "owner/other"},
+			want:           false,
+		},
+		{
+			name:           "same repository name under different owner",
+			expectedSource: "owner/repo",
+			labels:         Labels{DocoCDLabels.Source.Name: "someone-else/repo"},
+			want:           false,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			expectedSources := migrationSourceCandidates(tt.expectedSource)
 			if got := migrationSourceMatches(tt.labels, expectedSources); got != tt.want {
 				t.Fatalf("migrationSourceMatches() = %t, want %t", got, tt.want)
 			}
@@ -165,11 +180,25 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 		t.Skip("Swarm mode is not enabled, skipping migration integration test")
 	}
 
+	info, err := apiClient.Info(ctx, client.InfoOptions{})
+	if err != nil {
+		t.Fatalf("failed to inspect Swarm node: %v", err)
+	}
+
+	nodeID := info.Info.Swarm.NodeID
+	if nodeID == "" {
+		t.Fatal("Swarm manager has no node ID")
+	}
+
 	imageReader, err := apiClient.ImagePull(ctx, "busybox:latest", client.ImagePullOptions{})
 	if err != nil {
 		t.Skipf("cannot pull busybox test image: %v", err)
 	}
-	defer imageReader.Close()
+	defer func() {
+		if err := imageReader.Close(); err != nil {
+			t.Errorf("failed to close image pull response: %v", err)
+		}
+	}()
 
 	if _, err := io.Copy(io.Discard, imageReader); err != nil {
 		t.Fatalf("failed to pull busybox test image: %v", err)
@@ -210,17 +239,9 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 			name:       "swarm to compose",
 			sourceMode: true,
 			create: func(t *testing.T, stackName, volumeName string) error {
-				replicas := uint64(1)
-
-				result, createErr := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{Spec: swarmTypes.ServiceSpec{
-					Annotations: swarmTypes.Annotations{Name: stackName + "_service", Labels: swarmMigrationTestLabels(stackName)},
-					TaskTemplate: swarmTypes.TaskSpec{ContainerSpec: &swarmTypes.ContainerSpec{
-						Image:   "busybox:latest",
-						Command: []string{"sh", "-c", "while true; do sleep 3600; done"},
-						Mounts:  []mount.Mount{{Type: mount.TypeVolume, Source: volumeName, Target: "/data"}},
-					}},
-					Mode: swarmTypes.ServiceMode{Replicated: &swarmTypes.ReplicatedService{Replicas: &replicas}},
-				}})
+				result, createErr := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{
+					Spec: migrationSwarmVolumeServiceSpec(stackName, volumeName, nodeID),
+				})
 				if createErr != nil {
 					return createErr
 				}
@@ -286,7 +307,7 @@ func TestMigrateDeploymentMode_PreservesNamedVolumes(t *testing.T) {
 				)
 				targetContainerID = targetStack.ServiceContainerID(ctx, t, "service")
 			} else {
-				createMigrationSwarmVolumeService(ctx, t, apiClient, stackName, volumeName)
+				createMigrationSwarmVolumeService(ctx, t, apiClient, stackName, volumeName, nodeID)
 				targetContainerID = migrationServiceContainerID(ctx, t, apiClient, stackName, true)
 			}
 
@@ -309,20 +330,12 @@ volumes:
 `, volumeName)
 }
 
-func createMigrationSwarmVolumeService(ctx context.Context, t *testing.T, apiClient client.APIClient, stackName, volumeName string) {
+func createMigrationSwarmVolumeService(ctx context.Context, t *testing.T, apiClient client.APIClient, stackName, volumeName, nodeID string) {
 	t.Helper()
 
-	replicas := uint64(1)
-
-	result, err := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{Spec: swarmTypes.ServiceSpec{
-		Annotations: swarmTypes.Annotations{Name: stackName + "_service", Labels: swarmMigrationTestLabels(stackName)},
-		TaskTemplate: swarmTypes.TaskSpec{ContainerSpec: &swarmTypes.ContainerSpec{
-			Image:   "busybox:latest",
-			Command: []string{"sh", "-c", "while true; do sleep 3600; done"},
-			Mounts:  []mount.Mount{{Type: mount.TypeVolume, Source: volumeName, Target: "/data"}},
-		}},
-		Mode: swarmTypes.ServiceMode{Replicated: &swarmTypes.ReplicatedService{Replicas: &replicas}},
-	}})
+	result, err := apiClient.ServiceCreate(ctx, client.ServiceCreateOptions{
+		Spec: migrationSwarmVolumeServiceSpec(stackName, volumeName, nodeID),
+	})
 	if err != nil {
 		t.Fatalf("failed to create target Swarm deployment: %v", err)
 	}
@@ -330,6 +343,24 @@ func createMigrationSwarmVolumeService(ctx context.Context, t *testing.T, apiCli
 	t.Cleanup(func() { //nolint:contextcheck // cleanup must run after the test context is cancelled.
 		_, _ = apiClient.ServiceRemove(context.Background(), result.ID, client.ServiceRemoveOptions{})
 	})
+}
+
+func migrationSwarmVolumeServiceSpec(stackName, volumeName, nodeID string) swarmTypes.ServiceSpec {
+	replicas := uint64(1)
+
+	return swarmTypes.ServiceSpec{
+		Name: stackName + "_service", Labels: swarmMigrationTestLabels(stackName),
+		TaskTemplate: swarmTypes.TaskSpec{
+			ContainerSpec: &swarmTypes.ContainerSpec{
+				Image:   "busybox:latest",
+				Command: []string{"sh", "-c", "while true; do sleep 3600; done"},
+				Labels:  swarmMigrationTestLabels(stackName),
+				Mounts:  []mount.Mount{{Type: mount.TypeVolume, Source: volumeName, Target: "/data"}},
+			},
+			Placement: &swarmTypes.Placement{Constraints: []string{"node.id == " + nodeID}},
+		},
+		Mode: swarmTypes.ServiceMode{Replicated: &swarmTypes.ReplicatedService{Replicas: &replicas}},
+	}
 }
 
 func migrationServiceContainerID(ctx context.Context, t *testing.T, apiClient client.APIClient, stackName string, swarmMode bool) string {
@@ -351,7 +382,10 @@ func migrationServiceContainerID(ctx context.Context, t *testing.T, apiClient cl
 			}
 
 			for _, task := range tasks.Items {
-				if task.Status.ContainerStatus != nil && task.Status.ContainerStatus.ContainerID != "" {
+				if task.DesiredState == swarmTypes.TaskStateRunning &&
+					task.Status.State == swarmTypes.TaskStateRunning &&
+					task.Status.ContainerStatus != nil &&
+					task.Status.ContainerStatus.ContainerID != "" {
 					containerID = task.Status.ContainerStatus.ContainerID
 
 					return nil

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -110,12 +110,16 @@ func deploy(ctx context.Context,
 			continue
 		}
 
-		if err := cleanupObsoleteAutoDiscoveredContainers(ctx, jobLog,
-			entry.cli, entry.swarmMode, contextName, repoData.SourceUrl,
-			groupedConfigs,
-			metadata); err != nil {
-			jobLog.Error("failed to clean up obsolete auto-discovered containers for context",
-				slog.String("context", docker.DisplayContextName(contextName)), logger.ErrAttr(err))
+		for swarmMode, modeConfigs := range groupDeployConfigsByMode(groupedConfigs, entry.swarmMode) {
+			if err := cleanupObsoleteAutoDiscoveredContainers(ctx, jobLog,
+				entry.cli, swarmMode, contextName, repoData.SourceUrl,
+				modeConfigs,
+				metadata); err != nil {
+				jobLog.Error("failed to clean up obsolete auto-discovered containers for context",
+					slog.String("context", docker.DisplayContextName(contextName)),
+					slog.Bool("swarm_mode", swarmMode),
+					logger.ErrAttr(err))
+			}
 		}
 
 		if entry.closeFn != nil {
@@ -309,7 +313,7 @@ func resolveDeployContext(ctx context.Context, contexts *docker.ContextRegistry,
 
 func handleOneDeploy(ctx context.Context, deployLog *slog.Logger,
 	appConfig *app.Config, dataMountPoint container.MountPoint,
-	deploymentDockerCli command.Cli, swarmMode bool,
+	deploymentDockerCli command.Cli, swarmAvailable bool,
 	secretProvider *secretprovider.SecretProvider,
 	dc *deployConfig.Config,
 	jobID string,
@@ -318,6 +322,12 @@ func handleOneDeploy(ctx context.Context, deployLog *slog.Logger,
 	payLad *webhook.ParsedPayload,
 	metadata notification.Metadata,
 ) error {
+	swarmMode, err := dc.ResolveSwarmMode(swarmAvailable)
+	if err != nil {
+		return fmt.Errorf("failed to resolve swarm mode for deployment %q on docker context %q: %w",
+			dc.Name, docker.DisplayContextName(dc.Context), err)
+	}
+
 	if deployerLimiter != nil {
 		deployLog.Debug("queuing deployment")
 
@@ -338,6 +348,7 @@ func handleOneDeploy(ctx context.Context, deployLog *slog.Logger,
 			Cmd:            deploymentDockerCli,
 			DataMountPoint: dataMountPoint,
 			SwarmMode:      swarmMode,
+			SwarmAvailable: swarmAvailable,
 		},
 		payLad,
 		appConfig,
@@ -346,12 +357,34 @@ func handleOneDeploy(ctx context.Context, deployLog *slog.Logger,
 		metadata,
 	)
 
-	err := stageMgr.RunStages(ctx)
+	err = stageMgr.RunStages(ctx)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// groupDeployConfigsByMode partitions configs by their selected runtime mode.
+// Invalid explicit swarm requests are excluded here; handleOneDeploy reports
+// their descriptive error to the caller.
+func groupDeployConfigsByMode(dcs []*deployConfig.Config, swarmAvailable bool) map[bool][]*deployConfig.Config {
+	grouped := make(map[bool][]*deployConfig.Config)
+
+	for _, dc := range dcs {
+		if dc == nil {
+			continue
+		}
+
+		swarmMode, err := dc.ResolveSwarmMode(swarmAvailable)
+		if err != nil {
+			continue
+		}
+
+		grouped[swarmMode] = append(grouped[swarmMode], dc)
+	}
+
+	return grouped
 }
 
 func dockerCliForContext(baseCli command.Cli, quiet bool, contextName string) (command.Cli, func(), error) {

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -65,6 +65,36 @@ func TestDeploy_RejectsUnverifiedOCIArtifact(t *testing.T) {
 	}
 }
 
+func TestGroupDeployConfigsByMode(t *testing.T) {
+	t.Parallel()
+
+	compose := deployConfig.New("compose", "main")
+	swarm := deployConfig.New("swarm", "main")
+	automatic := deployConfig.New("automatic", "main")
+	composeEnabled := false
+	swarmEnabled := true
+	compose.Swarm.Enabled = &composeEnabled
+	swarm.Swarm.Enabled = &swarmEnabled
+
+	grouped := groupDeployConfigsByMode([]*deployConfig.Config{compose, swarm, automatic}, true)
+	if got := grouped[false]; len(got) != 1 || got[0] != compose {
+		t.Fatalf("compose group = %#v, want only explicit compose config", got)
+	}
+
+	if got := grouped[true]; len(got) != 2 || got[0] != swarm || got[1] != automatic {
+		t.Fatalf("swarm group = %#v, want explicit and automatic swarm configs", got)
+	}
+
+	unavailable := groupDeployConfigsByMode([]*deployConfig.Config{compose, swarm, automatic}, false)
+	if got := unavailable[false]; len(got) != 2 || got[0] != compose || got[1] != automatic {
+		t.Fatalf("unavailable swarm compose group = %#v, want explicit compose and automatic config", got)
+	}
+
+	if len(unavailable[true]) != 0 {
+		t.Fatalf("unavailable swarm group = %#v, want no valid swarm config", unavailable[true])
+	}
+}
+
 func TestDeploy(t *testing.T) {
 	encryption.SetupAgeKeyEnvVar(t)
 

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -37,6 +37,7 @@ const reconciliationSinceSafetySkew = 3 * time.Second
 type contextualEvent struct {
 	event       events.Message
 	contextName string
+	swarmMode   bool
 }
 
 // initContextCLIs populates j.contextCLIs with a Docker CLI entry for the default context
@@ -101,6 +102,10 @@ func (j *job) deployConfigsForContext(contextName string) []*deployConfig.Config
 	return filterConfigsByContext(j.info.deployConfigs, contextName)
 }
 
+func (j *job) deployConfigsForContextMode(contextName string, swarmMode bool) []*deployConfig.Config {
+	return filterConfigsByMode(j.deployConfigsForContext(contextName), j.swarmModeForContext(contextName), swarmMode)
+}
+
 func (j *job) run(ctx context.Context) {
 	jobLog := j.info.jobLog
 
@@ -132,19 +137,31 @@ func (j *job) run(ctx context.Context) {
 	var startupRecoveryWG sync.WaitGroup
 
 	for ctxName, entry := range j.contextCLIs {
-		startupRecoveryWG.Add(2)
+		for swarmMode, configs := range groupDeployConfigsByMode(j.deployConfigsForContext(ctxName), entry.swarmMode) {
+			if len(configs) == 0 {
+				continue
+			}
 
-		go func(ctxName string, entry contextCLIEntry) {
-			defer startupRecoveryWG.Done()
+			unhealthyConfigs := filterConfigsByMode(
+				getDeployConfigGroupByEvent(configs)["unhealthy"],
+				entry.swarmMode,
+				swarmMode,
+			)
 
-			j.restartUnhealthyContainersOnStartup(ctx, jobLog, ctxName, entry.cli, entry.swarmMode)
-		}(ctxName, entry)
+			startupRecoveryWG.Add(2)
 
-		go func(ctxName string, entry contextCLIEntry) {
-			defer startupRecoveryWG.Done()
+			go func(entry contextCLIEntry, swarmMode bool, unhealthyConfigs []*deployConfig.Config) {
+				defer startupRecoveryWG.Done()
 
-			j.redeployMissingServicesOnStartup(ctx, jobLog, ctxName, entry.cli, entry.swarmMode)
-		}(ctxName, entry)
+				j.restartUnhealthyContainersOnStartup(ctx, jobLog, entry.cli, swarmMode, unhealthyConfigs)
+			}(entry, swarmMode, unhealthyConfigs)
+
+			go func(ctxName string, entry contextCLIEntry, swarmMode bool, configs []*deployConfig.Config) {
+				defer startupRecoveryWG.Done()
+
+				j.redeployMissingServicesOnStartup(ctx, jobLog, ctxName, entry.cli, swarmMode, configs)
+			}(ctxName, entry, swarmMode, configs)
+		}
 	}
 
 	startupRecoveryWG.Wait()
@@ -156,19 +173,21 @@ func (j *job) run(ctx context.Context) {
 	expectedListeners := 0
 
 	for ctxName, entry := range j.contextCLIs {
-		if len(j.deployConfigsForContext(ctxName)) == 0 {
-			continue
+		for swarmMode, configs := range groupDeployConfigsByMode(j.deployConfigsForContext(ctxName), entry.swarmMode) {
+			if len(configs) == 0 {
+				continue
+			}
+
+			expectedListeners++
+
+			listenerWG.Add(1)
+
+			go func(ctxName string, entry contextCLIEntry, swarmMode bool, configs []*deployConfig.Config) {
+				defer listenerWG.Done()
+
+				j.runContextEventListener(ctx, jobLog, ctxName, entry, swarmMode, configs, mergedCh, listenerReadyCh)
+			}(ctxName, entry, swarmMode, configs)
 		}
-
-		expectedListeners++
-
-		listenerWG.Add(1)
-
-		go func(ctxName string, entry contextCLIEntry) {
-			defer listenerWG.Done()
-
-			j.runContextEventListener(ctx, jobLog, ctxName, entry, mergedCh, listenerReadyCh)
-		}(ctxName, entry)
 	}
 
 	if expectedListeners == 0 {
@@ -202,23 +221,19 @@ func (j *job) run(ctx context.Context) {
 				return
 			}
 
-			j.handleEvent(ctx, jobLog, ce.event, ce.contextName)
+			j.handleEvent(ctx, jobLog, ce.event, ce.contextName, ce.swarmMode)
 		}
 	}
 }
 
 // runContextEventListener connects to the Docker daemon for entry, listens for relevant events,
 // forwards them (tagged with contextName) to out, and automatically reconnects on disconnection.
-func (j *job) runContextEventListener(ctx context.Context, jobLog *slog.Logger, contextName string, entry contextCLIEntry, out chan<- contextualEvent, ready chan<- struct{}) {
+func (j *job) runContextEventListener(ctx context.Context, jobLog *slog.Logger, contextName string, entry contextCLIEntry, swarmMode bool, contextDCs []*deployConfig.Config, out chan<- contextualEvent, ready chan<- struct{}) {
 	repositoryLabelValue := gitInternal.GetFullName(j.info.repoData.SourceUrl)
 	if j.info.payload != nil && strings.TrimSpace(j.info.payload.FullName) != "" {
 		repositoryLabelValue = j.info.payload.FullName
 	}
 
-	swarmMode := entry.swarmMode
-
-	// Only listen for events for configs that target this context.
-	contextDCs := j.deployConfigsForContext(contextName)
 	contextGroupByEvent := getDeployConfigGroupByEvent(contextDCs)
 
 	if len(contextGroupByEvent) == 0 {
@@ -264,7 +279,7 @@ func (j *job) runContextEventListener(ctx context.Context, jobLog *slog.Logger, 
 			ready <- struct{}{}
 		}
 
-		reconnect, newestEventTime := j.forwardEvents(ctx, jobLog, eventResult.Messages, eventResult.Err, contextName, out)
+		reconnect, newestEventTime := j.forwardEvents(ctx, jobLog, eventResult.Messages, eventResult.Err, contextName, swarmMode, out)
 
 		if !newestEventTime.IsZero() {
 			nextCursor := newestEventTime.UTC().Add(-reconciliationSinceSafetySkew)
@@ -300,7 +315,7 @@ func (j *job) runContextEventListener(ctx context.Context, jobLog *slog.Logger, 
 
 // forwardEvents reads events from the Docker streaming API and sends them (tagged with contextName)
 // to out. Returns (reconnect bool, newestEventTime).
-func (j *job) forwardEvents(ctx context.Context, jobLog *slog.Logger, eventCh <-chan events.Message, errCh <-chan error, contextName string, out chan<- contextualEvent) (bool, time.Time) {
+func (j *job) forwardEvents(ctx context.Context, jobLog *slog.Logger, eventCh <-chan events.Message, errCh <-chan error, contextName string, swarmMode bool, out chan<- contextualEvent) (bool, time.Time) {
 	var newestEventTime time.Time
 
 	for {
@@ -338,7 +353,7 @@ func (j *job) forwardEvents(ctx context.Context, jobLog *slog.Logger, eventCh <-
 			}
 
 			select {
-			case out <- contextualEvent{event: event, contextName: contextName}:
+			case out <- contextualEvent{event: event, contextName: contextName, swarmMode: swarmMode}:
 			case <-ctx.Done():
 				return false, newestEventTime
 			case <-j.closeChan:
@@ -370,11 +385,11 @@ func dockerEventTime(event events.Message) time.Time {
 	return time.Time{}
 }
 
-func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events.Message, contextName string) {
+func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events.Message, contextName string, swarmMode bool) {
 	action := normalizeReconciliationEventAction(string(event.Action))
 	// Restrict candidates to the context the event originated from, since stack
 	// names are only guaranteed to be unique within a single Docker context.
-	dcs := filterConfigsByContext(j.deployConfigGroupByEvent[action], contextName)
+	dcs := filterConfigsByMode(filterConfigsByContext(j.deployConfigGroupByEvent[action], contextName), j.swarmModeForContext(contextName), swarmMode)
 
 	if len(dcs) == 0 {
 		return
@@ -419,7 +434,11 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 		return
 	}
 
-	if reconciliationHandler.isServiceSchedulerStopHeld(contextName, event.Actor.Attributes) {
+	// Scheduler stop holds are only registered for Compose-mode jobs, keyed by
+	// project/service. A Swarm service on the same context can carry matching
+	// labels, so restricting the check to Compose events avoids suppressing an
+	// unrelated Swarm event.
+	if !swarmMode && reconciliationHandler.isServiceSchedulerStopHeld(contextName, event.Actor.Attributes) {
 		jobLog.Debug("suppressing reconciliation event for service intentionally held stopped by job scheduler",
 			slog.String("event", action),
 			slog.String("stack", stackName),
@@ -460,7 +479,7 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 	defer stackLock.Unlock()
 
 	actorGroupName := "container"
-	if j.swarmModeForContext(contextName) {
+	if swarmMode {
 		actorGroupName = "service"
 	}
 
@@ -486,8 +505,6 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 	}
 
 	contextCLI := j.cliForContext(contextName)
-	contextSwarmMode := j.swarmModeForContext(contextName)
-
 	// For restart-oriented events the container is still present — restart it
 	// directly instead of going through a full redeploy pipeline.
 	if isRestartReconciliationAction(action) {
@@ -501,13 +518,13 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 			eventLog.Warn("multiple deploy configs matched restart event, using first match", slog.Int("deploy_config_count", len(stackDCs)))
 		}
 
-		restartResult := j.restartContainer(ctx, eventLog, event, restartDC, contextCLI, contextSwarmMode)
+		restartResult := j.restartContainer(ctx, eventLog, event, restartDC, contextCLI, swarmMode)
 		if restartResult.fallbackToDeploy {
 			if event.Actor.ID != "" {
 				waitForContainerRemovalSettled(ctx, eventLog, contextCLI.Client(), event.Actor.ID, containerRemovalSettleTimeout)
 			}
 
-			j.deploy(ctx, eventLog, stackDCs, action, event, traceID, contextName)
+			j.deploy(ctx, eventLog, stackDCs, action, event, traceID, contextName, swarmMode)
 		}
 
 		return
@@ -522,10 +539,10 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 		waitForContainerRemovalSettled(ctx, eventLog, contextCLI.Client(), event.Actor.ID, containerRemovalSettleTimeout)
 	}
 
-	j.deploy(ctx, eventLog, stackDCs, action, event, traceID, contextName)
+	j.deploy(ctx, eventLog, stackDCs, action, event, traceID, contextName, swarmMode)
 }
 
-func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConfig.Config, action string, event events.Message, traceID string, contextName string) {
+func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConfig.Config, action string, event events.Message, traceID string, contextName string, swarmMode bool) {
 	repoLock := lock.GetRepoLock(j.info.metadata.Repository)
 	repoLock.Lock()
 	defer repoLock.Unlock()
@@ -536,11 +553,10 @@ func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConf
 	// Use the context-specific CLI and only the deploy configs targeting this context
 	// for cleanup, so we inspect the correct remote daemon for obsolete containers.
 	contextCLI := j.cliForContext(contextName)
-	contextSwarmMode := j.swarmModeForContext(contextName)
-	contextDCs := j.deployConfigsForContext(contextName)
+	contextDCs := j.deployConfigsForContextMode(contextName, swarmMode)
 
 	if err := cleanupObsoleteAutoDiscoveredContainers(ctx, jobLog,
-		contextCLI, contextSwarmMode, contextName, j.info.repoData.SourceUrl,
+		contextCLI, swarmMode, contextName, j.info.repoData.SourceUrl,
 		contextDCs,
 		j.info.metadata); err != nil {
 		jobLog.Error("failed to clean up obsolete auto-discovered containers", logger.ErrAttr(err))
@@ -552,7 +568,7 @@ func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConf
 
 	// Enrich metadata with reconciliation event information for deploy notifications
 	actorKind := "container"
-	if contextSwarmMode {
+	if swarmMode {
 		actorKind = "service"
 	}
 

--- a/internal/reconciliation/reconciliation_startup.go
+++ b/internal/reconciliation/reconciliation_startup.go
@@ -21,10 +21,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/logger"
 )
 
-func (j *job) restartUnhealthyContainersOnStartup(ctx context.Context, jobLog *slog.Logger, contextName string, cli command.Cli, swarmMode bool) {
-	unhealthyAllDCs := j.deployConfigGroupByEvent["unhealthy"]
-
-	unhealthyDCs := filterConfigsByContext(unhealthyAllDCs, contextName)
+func (j *job) restartUnhealthyContainersOnStartup(ctx context.Context, jobLog *slog.Logger, cli command.Cli, swarmMode bool, unhealthyDCs []*deployConfig.Config) {
 	if len(unhealthyDCs) == 0 || swarmMode {
 		return
 	}
@@ -143,8 +140,8 @@ func uniqueRedeployDCsFromGroupByEvent(grouped map[string][]*deployConfig.Config
 // redeployMissingServicesOnStartup performs a one-time startup check for stacks whose
 // reconciliation is configured for redeploy-oriented events (e.g., "die", "destroy", "update")
 // and triggers a redeploy for any stacks that are completely missing their containers/services.
-func (j *job) redeployMissingServicesOnStartup(ctx context.Context, jobLog *slog.Logger, contextName string, cli command.Cli, swarmMode bool) {
-	allCandidates := uniqueRedeployDCsFromGroupByEvent(j.deployConfigGroupByEvent)
+func (j *job) redeployMissingServicesOnStartup(ctx context.Context, jobLog *slog.Logger, contextName string, cli command.Cli, swarmMode bool, modeConfigs []*deployConfig.Config) {
+	allCandidates := uniqueRedeployDCsFromGroupByEvent(getDeployConfigGroupByEvent(modeConfigs))
 
 	candidates := filterConfigsByContext(allCandidates, contextName)
 	if len(candidates) == 0 {
@@ -174,7 +171,7 @@ func (j *job) redeployMissingServicesOnStartup(ctx context.Context, jobLog *slog
 			),
 		)
 
-	j.deploy(ctx, eventLog, missingDCs, "startup_missing", events.Message{}, traceID, contextName)
+	j.deploy(ctx, eventLog, missingDCs, "startup_missing", events.Message{}, traceID, contextName, swarmMode)
 }
 
 // findMissingContainersOnStartup lists all running containers for this repository and returns
@@ -265,7 +262,24 @@ func filterConfigsByContext(dcs []*deployConfig.Config, contextName string) []*d
 	var result []*deployConfig.Config
 
 	for _, dc := range dcs {
-		if dc != nil && strings.TrimSpace(dc.Context) == contextName {
+		if dc != nil && docker.NormalizeContextName(dc.Context) == docker.NormalizeContextName(contextName) {
+			result = append(result, dc)
+		}
+	}
+
+	return result
+}
+
+func filterConfigsByMode(dcs []*deployConfig.Config, swarmAvailable, swarmMode bool) []*deployConfig.Config {
+	result := make([]*deployConfig.Config, 0, len(dcs))
+
+	for _, dc := range dcs {
+		if dc == nil {
+			continue
+		}
+
+		selected, err := dc.ResolveSwarmMode(swarmAvailable)
+		if err == nil && selected == swarmMode {
 			result = append(result, dc)
 		}
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -83,12 +83,11 @@ type scheduler struct {
 	// contextName is the normalized Docker context this worker operates on
 	// (empty string means the default context). See docker.NormalizeContextName.
 	contextName string
-	// swarmMode reflects the swarm mode of this worker's Docker context,
-	// resolved once via the context registry (or swarm.GetModeEnabled for the
-	// legacy single-context entry points). Using the per-context value instead
-	// of the process-global swarm.GetModeEnabled() lets each worker discover
-	// and schedule jobs correctly regardless of other contexts' modes.
-	swarmMode      bool
+	// mode is the runtime this worker manages jobs for. A Swarm manager hosts
+	// both Compose projects and Swarm stacks, so it runs one worker per mode
+	// instead of deriving behavior from the process-global
+	// swarm.GetModeEnabled().
+	mode           scheduledJobMode
 	secretProvider *secretprovider.SecretProvider
 	log            *slog.Logger
 	wg             *sync.WaitGroup
@@ -157,17 +156,25 @@ func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *syn
 		return
 	}
 
-	s := newScheduler(docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}, log, wg, secretProvider)
+	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
 
-	s.run(ctx)
+	mode := scheduledJobModeContainer
+	if cc.SwarmMode {
+		composeWorker := newSchedulerForMode(cc, scheduledJobModeContainer, log, wg, secretProvider)
+		graceful.SafeGo(wg, log, func() {
+			composeWorker.run(ctx)
+		})
+
+		mode = scheduledJobModeSwarm
+	}
+
+	newSchedulerForMode(cc, mode, log, wg, secretProvider).run(ctx)
 }
 
-// newScheduler builds a scheduler worker bound to a single Docker context, as
-// resolved by a docker.ContextRegistry (or synthesised for the legacy
-// single-context entry points Start/ListJobs/TriggerNow). log and wg may be
-// nil for short-lived, one-shot workers (e.g. a single ListJobs/TriggerNow
-// call) that never call run().
-func newScheduler(cc docker.ContextClient, log *slog.Logger, wg *sync.WaitGroup, secretProvider *secretprovider.SecretProvider) *scheduler {
+// newSchedulerForMode builds a scheduler worker bound to a single Docker
+// context and runtime mode. log and wg may be nil for short-lived, one-shot
+// workers (e.g. a single ListJobs/TriggerNow call) that never call run().
+func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *slog.Logger, wg *sync.WaitGroup, secretProvider *secretprovider.SecretProvider) *scheduler {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -177,7 +184,7 @@ func newScheduler(cc docker.ContextClient, log *slog.Logger, wg *sync.WaitGroup,
 	return &scheduler{
 		dockerCli:      cc.Cli,
 		contextName:    contextName,
-		swarmMode:      cc.SwarmMode,
+		mode:           mode,
 		secretProvider: secretProvider,
 		log:            log.With(slog.String("component", "scheduler"), slog.String("context", docker.DisplayContextName(contextName))),
 		wg:             wg,
@@ -195,9 +202,9 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 		return nil, errors.New("docker cli is required")
 	}
 
-	s := newScheduler(docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}, nil, nil, nil)
+	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
 
-	return s.listJobs(ctx, stackName)
+	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, nil, nil, stackName)
 }
 
 // listJobs returns all jobs discovered on this worker's Docker context,
@@ -302,9 +309,9 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 		return "", errors.New("docker cli is required")
 	}
 
-	s := newScheduler(docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}, log, nil, secretProvider)
+	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
 
-	return s.triggerNow(ctx, jobName, stackName)
+	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, log, jobName, stackName, secretProvider)
 }
 
 // triggerNow executes one configured scheduled job immediately on this
@@ -388,12 +395,10 @@ func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (
 // already running a worker are left untouched.
 const contextRefreshInterval = time.Minute
 
-// Manager runs one scheduler worker per Docker context known to a
-// docker.ContextRegistry and exposes context-aware ListJobs/TriggerNow for
-// REST wiring. It can be constructed even when automatic scheduling is
-// disabled: Start only needs to be called to run the background workers,
-// while ListJobs/TriggerNow work standalone (discovering jobs on demand) as
-// long as the registry can resolve the requested context.
+// Manager runs one Compose worker for every Docker context and, when a context
+// is a Swarm manager, an additional Swarm worker. It exposes context-aware
+// ListJobs/TriggerNow for REST wiring and can be constructed even when
+// automatic scheduling is disabled.
 type Manager struct {
 	registry       *docker.ContextRegistry
 	log            *slog.Logger
@@ -401,12 +406,12 @@ type Manager struct {
 	secretProvider *secretprovider.SecretProvider
 
 	mu      sync.Mutex
-	workers map[string]managedWorker // key = normalized context name
+	workers map[string]managedWorker // key = normalized context name + runtime mode
 }
 
 type managedWorker struct {
-	cancel    context.CancelFunc
-	swarmMode bool
+	cancel context.CancelFunc
+	mode   scheduledJobMode
 }
 
 // NewManager creates a scheduler Manager bound to registry. log and wg are
@@ -426,11 +431,9 @@ func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.Wai
 	}
 }
 
-// Start launches one background scheduler worker per Docker context currently
-// known to the registry, and periodically re-lists the registry to start
-// workers for any contexts that become available later. Contexts that fail to
-// resolve (e.g. an unreachable remote daemon) are logged and skipped without
-// affecting already-running workers for other contexts.
+// Start launches the required worker(s) for every Docker context currently
+// known to the registry, and periodically re-lists the registry to discover
+// new contexts.
 func (m *Manager) Start(ctx context.Context) {
 	if m == nil || m.registry == nil || m.wg == nil {
 		return
@@ -454,8 +457,8 @@ func (m *Manager) Start(ctx context.Context) {
 }
 
 // refreshWorkers reconciles scheduler workers with the current context list.
-// Unavailable contexts do not disturb existing workers, while removed contexts
-// are stopped and swarm-mode changes restart only the affected worker.
+// Unavailable contexts do not disturb existing workers; a changed capability
+// adds/removes only the Swarm worker while keeping the Compose worker alive.
 func (m *Manager) refreshWorkers(ctx context.Context) {
 	results, err := m.registry.List(ctx)
 	if err != nil {
@@ -466,15 +469,16 @@ func (m *Manager) refreshWorkers(ctx context.Context) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	available := make(map[string]struct{}, len(results))
+	available := make(map[string]struct{}, len(results)*2)
 	for _, result := range results {
 		name := docker.NormalizeContextName(result.Name)
-		available[name] = struct{}{}
-
-		running, hasWorker := m.workers[name]
 		if result.Err != nil {
-			if hasWorker {
-				continue
+			// Keep already-running workers alive while a transient context probe
+			// fails; only an actually removed context should stop them.
+			for key := range m.workers {
+				if workerContextFromKey(key) == name {
+					available[key] = struct{}{}
+				}
 			}
 
 			m.log.Warn("skipping unavailable docker context for scheduler",
@@ -485,40 +489,35 @@ func (m *Manager) refreshWorkers(ctx context.Context) {
 			continue
 		}
 
-		if hasWorker && running.swarmMode == result.SwarmMode {
-			continue
-		}
+		for _, mode := range schedulerModes(result.SwarmMode) {
+			key := schedulerWorkerKey(name, mode)
 
-		if hasWorker {
-			running.cancel()
-			delete(m.workers, name)
-			m.log.Info("restarting scheduler worker after Docker swarm mode changed",
-				slog.String("context", docker.DisplayContextName(name)),
-			)
-		}
+			available[key] = struct{}{}
+			if _, hasWorker := m.workers[key]; hasWorker {
+				continue
+			}
 
-		worker := newScheduler(result.ContextClient, m.log, m.wg, m.secretProvider)
-		workerCtx, cancel := context.WithCancel(ctx)
-		m.workers[name] = managedWorker{
-			cancel:    cancel,
-			swarmMode: result.SwarmMode,
-		}
+			worker := newSchedulerForMode(result.ContextClient, mode, m.log, m.wg, m.secretProvider)
+			workerCtx, cancel := context.WithCancel(ctx)
+			m.workers[key] = managedWorker{cancel: cancel, mode: mode}
 
-		graceful.SafeGo(m.wg, m.log, func() {
-			worker.run(workerCtx)
-		})
+			graceful.SafeGo(m.wg, m.log, func() {
+				worker.run(workerCtx)
+			})
+		}
 	}
 
-	for name, worker := range m.workers {
-		if _, ok := available[name]; ok {
+	for key, worker := range m.workers {
+		if _, ok := available[key]; ok {
 			continue
 		}
 
 		worker.cancel()
-		delete(m.workers, name)
-		clearRuntimeContext(name)
-		m.log.Info("stopped scheduler worker for removed Docker context",
-			slog.String("context", docker.DisplayContextName(name)),
+		delete(m.workers, key)
+		clearRuntimeContextMode(workerContextFromKey(key), worker.mode)
+		m.log.Info("stopped scheduler worker",
+			slog.String("context", docker.DisplayContextName(workerContextFromKey(key))),
+			slog.String("mode", string(worker.mode)),
 		)
 	}
 }
@@ -536,7 +535,7 @@ func (m *Manager) ListJobs(ctx context.Context, contextName, stackName string) (
 		return nil, fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
 	}
 
-	return newScheduler(cc, m.log, nil, m.secretProvider).listJobs(ctx, stackName)
+	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, m.secretProvider, stackName)
 }
 
 // TriggerNow executes one configured scheduled job immediately on the given
@@ -552,7 +551,71 @@ func (m *Manager) TriggerNow(ctx context.Context, contextName, jobName, stackNam
 		return "", fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
 	}
 
-	return newScheduler(cc, m.log, nil, secretProvider).triggerNow(ctx, jobName, stackName)
+	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, jobName, stackName, secretProvider)
+}
+
+func schedulerModes(swarmAvailable bool) []scheduledJobMode {
+	modes := []scheduledJobMode{scheduledJobModeContainer}
+	if swarmAvailable {
+		modes = append(modes, scheduledJobModeSwarm)
+	}
+
+	return modes
+}
+
+func schedulerWorkerKey(contextName string, mode scheduledJobMode) string {
+	return docker.NormalizeContextName(contextName) + "\x00" + string(mode)
+}
+
+func workerContextFromKey(key string) string {
+	contextName, _, _ := strings.Cut(key, "\x00")
+	return contextName
+}
+
+func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, secretProvider *secretprovider.SecretProvider, stackName string) ([]JobInfo, error) {
+	var result []JobInfo
+
+	for _, mode := range modes {
+		jobs, err := newSchedulerForMode(cc, mode, log, nil, secretProvider).listJobs(ctx, stackName)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, jobs...)
+	}
+
+	return result, nil
+}
+
+func triggerNowForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, jobName, stackName string, secretProvider *secretprovider.SecretProvider) (string, error) {
+	workers := make(map[scheduledJobMode]*scheduler, len(modes))
+
+	var jobs []scheduledJob
+
+	for _, mode := range modes {
+		worker := newSchedulerForMode(cc, mode, log, nil, secretProvider)
+
+		discovered, err := worker.discoverJobs(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to discover scheduled jobs: %w", err)
+		}
+
+		workers[mode] = worker
+
+		jobs = append(jobs, discovered...)
+	}
+
+	job, _, err := findRunnableJob(jobs, strings.TrimSpace(jobName), strings.TrimSpace(stackName))
+	if err != nil {
+		return "", err
+	}
+
+	worker, ok := workers[job.mode]
+	if !ok {
+		return "", fmt.Errorf("%w: %s", ErrScheduledJobNotFound, jobName)
+	}
+
+	return worker.triggerNow(ctx, jobName, stackName)
 }
 
 func findRunnableJob(jobs []scheduledJob, jobName, stackName string) (scheduledJob, docker.JobScheduleConfig, error) {
@@ -744,7 +807,7 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 		nearestNextRun, _ = getNearestNextRun(s.states)
 	}
 
-	setRuntimeStatesSnapshot(s.contextName, s.states)
+	setRuntimeStatesSnapshotForMode(s.contextName, s.mode, s.states)
 
 	return nearestNextRun, !nearestNextRun.IsZero()
 }
@@ -757,7 +820,7 @@ func (s *scheduler) watchJobChanges(ctx context.Context) <-chan struct{} {
 
 		for ctx.Err() == nil {
 			filters := make(client.Filters)
-			if s.swarmMode {
+			if s.mode == scheduledJobModeSwarm {
 				filters.Add("type", "service")
 
 				for _, action := range []string{"create", "update", "remove"} {
@@ -822,7 +885,7 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 		return nil, nil
 	}
 
-	if s.swarmMode {
+	if s.mode == scheduledJobModeSwarm {
 		services, err := s.dockerCli.Client().ServiceList(ctx, client.ServiceListOptions{})
 		if err != nil {
 			return nil, err
@@ -862,6 +925,13 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 	runningEphemeralByKey := make(map[string]bool)
 
 	for _, c := range containers.Items {
+		// A Swarm task is represented as a container too. On a Swarm manager it
+		// is handled by the Swarm worker through its parent service, never by the
+		// Compose worker.
+		if _, isSwarmTask := c.Labels["com.docker.swarm.service.name"]; isSwarmTask {
+			continue
+		}
+
 		key := jobKeyPrefix(s.contextName) + containerJobKey(c.ID, c.Labels)
 
 		// One_off runs execute in an ephemeral clone of the source container that
@@ -1786,12 +1856,16 @@ func schedulerNow() time.Time {
 // setRuntimeStatesSnapshot replaces one context's states while preserving all
 // other context partitions and newer manual-run timestamps.
 func setRuntimeStatesSnapshot(contextName string, states map[string]scheduledJobState) {
+	setRuntimeStatesSnapshotForMode(contextName, "", states)
+}
+
+func setRuntimeStatesSnapshotForMode(contextName string, mode scheduledJobMode, states map[string]scheduledJobState) {
 	runtimeStatesMu.Lock()
 	defer runtimeStatesMu.Unlock()
 
 	merged := make(map[string]scheduledJobState, len(runtimeStates)+len(states))
 	for key, state := range runtimeStates {
-		if !runtimeKeyInContext(contextName, key) {
+		if !runtimeKeyInContextMode(contextName, mode, key) {
 			merged[key] = state
 		}
 	}
@@ -1815,24 +1889,42 @@ func runtimeKeyInContext(contextName, key string) bool {
 	return strings.HasPrefix(key, jobKeyPrefix(contextName))
 }
 
+func runtimeKeyInContextMode(contextName string, mode scheduledJobMode, key string) bool {
+	if !runtimeKeyInContext(contextName, key) {
+		return false
+	}
+
+	if mode == "" {
+		return true
+	}
+
+	key = strings.TrimPrefix(key, jobKeyPrefix(contextName))
+
+	return strings.HasPrefix(key, string(mode)+":")
+}
+
 func clearRuntimeContext(contextName string) {
+	clearRuntimeContextMode(contextName, "")
+}
+
+func clearRuntimeContextMode(contextName string, mode scheduledJobMode) {
 	runtimeStatesMu.Lock()
 	defer runtimeStatesMu.Unlock()
 
 	for key := range runtimeStates {
-		if runtimeKeyInContext(contextName, key) {
+		if runtimeKeyInContextMode(contextName, mode, key) {
 			delete(runtimeStates, key)
 		}
 	}
 
 	for key := range runtimeRunStatuses {
-		if runtimeKeyInContext(contextName, key) {
+		if runtimeKeyInContextMode(contextName, mode, key) {
 			delete(runtimeRunStatuses, key)
 		}
 	}
 
 	for key := range runtimeRunningStates {
-		if runtimeKeyInContext(contextName, key) {
+		if runtimeKeyInContextMode(contextName, mode, key) {
 			delete(runtimeRunningStates, key)
 		}
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -33,6 +33,18 @@ func TestNextScheduledRun_PreservesScheduleAlignment(t *testing.T) {
 	}
 }
 
+func TestSchedulerModes(t *testing.T) {
+	t.Parallel()
+
+	if got := schedulerModes(false); !slices.Equal(got, []scheduledJobMode{scheduledJobModeContainer}) {
+		t.Fatalf("schedulerModes(false) = %v, want compose only", got)
+	}
+
+	if got := schedulerModes(true); !slices.Equal(got, []scheduledJobMode{scheduledJobModeContainer, scheduledJobModeSwarm}) {
+		t.Fatalf("schedulerModes(true) = %v, want compose and swarm", got)
+	}
+}
+
 func TestNextScheduledRun_SkipsMissedRunsWithoutDrift(t *testing.T) {
 	t.Parallel()
 
@@ -853,24 +865,24 @@ func TestJobInfo_ContextField(t *testing.T) {
 	}
 }
 
-func TestNewScheduler_NormalizesContextAndCarriesSwarmMode(t *testing.T) {
+func TestNewSchedulerForMode_NormalizesContextAndCarriesMode(t *testing.T) {
 	t.Parallel()
 
-	s := newScheduler(docker.ContextClient{Name: "Default", SwarmMode: true}, nil, nil, nil)
+	s := newSchedulerForMode(docker.ContextClient{Name: "Default", SwarmMode: true}, scheduledJobModeSwarm, nil, nil, nil)
 	if s.contextName != "" {
-		t.Fatalf("newScheduler() contextName = %q, want empty string for the default context", s.contextName)
+		t.Fatalf("newSchedulerForMode() contextName = %q, want empty string for the default context", s.contextName)
 	}
 
-	if !s.swarmMode {
-		t.Fatal("newScheduler() did not carry through SwarmMode=true from the context client")
+	if s.mode != scheduledJobModeSwarm {
+		t.Fatalf("newSchedulerForMode() mode = %q, want %q", s.mode, scheduledJobModeSwarm)
 	}
 
-	remote := newScheduler(docker.ContextClient{Name: "remote", SwarmMode: false}, nil, nil, nil)
+	remote := newSchedulerForMode(docker.ContextClient{Name: "remote", SwarmMode: false}, scheduledJobModeContainer, nil, nil, nil)
 	if remote.contextName != "remote" {
-		t.Fatalf("newScheduler() contextName = %q, want %q", remote.contextName, "remote")
+		t.Fatalf("newSchedulerForMode() contextName = %q, want %q", remote.contextName, "remote")
 	}
 
-	if remote.swarmMode {
-		t.Fatal("newScheduler() reported swarmMode=true, want false")
+	if remote.mode != scheduledJobModeContainer {
+		t.Fatalf("newSchedulerForMode() mode = %q, want %q", remote.mode, scheduledJobModeContainer)
 	}
 }

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -157,7 +157,17 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 		source = s.Payload.FullName
 	}
 
-	if err := docker.MigrateDeploymentMode(ctx, stageLog, s.Docker.Cmd, s.DeployConfig.Context, s.DeployConfig.Name, source, s.Docker.SwarmMode, s.Docker.SwarmAvailable); err != nil {
+	deploymentModeMigrated, err := docker.MigrateDeploymentMode(
+		ctx,
+		stageLog,
+		s.Docker.Cmd,
+		s.DeployConfig.Context,
+		s.DeployConfig.Name,
+		source,
+		s.Docker.SwarmMode,
+		s.Docker.SwarmAvailable,
+	)
+	if err != nil {
 		return fmt.Errorf("failed to migrate deployment mode: %w", err)
 	}
 
@@ -203,7 +213,10 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 		deployedDigest := deployedState.GetDeploymentCommitSHA()
 		resolvedDigest := s.Repository.Revision
 
-		if shouldSkipOCIDeployment(s.DeployConfig.ForceRecreate, deployedDigest, resolvedDigest) && !autoDiscoveryConfigChanged && !retryAfterFailure {
+		if !deploymentModeMigrated &&
+			shouldSkipOCIDeployment(s.DeployConfig.ForceRecreate, deployedDigest, resolvedDigest) &&
+			!autoDiscoveryConfigChanged &&
+			!retryAfterFailure {
 			stageLog.Debug("OCI artifact digest unchanged, skipping deployment",
 				slog.String("deployed_digest", strings.TrimSpace(deployedDigest)),
 				slog.String("resolved_digest", strings.TrimSpace(resolvedDigest)),
@@ -371,7 +384,8 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 			stageLog.Debug("force recreate enabled, proceeding with deployment",
 				slog.String("directory", s.DeployConfig.WorkingDirectory),
 			)
-		} else if shouldSkipDeployment(retryAfterFailure, composeChanged, autoDiscoveryConfigChanged, changedServices, ignoredInfo, imagesChanged, mismatchServices) {
+		} else if !deploymentModeMigrated &&
+			shouldSkipDeployment(retryAfterFailure, composeChanged, autoDiscoveryConfigChanged, changedServices, ignoredInfo, imagesChanged, mismatchServices) {
 			stageLog.Debug("no changes detected, skipping deployment",
 				slog.String("directory", s.DeployConfig.WorkingDirectory),
 			)

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -149,6 +149,18 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 		return fmt.Errorf("failed to hash deploy configuration: %w", err)
 	}
 
+	// Init has resolved the repository/payload identity by this point. Migrate
+	// before any skip detection, otherwise an unchanged source could leave the
+	// previous runtime mode alive indefinitely.
+	source := s.Repository.SourceUrl
+	if s.Payload != nil && strings.TrimSpace(s.Payload.FullName) != "" {
+		source = s.Payload.FullName
+	}
+
+	if err := docker.MigrateDeploymentMode(ctx, stageLog, s.Docker.Cmd, s.DeployConfig.Context, s.DeployConfig.Name, source, s.Docker.SwarmMode, s.Docker.SwarmAvailable); err != nil {
+		return fmt.Errorf("failed to migrate deployment mode: %w", err)
+	}
+
 	deployedState, err := docker.GetLatestDeployStatus(ctx, s.Docker.Cmd.Client(), s.Docker.SwarmMode, s.Repository.Name, s.DeployConfig.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get latest state from deployed services: %w", err)

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -138,6 +138,7 @@ type Docker struct {
 	DataMountPoint container.MountPoint
 	Project        *types.Project
 	SwarmMode      bool
+	SwarmAvailable bool
 }
 
 // DeploymentState holds the dynamic state information during the deployment process.

--- a/test/e2e/deployment_mode_migration_test.go
+++ b/test/e2e/deployment_mode_migration_test.go
@@ -95,6 +95,7 @@ func testDeploymentModeMigration(t *testing.T, scenario, stackName, volumeName s
 		return targetContainerID() != "" && sourceContainerID() == ""
 	})
 	waitForSuccessfulMigration(h, logOffset)
+	waitForScheduledJob(h, logOffset, targetSchedulerMode(sourceSwarm))
 	assertMigrationMarker(t, h, targetContainerID(), marker)
 }
 
@@ -116,6 +117,34 @@ func waitForSuccessfulMigration(h *Harness, logOffset int) {
 
 		return strings.Contains(logs[migrationIndex:], `"msg":"job completed successfully"`)
 	})
+}
+
+func waitForScheduledJob(h *Harness, logOffset int, mode string) {
+	h.t.Helper()
+
+	h.WaitFor(2*time.Minute, "scheduled job registered in "+mode+" mode", func() bool {
+		logs := h.daemonLogs()
+		if len(logs) < logOffset {
+			return false
+		}
+
+		for _, line := range strings.Split(logs[logOffset:], "\n") {
+			if strings.Contains(line, `"msg":"job scheduled"`) &&
+				strings.Contains(line, `"mode":"`+mode+`"`) {
+				return true
+			}
+		}
+
+		return false
+	})
+}
+
+func targetSchedulerMode(sourceSwarm bool) string {
+	if sourceSwarm {
+		return "container"
+	}
+
+	return "swarm"
 }
 
 func assertMigrationMarker(t *testing.T, h *Harness, containerID, want string) {

--- a/test/e2e/deployment_mode_migration_test.go
+++ b/test/e2e/deployment_mode_migration_test.go
@@ -1,0 +1,132 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	internalDocker "github.com/kimdre/doco-cd/internal/docker"
+)
+
+func TestDeploymentModeMigration(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		scenario    string
+		stackName   string
+		volumeName  string
+		sourceSwarm bool
+	}{
+		{
+			name:       "compose_to_swarm",
+			scenario:   "deployment-mode-migration",
+			stackName:  "e2e-deployment-mode-migration",
+			volumeName: "e2e-deployment-mode-migration-data",
+		},
+		{
+			name:        "swarm_to_compose",
+			scenario:    "deployment-mode-migration-swarm",
+			stackName:   "e2e-deployment-mode-migration-swarm",
+			volumeName:  "e2e-deployment-mode-migration-swarm-data",
+			sourceSwarm: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testDeploymentModeMigration(t, tc.scenario, tc.stackName, tc.volumeName, tc.sourceSwarm)
+		})
+	}
+}
+
+func testDeploymentModeMigration(t *testing.T, scenario, stackName, volumeName string, sourceSwarm bool) {
+	t.Helper()
+
+	const (
+		serviceName = "app"
+		marker      = "migration-data"
+	)
+
+	h := NewHarness(t, scenario)
+	if !h.isSwarmMode() {
+		t.Skip("deployment mode migration requires a Swarm manager")
+	}
+
+	h.TrackVolume(volumeName)
+	h.Start()
+
+	sourceContainerID := func() string {
+		if sourceSwarm {
+			return h.SwarmContainerID(stackName, serviceName)
+		}
+
+		return h.ComposeContainerID(stackName, serviceName)
+	}
+	targetContainerID := func() string {
+		if sourceSwarm {
+			return h.ComposeContainerID(stackName, serviceName)
+		}
+
+		return h.SwarmContainerID(stackName, serviceName)
+	}
+
+	h.WaitFor(2*time.Minute, "initial deployment", func() bool {
+		return sourceContainerID() != ""
+	})
+
+	if _, err := internalDocker.ExecContext(h.ctx, h.docker, sourceContainerID(),
+		"sh", "-c", "printf "+marker+" >/data/marker"); err != nil {
+		t.Fatalf("write source volume marker: %v", err)
+	}
+
+	logOffset := len(h.daemonLogs())
+	if sourceSwarm {
+		h.ReplaceInWorktree(".doco-cd.yml", "enabled: true", "enabled: false")
+	} else {
+		h.ReplaceInWorktree(".doco-cd.yml", "enabled: false", "enabled: true")
+	}
+
+	h.RepoPush("change deployment mode")
+
+	h.WaitFor(2*time.Minute, "deployment mode migration", func() bool {
+		return targetContainerID() != "" && sourceContainerID() == ""
+	})
+	waitForSuccessfulMigration(h, logOffset)
+	assertMigrationMarker(t, h, targetContainerID(), marker)
+}
+
+func waitForSuccessfulMigration(h *Harness, logOffset int) {
+	h.t.Helper()
+
+	h.WaitFor(2*time.Minute, "migration deployment completed", func() bool {
+		logs := h.daemonLogs()
+		if len(logs) < logOffset {
+			return false
+		}
+
+		logs = logs[logOffset:]
+
+		migrationIndex := strings.Index(logs, `"msg":"removing previous deployment mode before migration"`)
+		if migrationIndex < 0 {
+			return false
+		}
+
+		return strings.Contains(logs[migrationIndex:], `"msg":"job completed successfully"`)
+	})
+}
+
+func assertMigrationMarker(t *testing.T, h *Harness, containerID, want string) {
+	t.Helper()
+
+	output, err := internalDocker.ExecContext(h.ctx, h.docker, containerID, "cat", "/data/marker")
+	if err != nil {
+		t.Fatalf("read migration volume marker: %v", err)
+	}
+
+	if got := strings.TrimSpace(output); got != want {
+		t.Fatalf("migration volume marker = %q, want %q", got, want)
+	}
+}

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -45,6 +45,7 @@ type Harness struct {
 	repoPath   string // bare repo dir the gitserver container mounts read-only
 	worktree   string // host worktree dir used to build fixture/commits
 	dataVolume string
+	volumes    []string
 
 	wt     *git.Worktree
 	docker *client.Client
@@ -96,13 +97,13 @@ func NewHarness(t *testing.T, scenario string) *Harness {
 	h.repoPath = filepath.Join(h.workDir, "repos", scenario+".git")
 	h.worktree = filepath.Join(h.workDir, "src", scenario)
 
-	t.Cleanup(h.logFailure)
-
 	if keepAlive {
 		registerSuiteHarness(h)
 	} else {
 		t.Cleanup(h.teardown)
 	}
+
+	t.Cleanup(h.logFailure)
 
 	return h
 }
@@ -112,6 +113,12 @@ func NewHarness(t *testing.T, scenario string) *Harness {
 func (h *Harness) EnableRemoteContext() {
 	h.t.Helper()
 	h.remoteContext = true
+}
+
+// TrackVolume registers a scenario-owned named volume for teardown.
+func (h *Harness) TrackVolume(name string) {
+	h.t.Helper()
+	h.volumes = append(h.volumes, name)
 }
 
 // Start creates the initial fixture commit, builds and starts the gitserver
@@ -489,6 +496,12 @@ func (h *Harness) teardownInternal() {
 		}
 
 		h.cleanupStacks()
+
+		for _, volume := range h.volumes {
+			if _, err := h.docker.VolumeRemove(h.ctx, volume, client.VolumeRemoveOptions{Force: true}); err != nil {
+				h.logf("remove named volume %s: %v", volume, err)
+			}
+		}
 
 		if h.remoteDocker != nil {
 			_ = h.remoteDocker.Close()

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -192,6 +192,21 @@ func (h *Harness) ContainerID(project, service string) string {
 	return h.containerID(h.docker, h.isSwarmMode(), project, service)
 }
 
+// ComposeContainerID returns the running Compose container for a deployment
+// that explicitly selected Compose mode on a Swarm-capable Docker daemon.
+func (h *Harness) ComposeContainerID(project, service string) string {
+	h.t.Helper()
+
+	return h.containerID(h.docker, false, project, service)
+}
+
+// SwarmContainerID returns the running Swarm task container for a deployment.
+func (h *Harness) SwarmContainerID(project, service string) string {
+	h.t.Helper()
+
+	return h.containerID(h.docker, true, project, service)
+}
+
 // RemoteContainerID returns a Compose container from the disposable remote
 // Docker context enabled with EnableRemoteContext.
 func (h *Harness) RemoteContainerID(project, service string) string {

--- a/test/e2e/scenarios/deployment-mode-migration-swarm/fixture/.doco-cd.yml
+++ b/test/e2e/scenarios/deployment-mode-migration-swarm/fixture/.doco-cd.yml
@@ -1,0 +1,4 @@
+name: e2e-deployment-mode-migration-swarm
+working_dir: deploy
+swarm:
+  enabled: true

--- a/test/e2e/scenarios/deployment-mode-migration-swarm/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/deployment-mode-migration-swarm/fixture/deploy/compose.yaml
@@ -4,6 +4,12 @@ services:
     command: ["sleep", "600"]
     volumes:
       - data:/data
+  scheduled:
+    image: alpine:3.22
+    command: ["true"]
+    labels:
+      cd.doco.job.enabled: "true"
+      cd.doco.job.schedule: "@every 24h"
 
 volumes:
   data:

--- a/test/e2e/scenarios/deployment-mode-migration-swarm/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/deployment-mode-migration-swarm/fixture/deploy/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  app:
+    image: alpine:3.22
+    command: ["sleep", "600"]
+    volumes:
+      - data:/data
+
+volumes:
+  data:
+    name: e2e-deployment-mode-migration-swarm-data

--- a/test/e2e/scenarios/deployment-mode-migration/fixture/.doco-cd.yml
+++ b/test/e2e/scenarios/deployment-mode-migration/fixture/.doco-cd.yml
@@ -1,0 +1,4 @@
+name: e2e-deployment-mode-migration
+working_dir: deploy
+swarm:
+  enabled: false

--- a/test/e2e/scenarios/deployment-mode-migration/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/deployment-mode-migration/fixture/deploy/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  app:
+    image: alpine:3.22
+    command: ["sleep", "600"]
+    volumes:
+      - data:/data
+
+volumes:
+  data:
+    name: e2e-deployment-mode-migration-data

--- a/test/e2e/scenarios/deployment-mode-migration/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/deployment-mode-migration/fixture/deploy/compose.yaml
@@ -4,6 +4,12 @@ services:
     command: ["sleep", "600"]
     volumes:
       - data:/data
+  scheduled:
+    image: alpine:3.22
+    command: ["true"]
+    labels:
+      cd.doco.job.enabled: "true"
+      cd.doco.job.schedule: "@every 24h"
 
 volumes:
   data:

--- a/wiki/docs/Advanced/Swarm-Mode.md
+++ b/wiki/docs/Advanced/Swarm-Mode.md
@@ -8,9 +8,12 @@ tags:
 Doco-CD also supports [Docker Swarm mode](https://docs.docker.com/engine/swarm/), which allows you to manage a cluster of Docker engines as a single virtual engine. 
 This is useful for deploying applications across multiple nodes and ensuring high availability.
 
-If the Docker daemon is running in Swarm mode, doco-cd will detect this automatically and deploy everything as Swarm stacks instead of simple Compose projects.
+If the Docker daemon is running in Swarm mode, doco-cd will detect this automatically and deploy deployments as Swarm stacks instead of simple Compose projects.
 
-You can overwrite this to always deploy as Compose projects while running doco-cd in a Swarm environment by setting the `DOCKER_SWARM_FEATURES` environment variable to `false` (See the [Docker Settings](../Docker-Settings.md)).
+Set `swarm.enabled` in an individual deployment configuration to override this selection: `true` deploys a Swarm stack and `false` deploys a Compose project.
+This lets both deployment types run through one doco-cd instance on the same Swarm manager. If omitted, auto-detection is used.
+
+You can overwrite this globally to always deploy as Compose projects while running doco-cd in a Swarm environment by setting the `DOCKER_SWARM_FEATURES` environment variable to `false` (See the [Docker Settings](../Docker-Settings.md)).
 
 The deployment happens the same way as with Docker Compose projects, see the [Deploy Settings](../Deploy-Settings.md)
 

--- a/wiki/docs/Deploy-Settings.md
+++ b/wiki/docs/Deploy-Settings.md
@@ -615,10 +615,22 @@ Precedence:
 
 The following settings can be configured in the nested `swarm` object:
 
-| Key                | Type   | Description                                                                                                                                                                                         | Default value     |
-|--------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------|
-| `config_retention` | number | Number of old Swarm config revisions to keep per resource (excluding the active revision). `-1` disables automatic pruning. If unset, global [`DOCKER_SWARM_CONFIG_RETENTION`](Docker-Settings.md#swarm-environment-variables) is used. | unset (use global) |
-| `secret_retention` | number | Number of old Swarm secret revisions to keep per resource (excluding the active revision). `-1` disables automatic pruning. If unset, global [`DOCKER_SWARM_SECRET_RETENTION`](Docker-Settings.md#swarm-environment-variables) is used. | unset (use global) |
+| Key                | Type    | Description                                                                                                                                                                                                                                                                             | Default value       |
+|--------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| `enabled`          | boolean | `true` deploys a Docker Swarm stack. `false` deploys a Docker Compose project. When omitted, the Docker context determines the mode. An explicit `true` fails if the context is not a Swarm manager or [`DOCKER_SWARM_FEATURES=false`](Docker-Settings.md#swarm-environment-variables). | unset (auto-detect) |
+| `config_retention` | number  | Number of old Swarm config revisions to keep per resource (excluding the active revision). `-1` disables automatic pruning. If unset, global [`DOCKER_SWARM_CONFIG_RETENTION`](Docker-Settings.md#swarm-environment-variables) is used.                                                 | unset (use global)  |
+| `secret_retention` | number  | Number of old Swarm secret revisions to keep per resource (excluding the active revision). `-1` disables automatic pruning. If unset, global [`DOCKER_SWARM_SECRET_RETENTION`](Docker-Settings.md#swarm-environment-variables) is used.                                                 | unset (use global)  |
+
+Use `swarm.enabled` to select the deployment type for one stack:
+
+```yaml title=".doco-cd.yml"
+name: netbird
+swarm:
+  enabled: false
+```
+
+When the value of `enabled` changes for a doco-cd-managed deployment, doco-cd removes the previous-mode project or stack before deploying the new mode.
+Its volumes are retained during this migration.
 
 #### Keep old Swarm configs/secrets
 

--- a/wiki/docs/Docker-Settings.md
+++ b/wiki/docs/Docker-Settings.md
@@ -28,9 +28,9 @@ Most users can leave them at the defaults, and you can set them with [environmen
 
 These settings are specific to Docker Swarm mode behavior in Doco-CD.
 
-| Key                             | Type    | Description                                                                                                                                                                                                   | Default value |
-|---------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `DOCKER_SWARM_FEATURES`         | boolean | Enable the use Docker Swarm Mode features if the app has detected that it is running in a Docker Swarm environment                                                                                            | `true`        |
+| Key                             | Type    | Description                                                                                                                                                                                                                                          | Default value |
+|---------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `DOCKER_SWARM_FEATURES`         | boolean | Enable the use Docker Swarm Mode features if the app has detected that it is running in a Docker Swarm environment                                                                                                                                   | `true`        |
 | `DOCKER_SWARM_CONFIG_RETENTION` | number  | Global default number of old Swarm config revisions to keep per resource (excluding the active revision). Use `-1` to disable automatic pruning. Can be overridden per deployment via [`swarm.config_retention`](Deploy-Settings.md#swarm-settings). | `0`           |
 | `DOCKER_SWARM_SECRET_RETENTION` | number  | Global default number of old Swarm secret revisions to keep per resource (excluding the active revision). Use `-1` to disable automatic pruning. Can be overridden per deployment via [`swarm.secret_retention`](Deploy-Settings.md#swarm-settings). | `0`           |
 


### PR DESCRIPTION
Closes #1759

## Summary
- add `swarm.enabled` for per-deployment Compose or Swarm selection
- migrate doco-cd-managed stacks between modes while retaining volumes
- support mixed Compose and Swarm reconciliation, scheduling, and certificate rotation on Swarm managers
- document selection, global disable behavior, and migration

## Validation
- `golangci-lint run ./...`
- focused configuration, scheduler, certificate rotation, reconciliation, stages, and Docker migration tests