### PR TITLE
refactor(scheduler): make runtime state manager-owned

### DIFF
--- a/internal/mcp/jobs_test.go
+++ b/internal/mcp/jobs_test.go
@@ -224,11 +224,16 @@ func TestMCPScheduledJobsTool(t *testing.T) {
 `), test.WithName(projectName))
 
 	h := &Handler{dockerCli: dockerCli, log: logger.New(logger.LevelCritical)}
+	contexts := docker.NewContextRegistry(dockerCli, true)
+
+	t.Cleanup(func() { _ = contexts.Close() })
+
+	schedulerManager := scheduler.NewManager(contexts, h.log.Logger, nil, nil)
 	h.controlPlaneRuns = newTestControlPlaneRuns(t, testControlPlaneRunsOptions{
 		dockerCli: dockerCli,
 		log:       h.log,
 		scheduledJobs: testScheduledJobOperations{listJobs: func(ctx context.Context, _ string, stackName string) ([]scheduler.JobInfo, error) {
-			return scheduler.ListJobs(ctx, dockerCli, stackName)
+			return schedulerManager.ListJobs(ctx, "", stackName)
 		}},
 	})
 	server, _ := newMCPTestServerWithHandler(t, true, testMCPAPIKey, 1024, h)

--- a/internal/scheduler/scheduler_api.go
+++ b/internal/scheduler/scheduler_api.go
@@ -6,56 +6,14 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"time"
-
-	"github.com/docker/cli/cli/command"
 
 	"github.com/kimdre/doco-cd/internal/common/id"
 	"github.com/kimdre/doco-cd/internal/docker"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
-	"github.com/kimdre/doco-cd/internal/graceful"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/prometheus"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 )
-
-// legacyManager preserves shared state for the package-level compatibility
-// functions. Application code uses explicitly constructed Manager instances.
-var legacyManager = NewManager(nil, nil, nil, nil)
-
-func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider) {
-	if dockerCli == nil || log == nil || wg == nil {
-		return
-	}
-
-	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
-	runtime := legacyManager.runtime
-
-	mode := scheduledJobModeContainer
-	if cc.SwarmMode {
-		composeWorker := newSchedulerForMode(cc, scheduledJobModeContainer, log, wg, secretProvider, runtime)
-		graceful.SafeGo(wg, log, func() {
-			composeWorker.run(ctx)
-		})
-
-		mode = scheduledJobModeSwarm
-	}
-
-	newSchedulerForMode(cc, mode, log, wg, secretProvider, runtime).run(ctx)
-}
-
-// ListJobs returns all discovered scheduler jobs on the default Docker context,
-// optionally filtered by stack name.
-func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]JobInfo, error) {
-	if dockerCli == nil {
-		return nil, errors.New("docker cli is required")
-	}
-
-	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
-
-	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, nil, nil, legacyManager.runtime, stackName)
-}
 
 // listJobs returns all jobs discovered on this worker's Docker context,
 // optionally filtered by stack name.
@@ -149,19 +107,6 @@ func (s *scheduler) listJobs(ctx context.Context, stackName string) ([]JobInfo, 
 	}
 
 	return result, nil
-}
-
-// TriggerNow executes one configured scheduled job immediately on the default
-// Docker context. Job selection matches by container/service name and
-// optional stack name.
-func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jobName, stackName string, secretProvider secretprovider.SecretProvider) (string, error) {
-	if dockerCli == nil {
-		return "", errors.New("docker cli is required")
-	}
-
-	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
-
-	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, log, jobName, stackName, secretProvider, legacyManager.runtime)
 }
 
 // triggerNow executes one configured scheduled job immediately on this

--- a/internal/scheduler/scheduler_api.go
+++ b/internal/scheduler/scheduler_api.go
@@ -20,16 +20,21 @@ import (
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 )
 
+// legacyManager preserves shared state for the package-level compatibility
+// functions. Application code uses explicitly constructed Manager instances.
+var legacyManager = NewManager(nil, nil, nil, nil)
+
 func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider) {
 	if dockerCli == nil || log == nil || wg == nil {
 		return
 	}
 
 	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
+	runtime := legacyManager.runtime
 
 	mode := scheduledJobModeContainer
 	if cc.SwarmMode {
-		composeWorker := newSchedulerForMode(cc, scheduledJobModeContainer, log, wg, secretProvider)
+		composeWorker := newSchedulerForMode(cc, scheduledJobModeContainer, log, wg, secretProvider, runtime)
 		graceful.SafeGo(wg, log, func() {
 			composeWorker.run(ctx)
 		})
@@ -37,7 +42,7 @@ func Start(ctx context.Context, dockerCli command.Cli, log *slog.Logger, wg *syn
 		mode = scheduledJobModeSwarm
 	}
 
-	newSchedulerForMode(cc, mode, log, wg, secretProvider).run(ctx)
+	newSchedulerForMode(cc, mode, log, wg, secretProvider, runtime).run(ctx)
 }
 
 // ListJobs returns all discovered scheduler jobs on the default Docker context,
@@ -49,7 +54,7 @@ func ListJobs(ctx context.Context, dockerCli command.Cli, stackName string) ([]J
 
 	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
 
-	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, nil, nil, stackName)
+	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, nil, nil, legacyManager.runtime, stackName)
 }
 
 // listJobs returns all jobs discovered on this worker's Docker context,
@@ -63,9 +68,9 @@ func (s *scheduler) listJobs(ctx context.Context, stackName string) ([]JobInfo, 
 	now := schedulerNow()
 	stackName = strings.TrimSpace(stackName)
 	result := make([]JobInfo, 0, len(jobs))
-	states := getRuntimeStatesSnapshot()
-	runStatuses := getRuntimeRunStatusesSnapshot()
-	runningStates := getRuntimeRunningStatesSnapshot()
+	states := s.runtime.statesSnapshot()
+	runStatuses := s.runtime.runStatusesSnapshot()
+	runningStates := s.runtime.runningStatesSnapshot()
 
 	for _, job := range jobs {
 		stack := getJobStackName(job)
@@ -156,7 +161,7 @@ func TriggerNow(ctx context.Context, dockerCli command.Cli, log *slog.Logger, jo
 
 	cc := docker.ContextClient{Cli: dockerCli, SwarmMode: swarm.GetModeEnabled()}
 
-	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, log, jobName, stackName, secretProvider)
+	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, log, jobName, stackName, secretProvider, legacyManager.runtime)
 }
 
 // triggerNow executes one configured scheduled job immediately on this
@@ -212,12 +217,12 @@ func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (
 
 	defer unlockStacks()
 
-	setRuntimeRunInProgress(job.key, true)
-	defer setRuntimeRunInProgress(job.key, false)
+	s.setRunInProgress(job.key, true)
+	defer s.setRunInProgress(job.key, false)
 
 	err = s.executeScheduledRun(ctx, job, cfg)
-	updateRuntimeRunStatus(job, cfg, err)
-	setRuntimeLastRun(job.key, schedulerNow())
+	s.runtime.updateRunStatus(job, cfg, err)
+	s.runtime.setLastRun(job.key, schedulerNow())
 
 	if err != nil {
 		runFailed = true
@@ -234,11 +239,11 @@ func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (
 	return runID, nil
 }
 
-func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, secretProvider secretprovider.SecretProvider, stackName string) ([]JobInfo, error) {
+func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, secretProvider secretprovider.SecretProvider, runtime *runtimeStore, stackName string) ([]JobInfo, error) {
 	var result []JobInfo
 
 	for _, mode := range modes {
-		jobs, err := newSchedulerForMode(cc, mode, log, nil, secretProvider).listJobs(ctx, stackName)
+		jobs, err := newSchedulerForMode(cc, mode, log, nil, secretProvider, runtime).listJobs(ctx, stackName)
 		if err != nil {
 			return nil, err
 		}
@@ -249,13 +254,13 @@ func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.C
 	return result, nil
 }
 
-func triggerNowForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, jobName, stackName string, secretProvider secretprovider.SecretProvider) (string, error) {
+func triggerNowForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, jobName, stackName string, secretProvider secretprovider.SecretProvider, runtime *runtimeStore) (string, error) {
 	workers := make(map[scheduledJobMode]*scheduler, len(modes))
 
 	var jobs []scheduledJob
 
 	for _, mode := range modes {
-		worker := newSchedulerForMode(cc, mode, log, nil, secretProvider)
+		worker := newSchedulerForMode(cc, mode, log, nil, secretProvider, runtime)
 
 		discovered, err := worker.discoverJobs(ctx)
 		if err != nil {

--- a/internal/scheduler/scheduler_execution.go
+++ b/internal/scheduler/scheduler_execution.go
@@ -505,24 +505,16 @@ func (s *scheduler) sendRunNotification(job scheduledJob, cfg docker.JobSchedule
 }
 
 func (s *scheduler) isRunInProgress(key string) bool {
-	s.runningMu.Lock()
-	defer s.runningMu.Unlock()
-
-	return s.running[key]
+	return s.runtime.isRunInProgress(key)
 }
 
 func (s *scheduler) setRunInProgress(key string, inProgress bool) {
-	s.runningMu.Lock()
-	defer s.runningMu.Unlock()
-
-	setRuntimeRunInProgress(key, inProgress)
-
 	if inProgress {
-		s.running[key] = true
+		s.runtime.beginRun(s.contextName, s.mode, key)
 		return
 	}
 
-	delete(s.running, key)
+	s.runtime.endRun(key)
 }
 
 func getScheduledRunMetricLabels(job scheduledJob, cfg docker.JobScheduleConfig, stackName string) []string {

--- a/internal/scheduler/scheduler_manager.go
+++ b/internal/scheduler/scheduler_manager.go
@@ -30,14 +30,20 @@ type Manager struct {
 	log            *slog.Logger
 	wg             *sync.WaitGroup
 	secretProvider secretprovider.SecretProvider
+	runtime        *runtimeStore
 
 	mu      sync.Mutex
 	workers map[string]managedWorker // key = normalized context name + runtime mode
+	nextID  uint64
 }
 
 type managedWorker struct {
 	cancel context.CancelFunc
 	mode   scheduledJobMode
+	// id prevents a stopped worker from deleting a replacement using the same key.
+	id uint64
+	// stopping keeps the worker registered until its active runs have drained.
+	stopping bool
 }
 
 // NewManager creates a scheduler Manager bound to registry. log and wg are
@@ -53,6 +59,7 @@ func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.Wai
 		log:            log.With(slog.String("component", "scheduler_manager")),
 		wg:             wg,
 		secretProvider: secretProvider,
+		runtime:        newRuntimeStore(),
 		workers:        map[string]managedWorker{},
 	}
 }
@@ -68,6 +75,8 @@ func (m *Manager) Start(ctx context.Context) {
 	m.refreshWorkers(ctx)
 
 	graceful.SafeGo(m.wg, m.log, func() {
+		defer m.stopWorkers()
+
 		ticker := time.NewTicker(contextRefreshInterval)
 		defer ticker.Stop()
 
@@ -123,11 +132,15 @@ func (m *Manager) refreshWorkers(ctx context.Context) {
 				continue
 			}
 
-			worker := newSchedulerForMode(result.ContextClient, mode, m.log, m.wg, m.secretProvider)
+			worker := newSchedulerForMode(result.ContextClient, mode, m.log, m.wg, m.secretProvider, m.runtime)
 			workerCtx, cancel := context.WithCancel(ctx)
-			m.workers[key] = managedWorker{cancel: cancel, mode: mode}
+			m.nextID++
+			workerID := m.nextID
+			m.workers[key] = managedWorker{cancel: cancel, mode: mode, id: workerID}
 
 			graceful.SafeGo(m.wg, m.log, func() {
+				defer m.workerStopped(key, workerID)
+
 				worker.run(workerCtx)
 			})
 		}
@@ -138,9 +151,13 @@ func (m *Manager) refreshWorkers(ctx context.Context) {
 			continue
 		}
 
+		if worker.stopping {
+			continue
+		}
+
 		worker.cancel()
-		delete(m.workers, key)
-		clearRuntimeContextMode(workerContextFromKey(key), worker.mode)
+		worker.stopping = true
+		m.workers[key] = worker
 		m.log.Info("stopped scheduler worker",
 			slog.String("context", docker.DisplayContextName(workerContextFromKey(key))),
 			slog.String("mode", string(worker.mode)),
@@ -161,7 +178,7 @@ func (m *Manager) ListJobs(ctx context.Context, contextName, stackName string) (
 		return nil, fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
 	}
 
-	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, m.secretProvider, stackName)
+	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, m.secretProvider, m.runtime, stackName)
 }
 
 // TriggerNow executes one configured scheduled job immediately on the given
@@ -177,7 +194,37 @@ func (m *Manager) TriggerNow(ctx context.Context, contextName, jobName, stackNam
 		return "", fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
 	}
 
-	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, jobName, stackName, secretProvider)
+	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, jobName, stackName, secretProvider, m.runtime)
+}
+
+// stopWorkers requests cancellation for every managed worker. Each worker
+// removes its own runtime partition after its active runs have drained.
+func (m *Manager) stopWorkers() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for key, worker := range m.workers {
+		if worker.stopping {
+			continue
+		}
+
+		worker.cancel()
+		worker.stopping = true
+		m.workers[key] = worker
+	}
+}
+
+func (m *Manager) workerStopped(key string, id uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	worker, ok := m.workers[key]
+	if !ok || worker.id != id {
+		return
+	}
+
+	m.runtime.clearContextMode(workerContextFromKey(key), worker.mode)
+	delete(m.workers, key)
 }
 
 func schedulerModes(swarmAvailable bool) []scheduledJobMode {

--- a/internal/scheduler/scheduler_runtime.go
+++ b/internal/scheduler/scheduler_runtime.go
@@ -13,12 +13,29 @@ import (
 	"github.com/kimdre/doco-cd/internal/docker"
 )
 
-var (
-	runtimeStatesMu      sync.RWMutex
-	runtimeStates        = map[string]scheduledJobState{}
-	runtimeRunStatuses   = map[string]string{}
-	runtimeRunningStates = map[string]bool{}
-)
+// runtimeStore keeps the status exposed by scheduler APIs separate from the
+// worker-local scheduling state. Each Manager owns one store shared by its
+// background workers and on-demand operations.
+type runtimeStore struct {
+	mu            sync.RWMutex
+	states        map[string]scheduledJobState
+	runStatuses   map[string]string
+	runningStates map[string]int
+	clearing      map[string]bool
+	cond          *sync.Cond
+}
+
+func newRuntimeStore() *runtimeStore {
+	store := &runtimeStore{
+		states:        map[string]scheduledJobState{},
+		runStatuses:   map[string]string{},
+		runningStates: map[string]int{},
+		clearing:      map[string]bool{},
+	}
+	store.cond = sync.NewCond(&store.mu)
+
+	return store
+}
 
 func formatRunStatus(state, status string) string {
 	state = strings.TrimSpace(state)
@@ -94,32 +111,28 @@ func schedulerNow() time.Time {
 	return time.Now().In(time.Local)
 }
 
-// setRuntimeStatesSnapshot replaces one context's states while preserving all
+// setStatesSnapshot replaces one context's states while preserving all
 // other context partitions and newer manual-run timestamps.
-func setRuntimeStatesSnapshot(contextName string, states map[string]scheduledJobState) {
-	setRuntimeStatesSnapshotForMode(contextName, "", states)
-}
+func (s *runtimeStore) setStatesSnapshot(contextName string, mode scheduledJobMode, states map[string]scheduledJobState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-func setRuntimeStatesSnapshotForMode(contextName string, mode scheduledJobMode, states map[string]scheduledJobState) {
-	runtimeStatesMu.Lock()
-	defer runtimeStatesMu.Unlock()
-
-	merged := make(map[string]scheduledJobState, len(runtimeStates)+len(states))
-	for key, state := range runtimeStates {
+	merged := make(map[string]scheduledJobState, len(s.states)+len(states))
+	for key, state := range s.states {
 		if !runtimeKeyInContextMode(contextName, mode, key) {
 			merged[key] = state
 		}
 	}
 
 	for key, state := range states {
-		if existing, ok := runtimeStates[key]; ok && existing.lastRun.After(state.lastRun) {
+		if existing, ok := s.states[key]; ok && existing.lastRun.After(state.lastRun) {
 			state.lastRun = existing.lastRun
 		}
 
 		merged[key] = state
 	}
 
-	runtimeStates = merged
+	s.states = merged
 }
 
 func runtimeKeyInContext(contextName, key string) bool {
@@ -144,115 +157,166 @@ func runtimeKeyInContextMode(contextName string, mode scheduledJobMode, key stri
 	return strings.HasPrefix(key, string(mode)+":")
 }
 
-func clearRuntimeContext(contextName string) {
-	clearRuntimeContextMode(contextName, "")
-}
+func (s *runtimeStore) clearContextMode(contextName string, mode scheduledJobMode) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-func clearRuntimeContextMode(contextName string, mode scheduledJobMode) {
-	runtimeStatesMu.Lock()
-	defer runtimeStatesMu.Unlock()
+	partition := runtimePartitionKey(contextName, mode)
 
-	for key := range runtimeStates {
+	s.clearing[partition] = true
+	for s.hasRunningStateLocked(contextName, mode) {
+		s.cond.Wait()
+	}
+
+	for key := range s.states {
 		if runtimeKeyInContextMode(contextName, mode, key) {
-			delete(runtimeStates, key)
+			delete(s.states, key)
 		}
 	}
 
-	for key := range runtimeRunStatuses {
+	for key := range s.runStatuses {
 		if runtimeKeyInContextMode(contextName, mode, key) {
-			delete(runtimeRunStatuses, key)
+			delete(s.runStatuses, key)
 		}
 	}
 
-	for key := range runtimeRunningStates {
+	for key := range s.runningStates {
 		if runtimeKeyInContextMode(contextName, mode, key) {
-			delete(runtimeRunningStates, key)
+			delete(s.runningStates, key)
 		}
 	}
+
+	delete(s.clearing, partition)
+	s.cond.Broadcast()
 }
 
-func getRuntimeStatesSnapshot() map[string]scheduledJobState {
-	runtimeStatesMu.RLock()
-	defer runtimeStatesMu.RUnlock()
+func (s *runtimeStore) statesSnapshot() map[string]scheduledJobState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	return copyMapLocked(runtimeStates)
+	return copyMap(s.states)
 }
 
-func setRuntimeLastRun(key string, lastRun time.Time) {
+func (s *runtimeStore) setLastRun(key string, lastRun time.Time) {
 	if key == "" {
 		return
 	}
 
-	runtimeStatesMu.Lock()
-	defer runtimeStatesMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	state := runtimeStates[key]
+	state := s.states[key]
 	state.lastRun = lastRun
-	runtimeStates[key] = state
+	s.states[key] = state
 }
 
-func getRuntimeRunStatusesSnapshot() map[string]string {
-	runtimeStatesMu.RLock()
-	defer runtimeStatesMu.RUnlock()
+func (s *runtimeStore) runStatusesSnapshot() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	return copyMapLocked(runtimeRunStatuses)
+	return copyMap(s.runStatuses)
 }
 
-func setRuntimeRunStatus(key, status string) {
+func (s *runtimeStore) setRunStatus(key, status string) {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return
 	}
 
-	runtimeStatesMu.Lock()
-	defer runtimeStatesMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	runtimeRunStatuses[key] = strings.TrimSpace(status)
+	s.runStatuses[key] = strings.TrimSpace(status)
 }
 
-func getRuntimeRunningStatesSnapshot() map[string]bool {
-	runtimeStatesMu.RLock()
-	defer runtimeStatesMu.RUnlock()
+func (s *runtimeStore) runningStatesSnapshot() map[string]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-	return copyMapLocked(runtimeRunningStates)
+	states := make(map[string]bool, len(s.runningStates))
+	for key, count := range s.runningStates {
+		states[key] = count > 0
+	}
+
+	return states
 }
 
-func setRuntimeRunInProgress(key string, inProgress bool) {
+func (s *runtimeStore) isRunInProgress(key string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.runningStates[key] > 0
+}
+
+func (s *runtimeStore) beginRun(contextName string, mode scheduledJobMode, key string) {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return
 	}
 
-	runtimeStatesMu.Lock()
-	defer runtimeStatesMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	if inProgress {
-		runtimeRunningStates[key] = true
+	partition := runtimePartitionKey(contextName, mode)
+
+	contextPartition := runtimePartitionKey(contextName, "")
+	for s.clearing[partition] || s.clearing[contextPartition] {
+		s.cond.Wait()
+	}
+
+	s.runningStates[key]++
+}
+
+func (s *runtimeStore) endRun(key string) {
+	key = strings.TrimSpace(key)
+	if key == "" {
 		return
 	}
 
-	delete(runtimeRunningStates, key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.runningStates[key] <= 1 {
+		delete(s.runningStates, key)
+	} else {
+		s.runningStates[key]--
+	}
+
+	s.cond.Broadcast()
 }
 
-func updateRuntimeRunStatus(job scheduledJob, cfg docker.JobScheduleConfig, runErr error) {
+func (s *runtimeStore) updateRunStatus(job scheduledJob, cfg docker.JobScheduleConfig, runErr error) {
 	if job.mode != scheduledJobModeContainer || cfg.ExecutionMode != docker.JobExecutionModeOneOff {
 		return
 	}
 
 	if runErr == nil {
-		setRuntimeRunStatus(job.key, formatExitStatus(0))
+		s.setRunStatus(job.key, formatExitStatus(0))
 		return
 	}
 
 	if exitErr, ok := errors.AsType[*docker.ContainerExitError](runErr); ok {
-		setRuntimeRunStatus(job.key, formatExitStatus(exitErr.ExitCode))
+		s.setRunStatus(job.key, formatExitStatus(exitErr.ExitCode))
 	}
 }
 
-// copyMapLocked returns a shallow copy of m. Callers must hold runtimeStatesMu.
-func copyMapLocked[K comparable, V any](m map[K]V) map[K]V {
+func copyMap[K comparable, V any](m map[K]V) map[K]V {
 	ret := make(map[K]V, len(m))
 	maps.Copy(ret, m)
 
 	return ret
+}
+
+func runtimePartitionKey(contextName string, mode scheduledJobMode) string {
+	return docker.NormalizeContextName(contextName) + "\x00" + string(mode)
+}
+
+func (s *runtimeStore) hasRunningStateLocked(contextName string, mode scheduledJobMode) bool {
+	for key, count := range s.runningStates {
+		if count > 0 && runtimeKeyInContextMode(contextName, mode, key) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/scheduler/scheduler_runtime_test.go
+++ b/internal/scheduler/scheduler_runtime_test.go
@@ -86,55 +86,51 @@ func TestStatusForScheduledJob(t *testing.T) {
 // manual TriggerNow's last_run_at being wiped by the scheduler's next tick.
 func TestSetRuntimeStatesSnapshot_PreservesNewerManualLastRun(t *testing.T) {
 	key := "container:project/service"
-
-	runtimeStatesMu.Lock()
-	runtimeStates = map[string]scheduledJobState{}
-	runtimeStatesMu.Unlock()
+	runtime := newRuntimeStore()
 
 	manualRun := time.Now()
-	setRuntimeLastRun(key, manualRun)
+	runtime.setLastRun(key, manualRun)
 
 	// Simulate the loop's next refresh, unaware of the manual run.
-	setRuntimeStatesSnapshot("", map[string]scheduledJobState{
+	runtime.setStatesSnapshot("", "", map[string]scheduledJobState{
 		key: {nextRun: manualRun.Add(time.Hour)},
 	})
 
-	got := getRuntimeStatesSnapshot()[key]
+	got := runtime.statesSnapshot()[key]
 	if !got.lastRun.Equal(manualRun) {
 		t.Fatalf("expected manually triggered last run %v to survive scheduler refresh, got %v", manualRun, got.lastRun)
 	}
 
 	// A genuinely newer lastRun must still win.
 	newerRun := manualRun.Add(2 * time.Hour)
-	setRuntimeStatesSnapshot("", map[string]scheduledJobState{
+	runtime.setStatesSnapshot("", "", map[string]scheduledJobState{
 		key: {lastRun: newerRun},
 	})
 
-	got = getRuntimeStatesSnapshot()[key]
+	got = runtime.statesSnapshot()[key]
 	if !got.lastRun.Equal(newerRun) {
 		t.Fatalf("expected newer scheduler-tracked last run %v to win, got %v", newerRun, got.lastRun)
 	}
 }
 
 func TestSetRuntimeStatesSnapshotPreservesOtherContexts(t *testing.T) {
-	runtimeStatesMu.Lock()
-	runtimeStates = map[string]scheduledJobState{
+	runtime := newRuntimeStore()
+	runtime.states = map[string]scheduledJobState{
 		"remote::container:shared/job": {deployment: "remote"},
 	}
-	runtimeStatesMu.Unlock()
 
-	setRuntimeStatesSnapshot("", map[string]scheduledJobState{
+	runtime.setStatesSnapshot("", "", map[string]scheduledJobState{
 		"container:shared/job": {deployment: "default"},
 	})
 
-	states := getRuntimeStatesSnapshot()
+	states := runtime.statesSnapshot()
 	if len(states) != 2 {
 		t.Fatalf("expected both context partitions, got %#v", states)
 	}
 
-	setRuntimeStatesSnapshot("remote", map[string]scheduledJobState{})
+	runtime.setStatesSnapshot("remote", "", map[string]scheduledJobState{})
 
-	states = getRuntimeStatesSnapshot()
+	states = runtime.statesSnapshot()
 	if _, ok := states["remote::container:shared/job"]; ok {
 		t.Fatal("expected stale remote state to be removed")
 	}
@@ -145,54 +141,82 @@ func TestSetRuntimeStatesSnapshotPreservesOtherContexts(t *testing.T) {
 }
 
 func TestClearRuntimeContext(t *testing.T) {
-	t.Cleanup(func() {
-		runtimeStatesMu.Lock()
-		runtimeStates = map[string]scheduledJobState{}
-		runtimeRunStatuses = map[string]string{}
-		runtimeRunningStates = map[string]bool{}
-		runtimeStatesMu.Unlock()
-	})
-
-	runtimeStatesMu.Lock()
-	runtimeStates = map[string]scheduledJobState{
+	runtime := newRuntimeStore()
+	runtime.states = map[string]scheduledJobState{
 		"container:shared/job":         {deployment: "default"},
 		"remote::container:shared/job": {deployment: "remote"},
 	}
-	runtimeRunStatuses = map[string]string{
+	runtime.runStatuses = map[string]string{
 		"container:shared/job":         "running",
 		"remote::container:shared/job": "exited (0)",
 	}
-	runtimeRunningStates = map[string]bool{
-		"container:shared/job":         true,
-		"remote::container:shared/job": true,
+	runtime.runningStates = map[string]int{
+		"container:shared/job":         1,
+		"remote::container:shared/job": 1,
 	}
-	runtimeStatesMu.Unlock()
 
-	clearRuntimeContext("remote")
+	started := make(chan struct{})
+	cleared := make(chan struct{})
 
-	if _, ok := getRuntimeStatesSnapshot()["remote::container:shared/job"]; ok {
+	go func() {
+		close(started)
+		runtime.clearContextMode("remote", "")
+		close(cleared)
+	}()
+
+	<-started
+
+	select {
+	case <-cleared:
+		t.Fatal("expected cleanup to wait for the active remote run")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	runtime.endRun("remote::container:shared/job")
+	<-cleared
+
+	if _, ok := runtime.statesSnapshot()["remote::container:shared/job"]; ok {
 		t.Fatal("expected remote runtime state to be removed")
 	}
 
-	if _, ok := getRuntimeRunStatusesSnapshot()["remote::container:shared/job"]; ok {
+	if _, ok := runtime.runStatusesSnapshot()["remote::container:shared/job"]; ok {
 		t.Fatal("expected remote run status to be removed")
 	}
 
-	if _, ok := getRuntimeRunningStatesSnapshot()["remote::container:shared/job"]; ok {
+	if _, ok := runtime.runningStatesSnapshot()["remote::container:shared/job"]; ok {
 		t.Fatal("expected remote running state to be removed")
 	}
 
-	if _, ok := getRuntimeStatesSnapshot()["container:shared/job"]; !ok {
+	if _, ok := runtime.statesSnapshot()["container:shared/job"]; !ok {
 		t.Fatal("expected default runtime state to be preserved")
+	}
+}
+
+func TestRuntimeStoreTracksConcurrentRuns(t *testing.T) {
+	t.Parallel()
+
+	runtime := newRuntimeStore()
+	key := "container:shared/job"
+	runtime.beginRun("", scheduledJobModeContainer, key)
+	runtime.beginRun("", scheduledJobModeContainer, key)
+
+	runtime.endRun(key)
+
+	if !runtime.isRunInProgress(key) {
+		t.Fatal("expected the second concurrent run to remain active")
+	}
+
+	runtime.endRun(key)
+
+	if runtime.isRunInProgress(key) {
+		t.Fatal("expected the job to become idle after both runs ended")
 	}
 }
 
 func TestUpdateRuntimeRunStatus(t *testing.T) {
 	t.Parallel()
 
-	runtimeStatesMu.Lock()
-	runtimeRunStatuses = map[string]string{}
-	runtimeStatesMu.Unlock()
+	runtime := newRuntimeStore()
 
 	job := scheduledJob{
 		key:  "container:project/service",
@@ -200,17 +224,111 @@ func TestUpdateRuntimeRunStatus(t *testing.T) {
 	}
 	cfg := docker.JobScheduleConfig{ExecutionMode: docker.JobExecutionModeOneOff}
 
-	updateRuntimeRunStatus(job, cfg, nil)
+	runtime.updateRunStatus(job, cfg, nil)
 
-	if got := getRuntimeRunStatusesSnapshot()[job.key]; got != "exited (0)" {
+	if got := runtime.runStatusesSnapshot()[job.key]; got != "exited (0)" {
 		t.Fatalf("updateRuntimeRunStatus() success status=%q want=%q", got, "exited (0)")
 	}
 
 	wrapped := fmt.Errorf("scheduled run: %w", &docker.ContainerExitError{ContainerID: "abc", ExitCode: 143})
-	updateRuntimeRunStatus(job, cfg, wrapped)
+	runtime.updateRunStatus(job, cfg, wrapped)
 
-	if got := getRuntimeRunStatusesSnapshot()[job.key]; got != "exited (143)" {
+	if got := runtime.runStatusesSnapshot()[job.key]; got != "exited (143)" {
 		t.Fatalf("updateRuntimeRunStatus() error status=%q want=%q", got, "exited (143)")
+	}
+}
+
+func TestManagerRuntimeStateIsIsolated(t *testing.T) {
+	t.Parallel()
+
+	first := NewManager(nil, nil, nil, nil)
+	second := NewManager(nil, nil, nil, nil)
+	key := "container:project/service"
+
+	first.runtime.setLastRun(key, time.Now())
+
+	if _, ok := second.runtime.statesSnapshot()[key]; ok {
+		t.Fatal("expected scheduler managers to own independent runtime state")
+	}
+}
+
+func TestRuntimeStoreClearContextModePreservesOtherPartitions(t *testing.T) {
+	t.Parallel()
+
+	runtime := newRuntimeStore()
+	runtime.states = map[string]scheduledJobState{
+		"remote::container:shared/job": {deployment: "compose"},
+		"remote::swarm:shared/job":     {deployment: "swarm"},
+	}
+
+	runtime.clearContextMode("remote", scheduledJobModeContainer)
+
+	states := runtime.statesSnapshot()
+	if _, ok := states["remote::container:shared/job"]; ok {
+		t.Fatal("expected Compose runtime state to be removed")
+	}
+
+	if _, ok := states["remote::swarm:shared/job"]; !ok {
+		t.Fatal("expected Swarm runtime state to be preserved")
+	}
+}
+
+func TestManagerStopWorkersClearsRuntimeState(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil, nil)
+	key := schedulerWorkerKey("remote", scheduledJobModeContainer)
+	jobKey := "remote::container:shared/job"
+	cancelled := false
+	manager.workers[key] = managedWorker{
+		cancel: func() { cancelled = true },
+		mode:   scheduledJobModeContainer,
+		id:     1,
+	}
+	manager.runtime.setLastRun(jobKey, time.Now())
+
+	manager.stopWorkers()
+
+	if !cancelled {
+		t.Fatal("expected managed worker to be cancelled")
+	}
+
+	if worker := manager.workers[key]; !worker.stopping {
+		t.Fatal("expected managed worker to be marked as stopping")
+	}
+
+	manager.workerStopped(key, 1)
+
+	if len(manager.workers) != 0 {
+		t.Fatalf("expected stopped worker to be removed, got %d", len(manager.workers))
+	}
+
+	if _, ok := manager.runtime.statesSnapshot()[jobKey]; ok {
+		t.Fatal("expected worker runtime state to be cleared")
+	}
+}
+
+func TestManagerOldWorkerCannotClearReplacementState(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(nil, nil, nil, nil)
+	key := schedulerWorkerKey("remote", scheduledJobModeContainer)
+	jobKey := "remote::container:shared/job"
+	manager.workers[key] = managedWorker{
+		cancel: func() {},
+		mode:   scheduledJobModeContainer,
+		id:     2,
+	}
+	manager.runtime.setLastRun(jobKey, time.Now())
+
+	manager.workerStopped(key, 1)
+
+	if _, ok := manager.workers[key]; !ok {
+		t.Fatal("expected replacement worker to remain registered")
+	}
+
+	if _, ok := manager.runtime.statesSnapshot()[jobKey]; !ok {
+		t.Fatal("expected replacement worker runtime state to be preserved")
 	}
 }
 

--- a/internal/scheduler/scheduler_types.go
+++ b/internal/scheduler/scheduler_types.go
@@ -63,11 +63,10 @@ type scheduler struct {
 	log            *slog.Logger
 	wg             *sync.WaitGroup
 	startedAt      time.Time
+	runtime        *runtimeStore
+	runs           sync.WaitGroup
 
 	states map[string]scheduledJobState
-
-	runningMu sync.Mutex
-	running   map[string]bool
 
 	// stopHolds reference-counts services currently held stopped by
 	// stopServicesForJob/startServicesForJob. It is keyed by (mode, resolved
@@ -125,9 +124,13 @@ type JobInfo struct {
 // newSchedulerForMode builds a scheduler worker bound to a single Docker
 // context and runtime mode. log and wg may be nil for short-lived, one-shot
 // workers (e.g. a single ListJobs/TriggerNow call) that never call run().
-func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider) *scheduler {
+func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, runtime *runtimeStore) *scheduler {
 	if log == nil {
 		log = slog.Default()
+	}
+
+	if runtime == nil {
+		runtime = newRuntimeStore()
 	}
 
 	contextName := docker.NormalizeContextName(cc.Name)
@@ -140,8 +143,8 @@ func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *sl
 		log:            log.With(slog.String("component", "scheduler"), slog.String("context", docker.DisplayContextName(contextName))),
 		wg:             wg,
 		startedAt:      schedulerNow(),
+		runtime:        runtime,
 		states:         map[string]scheduledJobState{},
-		running:        map[string]bool{},
 		stopHolds:      map[stopHoldKey]*stopHoldState{},
 	}
 }

--- a/internal/scheduler/scheduler_types_test.go
+++ b/internal/scheduler/scheduler_types_test.go
@@ -21,7 +21,7 @@ func TestJobKeyPrefix(t *testing.T) {
 func TestNewSchedulerForMode_NormalizesContextAndCarriesMode(t *testing.T) {
 	t.Parallel()
 
-	s := newSchedulerForMode(docker.ContextClient{Name: "Default", SwarmMode: true}, scheduledJobModeSwarm, nil, nil, nil)
+	s := newSchedulerForMode(docker.ContextClient{Name: "Default", SwarmMode: true}, scheduledJobModeSwarm, nil, nil, nil, nil)
 	if s.contextName != "" {
 		t.Fatalf("newSchedulerForMode() contextName = %q, want empty string for the default context", s.contextName)
 	}
@@ -30,7 +30,7 @@ func TestNewSchedulerForMode_NormalizesContextAndCarriesMode(t *testing.T) {
 		t.Fatalf("newSchedulerForMode() mode = %q, want %q", s.mode, scheduledJobModeSwarm)
 	}
 
-	remote := newSchedulerForMode(docker.ContextClient{Name: "remote", SwarmMode: false}, scheduledJobModeContainer, nil, nil, nil)
+	remote := newSchedulerForMode(docker.ContextClient{Name: "remote", SwarmMode: false}, scheduledJobModeContainer, nil, nil, nil, nil)
 	if remote.contextName != "remote" {
 		t.Fatalf("newSchedulerForMode() contextName = %q, want %q", remote.contextName, "remote")
 	}

--- a/internal/scheduler/scheduler_worker.go
+++ b/internal/scheduler/scheduler_worker.go
@@ -22,6 +22,8 @@ const (
 )
 
 func (s *scheduler) run(ctx context.Context) {
+	defer s.runs.Wait()
+
 	jobChanges := s.watchJobChanges(ctx)
 	timer := time.NewTimer(time.Hour)
 
@@ -169,7 +171,7 @@ func (s *scheduler) refreshJobs(ctx context.Context, now time.Time) (time.Time, 
 		nearestNextRun, _ = getNearestNextRun(s.states)
 	}
 
-	setRuntimeStatesSnapshotForMode(s.contextName, s.mode, s.states)
+	s.runtime.setStatesSnapshot(s.contextName, s.mode, s.states)
 
 	return nearestNextRun, !nearestNextRun.IsZero()
 }
@@ -259,8 +261,10 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 	}
 
 	s.setRunInProgress(job.key, true)
+	s.runs.Add(1)
 
 	graceful.SafeGo(s.wg, s.log, func() {
+		defer s.runs.Done()
 		defer s.setRunInProgress(job.key, false)
 
 		runStart := time.Now()
@@ -304,7 +308,7 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 		runLog.Debug("triggering scheduled run")
 
 		err := s.executeScheduledRun(ctx, job, cfg)
-		updateRuntimeRunStatus(job, cfg, err)
+		s.runtime.updateRunStatus(job, cfg, err)
 
 		if err != nil {
 			runFailed = true


### PR DESCRIPTION
## Summary
- move scheduler runtime status maps into a store owned by `scheduler.Manager`
- share state across managed workers and on-demand operations while isolating manager instances
- drain active scheduled and manual runs before clearing context/mode state
- preserve package-level compatibility API state through a dedicated compatibility manager

## Validation
- `go test -race ./internal/scheduler/...`
- `make test-nobitwarden`
- `make build`
- `make fmt`

Part of #1764