### PR TITLE
fix(api): use snake case for compose responses

### DIFF
--- a/cmd/doco-cd/api_response.go
+++ b/cmd/doco-cd/api_response.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/moby/moby/api/types/container"
+)
+
+type projectResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	ConfigFiles string `json:"config_files"`
+	Reason      string `json:"reason"`
+}
+
+type portPublisherResponse struct {
+	URL           string `json:"url"`
+	TargetPort    int    `json:"target_port"`
+	PublishedPort int    `json:"published_port"`
+	Protocol      string `json:"protocol"`
+}
+
+type containerResponse struct {
+	ID           string                   `json:"id"`
+	Name         string                   `json:"name"`
+	Names        []string                 `json:"names"`
+	Image        string                   `json:"image"`
+	Command      string                   `json:"command"`
+	Project      string                   `json:"project"`
+	Service      string                   `json:"service"`
+	Created      int64                    `json:"created"`
+	State        container.ContainerState `json:"state"`
+	Status       string                   `json:"status"`
+	Health       container.HealthStatus   `json:"health"`
+	ExitCode     int                      `json:"exit_code"`
+	Publishers   []portPublisherResponse  `json:"publishers"`
+	Labels       map[string]string        `json:"labels"`
+	SizeRw       int64                    `json:"size_rw,omitempty"`
+	SizeRootFs   int64                    `json:"size_root_fs,omitempty"`
+	Mounts       []string                 `json:"mounts"`
+	Networks     []string                 `json:"networks"`
+	LocalVolumes int                      `json:"local_volumes"`
+}
+
+func projectResponses(projects []api.Stack) []projectResponse {
+	if projects == nil {
+		return nil
+	}
+
+	responses := make([]projectResponse, len(projects))
+	for i, project := range projects {
+		responses[i] = projectResponse{
+			ID:          project.ID,
+			Name:        project.Name,
+			Status:      project.Status,
+			ConfigFiles: project.ConfigFiles,
+			Reason:      project.Reason,
+		}
+	}
+
+	return responses
+}
+
+func containerResponses(containers []api.ContainerSummary) []containerResponse {
+	if containers == nil {
+		return nil
+	}
+
+	responses := make([]containerResponse, len(containers))
+	for i, c := range containers {
+		var publishers []portPublisherResponse
+		if c.Publishers != nil {
+			publishers = make([]portPublisherResponse, len(c.Publishers))
+			for j, publisher := range c.Publishers {
+				publishers[j] = portPublisherResponse{
+					URL:           publisher.URL,
+					TargetPort:    publisher.TargetPort,
+					PublishedPort: publisher.PublishedPort,
+					Protocol:      publisher.Protocol,
+				}
+			}
+		}
+
+		responses[i] = containerResponse{
+			ID:           c.ID,
+			Name:         c.Name,
+			Names:        c.Names,
+			Image:        c.Image,
+			Command:      c.Command,
+			Project:      c.Project,
+			Service:      c.Service,
+			Created:      c.Created,
+			State:        c.State,
+			Status:       c.Status,
+			Health:       c.Health,
+			ExitCode:     c.ExitCode,
+			Publishers:   publishers,
+			Labels:       c.Labels,
+			SizeRw:       c.SizeRw,
+			SizeRootFs:   c.SizeRootFs,
+			Mounts:       c.Mounts,
+			Networks:     c.Networks,
+			LocalVolumes: c.LocalVolumes,
+		}
+	}
+
+	return responses
+}

--- a/cmd/doco-cd/api_response_test.go
+++ b/cmd/doco-cd/api_response_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/docker/compose/v5/pkg/api"
+	"github.com/moby/moby/api/types/container"
+)
+
+func TestProjectResponsesUseSnakeCaseJSON(t *testing.T) {
+	projects := []api.Stack{{
+		ID:          "project-id",
+		Name:        "project-name",
+		Status:      "running",
+		ConfigFiles: "compose.yaml",
+		Reason:      "healthy",
+	}}
+
+	got, err := json.Marshal(projectResponses(projects))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `[{"id":"project-id","name":"project-name","status":"running","config_files":"compose.yaml","reason":"healthy"}]`
+	if string(got) != want {
+		t.Fatalf("JSON = %s, want %s", got, want)
+	}
+
+	if strings.Contains(string(got), `"ID"`) {
+		t.Fatalf("JSON contains PascalCase field: %s", got)
+	}
+}
+
+func TestContainerResponsesUseSnakeCaseJSON(t *testing.T) {
+	containers := []api.ContainerSummary{{
+		ID:       "container-id",
+		Name:     "web-1",
+		Names:    []string{"web-1"},
+		Image:    "nginx:latest",
+		Command:  "nginx -g daemon off;",
+		Project:  "project-name",
+		Service:  "web",
+		Created:  123,
+		State:    container.ContainerState("running"),
+		Status:   "Up 1 minute",
+		Health:   container.HealthStatus("healthy"),
+		ExitCode: 0,
+		Publishers: api.PortPublishers{{
+			URL:           "0.0.0.0",
+			TargetPort:    80,
+			PublishedPort: 8080,
+			Protocol:      "tcp",
+		}},
+		Labels:       map[string]string{"com.example": "value"},
+		SizeRw:       1,
+		SizeRootFs:   2,
+		Mounts:       []string{"/host:/container"},
+		Networks:     []string{"default"},
+		LocalVolumes: 3,
+	}}
+
+	got, err := json.Marshal(containerResponses(containers))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `[{"id":"container-id","name":"web-1","names":["web-1"],"image":"nginx:latest","command":"nginx -g daemon off;","project":"project-name","service":"web","created":123,"state":"running","status":"Up 1 minute","health":"healthy","exit_code":0,"publishers":[{"url":"0.0.0.0","target_port":80,"published_port":8080,"protocol":"tcp"}],"labels":{"com.example":"value"},"size_rw":1,"size_root_fs":2,"mounts":["/host:/container"],"networks":["default"],"local_volumes":3}]`
+	if string(got) != want {
+		t.Fatalf("JSON = %s, want %s", got, want)
+	}
+
+	for _, field := range []string{`"ID"`, `"TargetPort"`, `"SizeRootFs"`} {
+		if strings.Contains(string(got), field) {
+			t.Fatalf("JSON contains PascalCase field %s: %s", field, got)
+		}
+	}
+}

--- a/cmd/doco-cd/handler_api.go
+++ b/cmd/doco-cd/handler_api.go
@@ -539,7 +539,7 @@ func (h *handlerData) ProjectApiHandler(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 
-		JSONResponse(w, containers, jobID, http.StatusOK)
+		JSONResponse(w, containerResponses(containers), jobID, http.StatusOK)
 	case http.MethodDelete:
 		timeoutSec := getQueryParam(r, w, jobLog, jobID, "timeout", "int", 30).(int)
 		timeout := time.Duration(timeoutSec) * time.Second
@@ -617,7 +617,7 @@ func (h *handlerData) GetProjectsApiHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	JSONResponse(w, projects, jobID, http.StatusOK)
+	JSONResponse(w, projectResponses(projects), jobID, http.StatusOK)
 }
 
 // ProjectActionApiHandler handles API requests to manage Docker Compose projects.

--- a/cmd/doco-cd/handler_api_test.go
+++ b/cmd/doco-cd/handler_api_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -234,7 +235,47 @@ func TestHandlerData_ProjectApiHandler(t *testing.T) {
 			if status := rr.Code; status != tc.expectedStatus {
 				t.Errorf("handler returned wrong status code: got %v want %v", status, tc.expectedStatus)
 			}
+
+			switch tc.name {
+			case "Get all Projects":
+				assertAPIContentFields(t, rr.Body.Bytes(), []string{"id", "name", "config_files"}, []string{"ID", "Name", "ConfigFiles"})
+			case "Get Project":
+				assertAPIContentFields(t, rr.Body.Bytes(), []string{"id", "name", "exit_code", "publishers"}, []string{"ID", "Name", "ExitCode", "Publishers"})
+			}
 		})
+	}
+}
+
+func assertAPIContentFields(t *testing.T, body []byte, expected, forbidden []string) {
+	t.Helper()
+
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("invalid API response: %v", err)
+	}
+
+	contentJSON, ok := envelope["content"]
+	if !ok {
+		t.Fatalf("API response has no content envelope: %s", body)
+	}
+
+	var content []map[string]json.RawMessage
+	if err := json.Unmarshal(contentJSON, &content); err != nil {
+		t.Fatalf("invalid content envelope: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatalf("content envelope is empty: %s", body)
+	}
+
+	for _, field := range expected {
+		if _, ok := content[0][field]; !ok {
+			t.Errorf("content is missing %q: %s", field, body)
+		}
+	}
+	for _, field := range forbidden {
+		if _, ok := content[0][field]; ok {
+			t.Errorf("content contains PascalCase field %q: %s", field, body)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- map Docker Compose project and container results into API-owned response types
- serialize every exposed field with explicit `snake_case` JSON names
- preserve the existing `content` envelope and response values

## Breaking change

This renames fields returned by `GET /v1/api/projects` and `GET /v1/api/project/{projectName}` from their dependency-defined PascalCase names to snake_case. Existing API consumers must update accordingly.

The Compose response structs come from `github.com/docker/compose/v5/pkg/api`, so Doco-CD cannot add tags to those dependency types directly; the response mapping keeps the wire contract under Doco-CD control.

## Test plan

- `GOTOOLCHAIN=local /tmp/go/bin/go test ./cmd/doco-cd -count=1`
- endpoint tests assert snake_case fields inside the `content` envelope and reject representative PascalCase fields