### PR TITLE
refactor(reconciliation): introduce typed deployment requests

### DIFF
--- a/cmd/doco-cd/controlplane_test_helpers_test.go
+++ b/cmd/doco-cd/controlplane_test_helpers_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 )
 
-func newTestReconciliationManager(t *testing.T) *reconciliation.Manager {
+func newTestReconciliationManager(t *testing.T, dependencies reconciliation.Dependencies) *reconciliation.Manager {
 	t.Helper()
 
-	manager, err := reconciliation.NewManager(reconciliation.Dependencies{})
+	manager, err := reconciliation.NewManager(dependencies)
 	if err != nil {
 		t.Fatalf("failed to create reconciliation manager: %v", err)
 	}

--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -179,20 +179,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 		}
 	}
 
-	var (
-		jobTrigger   = req.JobTrigger
-		sourceType   = req.SourceType
-		sourceRef    = req.SourceRef
-		ref          = req.Ref
-		private      = req.Private
-		metadata     = req.Metadata
-		customTarget = req.CustomTarget
-		testName     = req.TestName
-		pollConfig   = req.PollConfig
-		payload      = req.Payload
-	)
-
-	sourceType = config.NormalizeSourceType(sourceType)
+	sourceType := config.NormalizeSourceType(req.SourceType)
 	if err := config.ValidateSourceType(sourceType); err != nil {
 		return handleError{
 			err:            err,
@@ -216,25 +203,25 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 		)
 	}
 
-	repoName := git.GetRepoName(sourceRef)
+	repoName := git.GetRepoName(req.SourceRef)
 	if sourceType == config.SourceTypeOCI {
-		repoName = oci.RepositoryNameFromArtifact(sourceRef)
+		repoName = oci.RepositoryNameFromArtifact(req.SourceRef)
 	}
 
 	logField := logEntityForSourceType(sourceType)
 
 	logValue := repoName
 	if sourceType == config.SourceTypeOCI {
-		logValue = strings.TrimSpace(sourceRef)
+		logValue = strings.TrimSpace(req.SourceRef)
 	}
 
 	jobLog = jobLog.With(
 		slog.String(logField, logValue),
 	)
 
-	if customTarget != "" {
-		jobLog = jobLog.With(slog.String("target", customTarget))
-		metadata.Target = strings.TrimSpace(customTarget)
+	if req.CustomTarget != "" {
+		jobLog = jobLog.With(slog.String("target", req.CustomTarget))
+		req.Metadata.Target = strings.TrimSpace(req.CustomTarget)
 	}
 
 	if strings.Contains(repoName, "..") {
@@ -279,19 +266,19 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 		}
 	}
 
-	resolvedRevision := strings.TrimSpace(payload.Digest)
+	resolvedRevision := strings.TrimSpace(req.Payload.Digest)
 	ociTrusted := sourceType != config.SourceTypeOCI
 
 	switch sourceType {
 	case config.SourceTypeGit:
 		// Skip the network fetch when the payload carries the exact commit SHA and
 		// the local repo HEAD already matches it (e.g. webhook re-deliveries).
-		if sha := strings.TrimSpace(payload.CommitSHAString()); sha != "" {
+		if sha := strings.TrimSpace(req.Payload.CommitSHAString()); sha != "" {
 			if matches, _ := git.HeadMatchesCommit(internalRepoPath, sha); matches {
 				jobLog.Debug("skipping fetch, repository already at requested commit", slog.String("commit", sha))
 
 				if repo, openErr := git.OpenRepository(internalRepoPath); openErr == nil {
-					if latestCommit, latestErr := git.GetLatestCommit(repo, ref); latestErr == nil {
+					if latestCommit, latestErr := git.GetLatestCommit(repo, req.Ref); latestErr == nil {
 						resolvedRevision = strings.TrimSpace(latestCommit)
 					}
 				}
@@ -301,12 +288,12 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 		}
 
 		repo, err := git.CloneOrUpdateRepository(jobLog,
-			sourceRef, ref, internalRepoPath, externalRepoPath,
-			private, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken,
+			req.SourceRef, req.Ref, internalRepoPath, externalRepoPath,
+			req.Private, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken,
 			appConfig.SkipTLSVerification, appConfig.HttpProxy, appConfig.GitCloneSubmodules, appConfig.GitCloneDepth,
 		)
 		if err != nil {
-			postEarlyCommitStatus(ctx, jobLog, appConfig, sourceType, sourceRef, resolvedRevision, payload, commitstatus.DeployContext, earlyFailureCommitStatusDescription(err))
+			postEarlyCommitStatus(ctx, jobLog, appConfig, sourceType, req.SourceRef, resolvedRevision, req.Payload, commitstatus.DeployContext, earlyFailureCommitStatusDescription(err))
 
 			return handleError{
 				err:            err,
@@ -315,12 +302,12 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 			}
 		}
 
-		latestCommit, err := git.GetLatestCommit(repo, ref)
+		latestCommit, err := git.GetLatestCommit(repo, req.Ref)
 		if err == nil {
 			resolvedRevision = strings.TrimSpace(latestCommit)
 		}
 	case config.SourceTypeOCI:
-		resolvedDigest, err := oci.ResolveDigest(ctx, sourceRef, strings.TrimSpace(payload.Digest))
+		resolvedDigest, err := oci.ResolveDigest(ctx, req.SourceRef, strings.TrimSpace(req.Payload.Digest))
 		if err != nil {
 			return handleError{
 				err:            err,
@@ -329,7 +316,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 			}
 		}
 
-		if err := oci.VerifyWithCosign(ctx, sourceRef, resolvedDigest, appConfig.OciTrustPolicy, config.OciTrustPolicyOverride{}, appConfig.OciVerifyMaxWorkers); err != nil {
+		if err := oci.VerifyWithCosign(ctx, req.SourceRef, resolvedDigest, appConfig.OciTrustPolicy, config.OciTrustPolicyOverride{}, appConfig.OciVerifyMaxWorkers); err != nil {
 			return handleError{
 				err:            err,
 				msg:            "failed OCI signature verification",
@@ -338,8 +325,8 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 		}
 
 		pullResult, err := oci.PullAndExtract(ctx,
-			sourceRef, resolvedDigest, config.OciArtifactLayoutV1,
-			internalRepoPath, customTarget)
+			req.SourceRef, resolvedDigest, config.OciArtifactLayoutV1,
+			internalRepoPath, req.CustomTarget)
 		if err != nil {
 			return handleError{
 				err:            err,
@@ -350,21 +337,21 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 
 		resolvedRevision = pullResult.Digest
 		ociTrusted = true
-		payload.Source = webhook.PayloadSourceOCI
-		payload.Artifact = sourceRef
-		payload.Digest = pullResult.Digest
+		req.Payload.Source = webhook.PayloadSourceOCI
+		req.Payload.Artifact = req.SourceRef
+		req.Payload.Digest = pullResult.Digest
 
-		payload.Trigger = pullResult.Digest
-		if payload.FullName == "" {
-			payload.FullName = repoName
+		req.Payload.Trigger = pullResult.Digest
+		if req.Payload.FullName == "" {
+			req.Payload.FullName = repoName
 		}
 
-		if payload.Name == "" {
-			payload.Name = path.Base(repoName)
+		if req.Payload.Name == "" {
+			req.Payload.Name = path.Base(repoName)
 		}
 
-		if payload.WebURL == "" {
-			payload.WebURL = sourceRef
+		if req.Payload.WebURL == "" {
+			req.Payload.WebURL = req.SourceRef
 		}
 	}
 
@@ -382,11 +369,11 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 		GitCloneDepth:           appConfig.GitCloneDepth,
 	}
 
-	switch jobTrigger {
+	switch req.JobTrigger {
 	case stages.JobTriggerWebhook:
-		deployConfigs, err = deploy.GetConfigs(internalRepoPath, appConfig.DeployConfigBaseDir, customTarget, payload.Ref, gitOpts)
+		deployConfigs, err = deploy.GetConfigs(internalRepoPath, appConfig.DeployConfigBaseDir, req.CustomTarget, req.Payload.Ref, gitOpts)
 		if err != nil {
-			postEarlyCommitStatus(ctx, jobLog, appConfig, sourceType, sourceRef, resolvedRevision, payload, commitstatus.DeployContext, earlyFailureCommitStatusDescription(err))
+			postEarlyCommitStatus(ctx, jobLog, appConfig, sourceType, req.SourceRef, resolvedRevision, req.Payload, commitstatus.DeployContext, earlyFailureCommitStatusDescription(err))
 
 			return handleError{
 				err:            err,
@@ -395,9 +382,9 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 			}
 		}
 	case stages.JobTriggerPoll:
-		deployConfigs, err = deploy.ResolveConfigs(pollConfig.Deployments, pollConfig.CustomTarget, ref, internalRepoPath, appConfig.DeployConfigBaseDir, gitOpts)
+		deployConfigs, err = deploy.ResolveConfigs(req.PollConfig.Deployments, req.PollConfig.CustomTarget, req.Ref, internalRepoPath, appConfig.DeployConfigBaseDir, gitOpts)
 		if err != nil {
-			postEarlyCommitStatus(ctx, jobLog, appConfig, sourceType, sourceRef, resolvedRevision, payload, commitstatus.DeployContext, earlyFailureCommitStatusDescription(err))
+			postEarlyCommitStatus(ctx, jobLog, appConfig, sourceType, req.SourceRef, resolvedRevision, req.Payload, commitstatus.DeployContext, earlyFailureCommitStatusDescription(err))
 
 			return handleError{
 				err:            err,
@@ -407,7 +394,7 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 		}
 	default:
 		return handleError{
-			err:            fmt.Errorf("unsupported job trigger: %s", jobTrigger),
+			err:            fmt.Errorf("unsupported job trigger: %s", req.JobTrigger),
 			msg:            "unsupported job trigger",
 			httpStatusCode: http.StatusBadRequest,
 		}
@@ -415,22 +402,22 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 
 	// For OCI sources, the deploy config's reference must reflect the actual artifact tag that
 	// triggered this deployment (e.g. "latest"), overriding any reference baked into the config file.
-	if sourceType == config.SourceTypeOCI && ref != "" {
+	if sourceType == config.SourceTypeOCI && req.Ref != "" {
 		for _, cfg := range deployConfigs {
-			cfg.Reference = ref
+			cfg.Reference = req.Ref
 		}
 	}
 
 	for _, cfg := range deployConfigs {
-		cfg.Internal.ConfigTarget = strings.TrimSpace(customTarget)
-		if metadata.DeploymentTargetObserver != nil {
-			metadata.DeploymentTargetObserver(cfg.Name, cfg.Context)
+		cfg.Internal.ConfigTarget = strings.TrimSpace(req.CustomTarget)
+		if req.Metadata.DeploymentTargetObserver != nil {
+			req.Metadata.DeploymentTargetObserver(cfg.Name, cfg.Context)
 		}
 	}
 
 	repoData := stages.RepositoryData{
 		Source:       sourceType,
-		SourceUrl:    sourceRef,
+		SourceUrl:    req.SourceRef,
 		Name:         repoName,
 		PathInternal: internalRepoPath,
 		PathExternal: externalRepoPath,
@@ -448,12 +435,12 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 
 	if err := reconciliationManager.Deploy(ctx, reconciliation.DeployRequest{
 		Logger:        jobLog,
-		Metadata:      metadata,
-		JobTrigger:    jobTrigger,
+		Metadata:      req.Metadata,
+		JobTrigger:    req.JobTrigger,
 		Repository:    repoData,
 		DeployConfigs: deployConfigs,
-		Payload:       &payload,
-		TestName:      testName,
+		Payload:       &req.Payload,
+		TestName:      req.TestName,
 	}); err != nil {
 		if errors.Is(err, stages.ErrWebhookFilterMismatch) {
 			return err

--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -16,16 +16,15 @@ import (
 	"github.com/kimdre/doco-cd/internal/config"
 
 	"github.com/kimdre/doco-cd/internal/commitstatus"
+	"github.com/kimdre/doco-cd/internal/common/validation"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/config/poll"
-	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/reconciliation"
-	"github.com/kimdre/doco-cd/internal/secretprovider"
 	"github.com/kimdre/doco-cd/internal/source/oci"
 	"github.com/kimdre/doco-cd/internal/stages"
 	"github.com/kimdre/doco-cd/internal/webhook"
@@ -148,20 +147,51 @@ func postEarlyCommitStatus(ctx context.Context, jobLog *slog.Logger, appConfig *
 	}
 }
 
+// handleRequest bundles handle's per-call, per-deployment-request input: the source location and
+// its trigger/reference/visibility, notification metadata, an optional custom deploy target,
+// an optional test identity, poll configuration (used only for poll-triggered requests), and the
+// parsed webhook payload (zero value for non-webhook triggers).
+type handleRequest struct {
+	JobTrigger   stages.JobTrigger `validate:"required,oneof=webhook poll"`
+	SourceType   config.SourceType `validate:"required"`
+	SourceRef    string            `validate:"required"`
+	Ref          string
+	Private      bool
+	Metadata     notification.Metadata
+	CustomTarget string
+	TestName     string
+	PollConfig   poll.Config
+	Payload      webhook.ParsedPayload
+}
+
 func handle(ctx context.Context, jobLog *slog.Logger,
 	reconciliationManager *reconciliation.Manager,
 	appConfig *app.Config,
 	dataMountPoint container.MountPoint,
-	secretProvider secretprovider.SecretProvider,
 	dockerCli command.Cli,
-	contexts *docker.ContextRegistry,
-	jobTrigger stages.JobTrigger,
-	sourceType config.SourceType, sourceRef string, ref string, private bool,
-	metadata notification.Metadata,
-	customTarget string, testName string,
-	pollConfig poll.Config,
-	payload webhook.ParsedPayload,
+	req handleRequest,
 ) error {
+	if err := validation.Validate(req); err != nil {
+		return handleError{
+			err:            err,
+			msg:            "invalid deployment request",
+			httpStatusCode: http.StatusInternalServerError,
+		}
+	}
+
+	var (
+		jobTrigger   = req.JobTrigger
+		sourceType   = req.SourceType
+		sourceRef    = req.SourceRef
+		ref          = req.Ref
+		private      = req.Private
+		metadata     = req.Metadata
+		customTarget = req.CustomTarget
+		testName     = req.TestName
+		pollConfig   = req.PollConfig
+		payload      = req.Payload
+	)
+
 	sourceType = config.NormalizeSourceType(sourceType)
 	if err := config.ValidateSourceType(sourceType); err != nil {
 		return handleError{
@@ -416,9 +446,15 @@ func handle(ctx context.Context, jobLog *slog.Logger,
 		}
 	}
 
-	if err := reconciliationManager.Deploy(ctx, jobLog, appConfig,
-		dataMountPoint, dockerCli, contexts, secretProvider, metadata, jobTrigger,
-		repoData, deployConfigs, &payload, testName); err != nil {
+	if err := reconciliationManager.Deploy(ctx, reconciliation.DeployRequest{
+		Logger:        jobLog,
+		Metadata:      metadata,
+		JobTrigger:    jobTrigger,
+		Repository:    repoData,
+		DeployConfigs: deployConfigs,
+		Payload:       &payload,
+		TestName:      testName,
+	}); err != nil {
 		if errors.Is(err, stages.ErrWebhookFilterMismatch) {
 			return err
 		}

--- a/cmd/doco-cd/handler.go
+++ b/cmd/doco-cd/handler.go
@@ -153,8 +153,8 @@ func postEarlyCommitStatus(ctx context.Context, jobLog *slog.Logger, appConfig *
 // parsed webhook payload (zero value for non-webhook triggers).
 type handleRequest struct {
 	JobTrigger   stages.JobTrigger `validate:"required,oneof=webhook poll"`
-	SourceType   config.SourceType `validate:"required"`
-	SourceRef    string            `validate:"required"`
+	SourceType   config.SourceType
+	SourceRef    string `validate:"required"`
 	Ref          string
 	Private      bool
 	Metadata     notification.Metadata

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -12,10 +12,8 @@ import (
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/poll"
-	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/reconciliation"
-	"github.com/kimdre/doco-cd/internal/secretprovider"
 	"github.com/kimdre/doco-cd/internal/stages"
 
 	"github.com/kimdre/doco-cd/internal/git"
@@ -281,7 +279,7 @@ func pollError(jobLog *slog.Logger, metadata notification.Metadata, err error) {
 // "poll-watch" when triggered by the local repository filesystem watcher) and is
 // reported in the "polling <entity>" log line's trigger.event field.
 func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config, dataMountPoint container.MountPoint,
-	dockerCli command.Cli, contexts *docker.ContextRegistry, logger *slog.Logger, metadata notification.Metadata, secretProvider secretprovider.SecretProvider,
+	dockerCli command.Cli, logger *slog.Logger, metadata notification.Metadata,
 	triggerReason string, reconciliationManager *reconciliation.Manager,
 ) error {
 	startTime := time.Now()
@@ -334,10 +332,19 @@ func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config,
 	}
 
 	deployErr := handle(ctx, jobLog, reconciliationManager,
-		appConfig, dataMountPoint, secretProvider, dockerCli, contexts,
-		stages.JobTriggerPoll, sourceType, sourceRef, pollReference, false,
-		metadata, pollConfig.CustomTarget, "",
-		pollConfig, webhook.ParsedPayload{},
+		appConfig, dataMountPoint, dockerCli,
+		handleRequest{
+			JobTrigger:   stages.JobTriggerPoll,
+			SourceType:   sourceType,
+			SourceRef:    sourceRef,
+			Ref:          pollReference,
+			Private:      false,
+			Metadata:     metadata,
+			CustomTarget: pollConfig.CustomTarget,
+			TestName:     "",
+			PollConfig:   pollConfig,
+			Payload:      webhook.ParsedPayload{},
+		},
 	)
 
 	nextRun := time.Now().Add(pollConfig.Interval).Format(time.RFC3339)

--- a/cmd/doco-cd/handler_poll_test.go
+++ b/cmd/doco-cd/handler_poll_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/controlplane"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/notification"
+	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 	"github.com/kimdre/doco-cd/internal/secretprovider/bitwardensecretsmanager"
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
@@ -434,15 +435,20 @@ func TestRunPoll(t *testing.T) {
 	}
 
 	// Run initial poll
-	reconciliationManager := newTestReconciliationManager(t)
-	if err := RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, nil, log.With(), metadata, secretProvider, pollTriggerDefault, reconciliationManager); err != nil {
+	reconciliationManager := newTestReconciliationManager(t, reconciliation.Dependencies{
+		AppConfig:      appConfig,
+		DataMountPoint: dataMountPoint,
+		DockerCLI:      dockerCli,
+		SecretProvider: secretProvider,
+	})
+	if err := RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, log.With(), metadata, pollTriggerDefault, reconciliationManager); err != nil {
 		t.Fatalf("Initial poll deployment failed: %v", err)
 	}
 
 	pollConfig.Reference = "destroy"
 
 	// Run the second poll to destroy
-	if err := RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, nil, log.With(), metadata, secretProvider, pollTriggerDefault, reconciliationManager); err != nil {
+	if err := RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, log.With(), metadata, pollTriggerDefault, reconciliationManager); err != nil {
 		t.Fatalf("Second poll deployment failed: %v", err)
 	}
 }

--- a/cmd/doco-cd/handler_test.go
+++ b/cmd/doco-cd/handler_test.go
@@ -9,11 +9,23 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kimdre/doco-cd/internal/common/validation"
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/git"
+	"github.com/kimdre/doco-cd/internal/stages"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
+
+func TestHandleRequestAllowsDefaultSourceType(t *testing.T) {
+	err := validation.Validate(handleRequest{
+		JobTrigger: stages.JobTriggerWebhook,
+		SourceRef:  "https://github.com/owner/repo.git",
+	})
+	if err != nil {
+		t.Fatalf("handleRequest with default source type must validate: %v", err)
+	}
+}
 
 func TestEarlyFailureCommitStatusDescription(t *testing.T) {
 	tests := []struct {

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -316,8 +316,7 @@ func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any
 // handleEvent executes the deployment process for a given webhook event.
 func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter, appConfig *app.Config,
 	dataMountPoint container.MountPoint, payload webhook.ParsedPayload, customTarget string, metadata notification.Metadata,
-	dockerCli command.Cli, contexts *docker.ContextRegistry, secretProvider secretprovider.SecretProvider,
-	testName string,
+	dockerCli command.Cli, testName string,
 	reconciliationManager *reconciliation.Manager,
 ) (controlplane.RunResult, error) {
 	startTime := time.Now()
@@ -403,9 +402,19 @@ func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	}
 
 	deployErr := handle(ctx, jobLog, reconciliationManager,
-		appConfig, dataMountPoint, secretProvider, dockerCli, contexts,
-		stages.JobTriggerWebhook, sourceType, sourceRef, payload.Ref, payload.Private,
-		metadata, customTarget, testName, poll.Config{}, payload,
+		appConfig, dataMountPoint, dockerCli,
+		handleRequest{
+			JobTrigger:   stages.JobTriggerWebhook,
+			SourceType:   sourceType,
+			SourceRef:    sourceRef,
+			Ref:          payload.Ref,
+			Private:      payload.Private,
+			Metadata:     metadata,
+			CustomTarget: customTarget,
+			TestName:     testName,
+			PollConfig:   poll.Config{},
+			Payload:      payload,
+		},
 	)
 	if errors.Is(deployErr, stages.ErrWebhookFilterMismatch) {
 		msg := "deployment skipped, webhook filter did not match"
@@ -582,7 +591,7 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 
 		defer repoLock.Unlock()
 
-		return handleEvent(ctx, jobLog, w, h.appConfig, h.dataMountPoint, payload, customTarget, metadata, h.dockerCli, h.contexts, h.secretProvider, h.testName, h.reconciliation)
+		return handleEvent(ctx, jobLog, w, h.appConfig, h.dataMountPoint, payload, customTarget, metadata, h.dockerCli, h.testName, h.reconciliation)
 	}
 
 	mode := controlplane.RunAsynchronous

--- a/cmd/doco-cd/handler_webhook_test.go
+++ b/cmd/doco-cd/handler_webhook_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/encryption"
 	"github.com/kimdre/doco-cd/internal/lock"
 	"github.com/kimdre/doco-cd/internal/logger"
+	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
 
@@ -288,10 +289,14 @@ func TestHandlerData_WebhookHandler(t *testing.T) {
 			Destination: tmpDir,
 			Mode:        "rw",
 		},
-		log:            log,
-		testName:       stackName,
-		reconciliation: newTestReconciliationManager(t),
+		log:      log,
+		testName: stackName,
 	}
+	h.reconciliation = newTestReconciliationManager(t, reconciliation.Dependencies{
+		AppConfig:      appConfig,
+		DataMountPoint: h.dataMountPoint,
+		DockerCLI:      dockerCli,
+	})
 	h.controlPlaneRuns = newTestControlPlaneRuns(t, testControlPlaneRunsOptions{
 		appConfig:      appConfig,
 		dataMountPoint: h.dataMountPoint,

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -349,6 +349,11 @@ func run() error {
 	}
 
 	reconciliationManager, err := reconciliation.NewManager(reconciliation.Dependencies{
+		AppConfig:                c,
+		DataMountPoint:           dataMountPoint,
+		DockerCLI:                dockerCli,
+		Contexts:                 contexts,
+		SecretProvider:           secretProvider,
 		MaxConcurrentDeployments: c.MaxConcurrentDeployments,
 	})
 	if err != nil {
@@ -375,11 +380,11 @@ func run() error {
 				DockerCLI:      dockerCli,
 				Contexts:       contexts,
 				Runner: func(ctx context.Context, pollConfig poll.Config, appConfig *app.Config, dataMountPoint container.MountPoint,
-					dockerCli command.Cli, contexts *docker.ContextRegistry, logger *slog.Logger, metadata notification.Metadata,
-					secretProvider secretprovider.SecretProvider, triggerReason string,
+					dockerCli command.Cli, _ *docker.ContextRegistry, logger *slog.Logger, metadata notification.Metadata,
+					_ secretprovider.SecretProvider, triggerReason string,
 				) error {
-					return RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, contexts, logger, metadata,
-						secretProvider, triggerReason, reconciliationManager)
+					return RunPoll(ctx, pollConfig, appConfig, dataMountPoint, dockerCli, logger, metadata,
+						triggerReason, reconciliationManager)
 				},
 			},
 		},

--- a/cmd/doco-cd/main_test.go
+++ b/cmd/doco-cd/main_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/encryption"
 	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/logger"
+	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
 
@@ -435,7 +436,12 @@ env_files:
 				Repository: git.GetRepoName(tc.payload.CloneURL),
 				Revision:   notification.GetRevision(tc.payload.Ref, tc.payload.CommitSHAString()),
 			}
-			reconciliationManager := newTestReconciliationManager(t)
+			reconciliationManager := newTestReconciliationManager(t, reconciliation.Dependencies{
+				AppConfig:      appConfig,
+				DataMountPoint: testMountPoint,
+				DockerCLI:      dockerCli,
+				SecretProvider: secretProvider,
+			})
 
 			err = retry.New(
 				retry.Attempts(3),
@@ -454,8 +460,6 @@ env_files:
 					tc.customTarget,
 					metadata,
 					dockerCli,
-					nil,
-					secretProvider,
 					stackName,
 					reconciliationManager,
 				); err != nil {

--- a/internal/docker/compose_deploy.go
+++ b/internal/docker/compose_deploy.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/common/types/set"
 	"github.com/kimdre/doco-cd/internal/common/types/slice"
+	"github.com/kimdre/doco-cd/internal/common/validation"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker/registryauth"
 	gitInternal "github.com/kimdre/doco-cd/internal/git"
@@ -310,13 +311,49 @@ func resolveDeploymentMetricsDeploymentLabel(deployName string) string {
 }
 
 // DeployStack deploys the stack using the provided deployment configuration.
-func DeployStack(
-	jobLog *slog.Logger, externalRepoPath string, ctx *context.Context,
-	dockerCli command.Cli, payload *webhook.ParsedPayload, deployConfig *deploy.Config,
-	detectedChanges []Change, needSignal []SignalService, latestCommit, appVersion string,
-	globalSwarmConfigRetention int, globalSwarmSecretRetention int, swarmMode bool,
-	hashNormMap map[string]string,
-) error {
+// DeployRequest bundles DeployStack's per-deployment input: the job logger, the external
+// repository path used to resolve compose file locations, the Docker CLI, the parsed webhook
+// payload (may be nil for non-webhook triggers), the resolved deploy config, detected service
+// changes and signal targets from change detection, the latest commit, the running app version,
+// Swarm config/secret retention counts, whether Swarm mode is active, and the PKI role
+// normalization map.
+type DeployRequest struct {
+	JobLog                     *slog.Logger `validate:"required,nostructlevel"`
+	ExternalRepoPath           string       `validate:"required"`
+	DockerCLI                  command.Cli  `validate:"required,nostructlevel"`
+	Payload                    *webhook.ParsedPayload
+	DeployConfig               *deploy.Config `validate:"required,nostructlevel"`
+	DetectedChanges            []Change
+	NeedSignal                 []SignalService
+	LatestCommit               string
+	AppVersion                 string `validate:"required"`
+	GlobalSwarmConfigRetention int
+	GlobalSwarmSecretRetention int
+	SwarmMode                  bool
+	HashNormMap                map[string]string
+}
+
+func DeployStack(ctx context.Context, req DeployRequest) error {
+	if err := validation.Validate(req); err != nil {
+		return fmt.Errorf("validate deploy stack request: %w", err)
+	}
+
+	var (
+		jobLog                     = req.JobLog
+		externalRepoPath           = req.ExternalRepoPath
+		dockerCli                  = req.DockerCLI
+		payload                    = req.Payload
+		deployConfig               = req.DeployConfig
+		detectedChanges            = req.DetectedChanges
+		needSignal                 = req.NeedSignal
+		latestCommit               = req.LatestCommit
+		appVersion                 = req.AppVersion
+		globalSwarmConfigRetention = req.GlobalSwarmConfigRetention
+		globalSwarmSecretRetention = req.GlobalSwarmSecretRetention
+		swarmMode                  = req.SwarmMode
+		hashNormMap                = req.HashNormMap
+	)
+
 	startTime := time.Now()
 	repositoryLabel := resolveDeploymentMetricsRepositoryLabel(payload)
 	deploymentLabel := resolveDeploymentMetricsDeploymentLabel(deployConfig.Name)
@@ -349,7 +386,7 @@ func DeployStack(
 
 	deploymentPhase.Set("loading compose configuration")
 
-	project, err := LoadCompose(*ctx, dockerCli, externalRepoPath, externalWorkingDir, deployConfig.Name, deployConfig.ComposeFiles,
+	project, err := LoadCompose(ctx, dockerCli, externalRepoPath, externalWorkingDir, deployConfig.Name, deployConfig.ComposeFiles,
 		deployConfig.EnvFiles, deployConfig.Profiles, deployConfig.Internal.Environment)
 	if err != nil {
 		return fmt.Errorf("failed to load compose config: %w", err)
@@ -362,7 +399,7 @@ func DeployStack(
 	if deployConfig.WaitRunningJobs {
 		deploymentPhase.Set("waiting for running scheduled jobs")
 
-		if err = waitForRunningJobs(*ctx, dockerCli, deployConfig, project, stackLog, swarmMode); err != nil {
+		if err = waitForRunningJobs(ctx, dockerCli, deployConfig, project, stackLog, swarmMode); err != nil {
 			return err
 		}
 	}
@@ -412,12 +449,12 @@ func DeployStack(
 		addSwarmConfigLabels(cfg, deployConfig, payload, externalWorkingDir, appVersion, timestamp, latestCommit)
 		addSwarmSecretLabels(cfg, deployConfig, payload, externalWorkingDir, appVersion, timestamp, latestCommit)
 
-		if err = removeMismatchedRecreatableVolumes(*ctx, dockerCli.Client(), deployConfig.Name, project); err != nil {
+		if err = removeMismatchedRecreatableVolumes(ctx, dockerCli.Client(), deployConfig.Name, project); err != nil {
 			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 			return fmt.Errorf("failed to remove mismatched recreatable volumes: %w", err)
 		}
 
-		err = DeploySwarmStack(*ctx, dockerCli, cfg, opts)
+		err = DeploySwarmStack(ctx, dockerCli, cfg, opts)
 		if err != nil {
 			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 
@@ -429,7 +466,7 @@ func DeployStack(
 		if swarmConfigRetention >= 0 {
 			deploymentPhase.Set("pruning stack configs")
 
-			err = PruneStackConfigs(*ctx, dockerCli.Client(), deployConfig.Name, swarmConfigRetention)
+			err = PruneStackConfigs(ctx, dockerCli.Client(), deployConfig.Name, swarmConfigRetention)
 			if err != nil {
 				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 
@@ -444,7 +481,7 @@ func DeployStack(
 		if swarmSecretRetention >= 0 {
 			deploymentPhase.Set("pruning stack secrets")
 
-			err = PruneStackSecrets(*ctx, dockerCli.Client(), deployConfig.Name, swarmSecretRetention)
+			err = PruneStackSecrets(ctx, dockerCli.Client(), deployConfig.Name, swarmSecretRetention)
 			if err != nil {
 				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 
@@ -461,7 +498,7 @@ func DeployStack(
 
 			stackLog.Info("prune images on swarm nodes")
 
-			err = RunImagePruneJob(*ctx, dockerCli)
+			err = RunImagePruneJob(ctx, dockerCli)
 			if err != nil {
 				prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()
 
@@ -504,7 +541,7 @@ func DeployStack(
 
 		deploymentPhase.Set("deploying compose stack")
 
-		err = deployCompose(*ctx, dockerCli, project, deployConfig, recreateMode,
+		err = deployCompose(ctx, dockerCli, project, deployConfig, recreateMode,
 			forcedServices.ToSlice(), needSignal, deploymentPhase.Set)
 		if err != nil {
 			prometheus.DeploymentErrorsTotal.WithLabelValues(repositoryLabel, deploymentLabel, contextLabel).Inc()

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -173,6 +173,14 @@ func waitForSingleRunningProjectContainerID(ctx context.Context, t *testing.T, c
 	return containerID, err
 }
 
+func TestDeployStackValidatesRequest(t *testing.T) {
+	t.Parallel()
+
+	if err := DeployStack(t.Context(), DeployRequest{}); err == nil {
+		t.Fatal("DeployStack() error = nil, want request validation error")
+	}
+}
+
 func TestDeployCompose(t *testing.T) {
 	encryption.SetupAgeKeyEnvVar(t)
 
@@ -337,8 +345,16 @@ compose_files:
 				return strings.Contains(strings.ToLower(err.Error()), ErrNoSuchImage.Error())
 			}),
 		).Do(func() error {
-			return DeployStack(jobLog, repoPath, &ctx, dockerCli, &p, deployConf,
-				nil, nil, latestCommit, "dev", 0, 0, swarm.GetModeEnabled(), nil)
+			return DeployStack(ctx, DeployRequest{
+				JobLog:           jobLog,
+				ExternalRepoPath: repoPath,
+				DockerCLI:        dockerCli,
+				Payload:          &p,
+				DeployConfig:     deployConf,
+				LatestCommit:     latestCommit,
+				AppVersion:       "dev",
+				SwarmMode:        swarm.GetModeEnabled(),
+			})
 		})
 		if err != nil {
 			t.Fatalf("failed to deploy stack: %v", err)

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -9,38 +9,27 @@ import (
 	"sync"
 
 	"github.com/docker/cli/cli/command"
-	"github.com/moby/moby/api/types/container"
 
+	"github.com/kimdre/doco-cd/internal/common/validation"
 	"github.com/kimdre/doco-cd/internal/config"
-	"github.com/kimdre/doco-cd/internal/config/app"
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker"
 	dockerSwarm "github.com/kimdre/doco-cd/internal/docker/swarm"
 
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
-	"github.com/kimdre/doco-cd/internal/secretprovider"
 	"github.com/kimdre/doco-cd/internal/stages"
 	"github.com/kimdre/doco-cd/internal/test"
-	"github.com/kimdre/doco-cd/internal/webhook"
 )
 
 var ErrOCIArtifactNotVerified = errors.New("OCI artifact is not verified")
 
-func (m *Manager) Deploy(ctx context.Context,
-	jobLog *slog.Logger,
-	appConfig *app.Config,
-	dataMountPoint container.MountPoint,
-	dockerCli command.Cli,
-	contexts *docker.ContextRegistry,
-	secretProvider secretprovider.SecretProvider,
-	metadata notification.Metadata,
-	jobTrigger stages.JobTrigger,
-	repoData stages.RepositoryData,
-	deployConfigs []*deployConfig.Config,
-	payload *webhook.ParsedPayload,
-	testName string,
-) error {
+// Deploy validates req and runs a reconciliation deployment using the Manager's stable
+// dependencies (app config, Docker CLI, context registry, secret provider) together with req's
+// per-run trigger, repository, deploy configs, and notification metadata. Unless req.TestName is
+// set, it also registers a long-lived reconciliation job that watches for drift after the
+// initial deployment.
+func (m *Manager) Deploy(ctx context.Context, req DeployRequest) error {
 	if m == nil {
 		return errors.New("reconciliation manager is required")
 	}
@@ -50,81 +39,57 @@ func (m *Manager) Deploy(ctx context.Context,
 	}
 	defer m.deployWG.Done()
 
-	err := m.deploy(ctx, jobLog, appConfig,
-		dataMountPoint, dockerCli, contexts, secretProvider, metadata,
-		jobTrigger, repoData, deployConfigs, payload, testName)
+	if err := validation.Validate(req); err != nil {
+		return fmt.Errorf("validate deploy request: %w", err)
+	}
+
+	err := m.deploy(ctx, req)
 
 	// Skip long-lived reconciliation listeners for test-triggered deployments.
 	// Test runs use testName only to make stacks unique and do not need background
 	// Docker event watchers that can outlive the test and race with TempDir cleanup.
-	if testName == "" {
-		m.addJob(ctx, jobInfo{
-			appConfig:      appConfig,
-			dataMountPoint: dataMountPoint,
-			dockerCli:      dockerCli,
-			contexts:       contexts,
-			secretProvider: secretProvider,
-			log:            jobLog,
-			metadata:       metadata,
-			jobTrigger:     jobTrigger,
-			repoData:       repoData,
-			deployConfigs:  deployConfigs,
-			payload:        payload,
-			testName:       testName,
-		})
+	if req.TestName == "" {
+		m.addJob(ctx, req)
 	}
 
 	return err
 }
 
-func (m *Manager) deploy(ctx context.Context,
-	jobLog *slog.Logger,
-	appConfig *app.Config,
-	dataMountPoint container.MountPoint,
-	dockerCli command.Cli,
-	contexts *docker.ContextRegistry,
-	secretProvider secretprovider.SecretProvider,
-	metadata notification.Metadata,
-	jobTrigger stages.JobTrigger,
-	repoData stages.RepositoryData,
-	deployConfigs []*deployConfig.Config,
-	payload *webhook.ParsedPayload,
-	testName string,
-) error {
-	if repoData.Source == config.SourceTypeOCI && !repoData.OCITrusted {
+func (m *Manager) deploy(ctx context.Context, req DeployRequest) error {
+	if req.Repository.Source == config.SourceTypeOCI && !req.Repository.OCITrusted {
 		return fmt.Errorf("%w: refusing to run reconciliation cleanup before trust-policy verification", ErrOCIArtifactNotVerified)
 	}
 
 	configsByContext := map[string][]*deployConfig.Config{}
 
-	for _, dc := range deployConfigs {
+	for _, dc := range req.DeployConfigs {
 		contextName := docker.NormalizeContextName(dc.Context)
 		configsByContext[contextName] = append(configsByContext[contextName], dc)
 	}
 
 	dockerQuiet := false
-	if appConfig != nil {
-		dockerQuiet = appConfig.DockerQuietDeploy
+	if m.appConfig != nil {
+		dockerQuiet = m.appConfig.DockerQuietDeploy
 	}
 
 	for contextName, groupedConfigs := range configsByContext {
-		entry := resolveDeployContext(ctx, contexts, dockerCli, dockerQuiet, contextName)
+		entry := resolveDeployContext(ctx, m.contexts, m.dockerCli, dockerQuiet, contextName)
 		if entry.err != nil {
 			// Isolate per-context failures: an unreachable context must not block
 			// cleanup/deploy for other (healthy) contexts. handleDeploy below fails
 			// only the affected deployments.
-			jobLog.Error("failed to create docker client for context, skipping cleanup for it",
+			req.Logger.Error("failed to create docker client for context, skipping cleanup for it",
 				slog.String("context", docker.DisplayContextName(contextName)), logger.ErrAttr(entry.err))
 
 			continue
 		}
 
 		for swarmMode, modeConfigs := range groupDeployConfigsByMode(groupedConfigs, entry.swarmMode) {
-			if err := cleanupObsoleteAutoDiscoveredContainers(ctx, jobLog,
-				entry.cli, swarmMode, contextName, repoData.SourceUrl,
+			if err := cleanupObsoleteAutoDiscoveredContainers(ctx, req.Logger,
+				entry.cli, swarmMode, contextName, req.Repository.SourceUrl,
 				modeConfigs,
-				metadata); err != nil {
-				jobLog.Error("failed to clean up obsolete auto-discovered containers for context",
+				req.Metadata); err != nil {
+				req.Logger.Error("failed to clean up obsolete auto-discovered containers for context",
 					slog.String("context", docker.DisplayContextName(contextName)),
 					slog.Bool("swarm_mode", swarmMode),
 					logger.ErrAttr(err))
@@ -136,34 +101,18 @@ func (m *Manager) deploy(ctx context.Context,
 		}
 	}
 
-	return m.handleDeploy(ctx, jobLog, appConfig,
-		dataMountPoint, dockerCli, contexts, secretProvider, metadata.JobID, jobTrigger,
-		repoData, deployConfigs, payload, testName, metadata)
+	return m.handleDeploy(ctx, req)
 }
 
-func (m *Manager) handleDeploy(ctx context.Context,
-	jobLog *slog.Logger,
-	appConfig *app.Config,
-	dataMountPoint container.MountPoint,
-	dockerCli command.Cli,
-	contexts *docker.ContextRegistry,
-	secretProvider secretprovider.SecretProvider,
-	jobID string,
-	jobTrigger stages.JobTrigger,
-	repoData stages.RepositoryData,
-	deployConfigs []*deployConfig.Config,
-	payload *webhook.ParsedPayload,
-	testName string,
-	metadata notification.Metadata,
-) error {
+func (m *Manager) handleDeploy(ctx context.Context, req DeployRequest) error {
 	dockerQuiet := false
-	if appConfig != nil {
-		dockerQuiet = appConfig.DockerQuietDeploy
+	if m.appConfig != nil {
+		dockerQuiet = m.appConfig.DockerQuietDeploy
 	}
 
 	// Build one Docker CLI per distinct context up front and share it across all
 	// deployments targeting that context, instead of creating a client per deployment.
-	contextCLIs := buildDeployContextCLIs(ctx, contexts, dockerCli, dockerQuiet, deployConfigs)
+	contextCLIs := buildDeployContextCLIs(ctx, m.contexts, m.dockerCli, dockerQuiet, req.DeployConfigs)
 
 	defer func() {
 		for contextName, entry := range contextCLIs {
@@ -177,34 +126,34 @@ func (m *Manager) handleDeploy(ctx context.Context,
 	// limited by this manager's deployment limiter.
 	var wg sync.WaitGroup
 
-	resultCh := make(chan error, len(deployConfigs))
+	resultCh := make(chan error, len(req.DeployConfigs))
 
-	for _, deployCfg := range deployConfigs {
-		deployLog := jobLog.
+	for _, deployCfg := range req.DeployConfigs {
+		deployLog := req.Logger.
 			WithGroup("deploy").
 			With(slog.String("stack", deployCfg.Name))
 
-		if repoData.Source != config.SourceTypeOCI {
+		if req.Repository.Source != config.SourceTypeOCI {
 			deployLog = deployLog.With(slog.String("reference", deployCfg.Reference))
 		}
 
-		if ctx := strings.TrimSpace(deployCfg.Context); ctx != "" {
-			deployLog = deployLog.With(slog.String("context", ctx))
+		if ctxName := strings.TrimSpace(deployCfg.Context); ctxName != "" {
+			deployLog = deployLog.With(slog.String("context", ctxName))
 		}
 
 		// Used to make test deployments unique and prevent conflicts between tests when running in parallel.
 		// It is not used in production.
-		if testName != "" {
-			deployCfg.Name = test.ConvertTestName(testName)
+		if req.TestName != "" {
+			deployCfg.Name = test.ConvertTestName(req.TestName)
 		}
 
-		m.deployments.start(repoData.Name, deployCfg.Context, deployCfg.Name)
+		m.deployments.start(req.Repository.Name, deployCfg.Context, deployCfg.Name)
 
 		wg.Add(1)
 
 		go func(dc *deployConfig.Config) {
 			defer wg.Done()
-			defer m.deployments.finish(repoData.Name, dc.Context, dc.Name)
+			defer m.deployments.finish(req.Repository.Name, dc.Context, dc.Name)
 
 			contextName := docker.NormalizeContextName(dc.Context)
 
@@ -219,9 +168,7 @@ func (m *Manager) handleDeploy(ctx context.Context,
 				return
 			}
 
-			err := m.handleOneDeploy(ctx, deployLog,
-				appConfig, dataMountPoint, entry.cli, entry.swarmMode, secretProvider,
-				dc, jobID, jobTrigger, repoData, payload, metadata)
+			err := m.handleOneDeploy(ctx, req, deployLog, entry.cli, entry.swarmMode, dc)
 
 			resultCh <- err
 		}(deployCfg)
@@ -253,7 +200,7 @@ func (m *Manager) handleDeploy(ctx context.Context,
 		return errors.Join(errs...)
 	}
 
-	if successCount == 0 && len(deployConfigs) > 0 {
+	if successCount == 0 && len(req.DeployConfigs) > 0 {
 		// All deployments were skipped by the webhook filter
 		return stages.ErrWebhookFilterMismatch
 	}
@@ -321,16 +268,8 @@ func resolveDeployContext(ctx context.Context, contexts *docker.ContextRegistry,
 	return deployContextCLI{cli: cli, closeFn: closeFn, swarmMode: swarmMode}
 }
 
-func (m *Manager) handleOneDeploy(ctx context.Context, deployLog *slog.Logger,
-	appConfig *app.Config, dataMountPoint container.MountPoint,
-	deploymentDockerCli command.Cli, swarmAvailable bool,
-	secretProvider secretprovider.SecretProvider,
-	dc *deployConfig.Config,
-	jobID string,
-	jobTrigger stages.JobTrigger,
-	repoData stages.RepositoryData,
-	payLad *webhook.ParsedPayload,
-	metadata notification.Metadata,
+func (m *Manager) handleOneDeploy(ctx context.Context, req DeployRequest, deployLog *slog.Logger,
+	deploymentDockerCli command.Cli, swarmAvailable bool, dc *deployConfig.Config,
 ) error {
 	swarmMode, err := dc.ResolveSwarmMode(swarmAvailable)
 	if err != nil {
@@ -341,31 +280,38 @@ func (m *Manager) handleOneDeploy(ctx context.Context, deployLog *slog.Logger,
 	if m.limiter != nil {
 		deployLog.Debug("queuing deployment")
 
-		unlock, lErr := m.limiter.acquire(ctx, repoData.Name, NormalizeReference(dc.Reference))
+		unlock, lErr := m.limiter.acquire(ctx, req.Repository.Name, NormalizeReference(dc.Reference))
 		if lErr != nil {
 			return lErr
 		}
 		defer unlock()
 	}
 
-	stageMgr := stages.NewStageManager(
-		jobID,
-		jobTrigger,
-		deployLog,
-		failNotifyFunc,
-		&repoData,
-		&stages.Docker{
-			Cmd:            deploymentDockerCli,
-			DataMountPoint: dataMountPoint,
-			SwarmMode:      swarmMode,
-			SwarmAvailable: swarmAvailable,
+	stageMgr, err := stages.NewStageManager(
+		stages.Dependencies{
+			AppConfig:         m.appConfig,
+			SecretProvider:    m.secretProvider,
+			NotifyFailureFunc: failNotifyFunc,
 		},
-		payLad,
-		appConfig,
-		dc,
-		secretProvider,
-		metadata,
+		stages.RunInput{
+			Log:        deployLog,
+			JobID:      req.Metadata.JobID,
+			JobTrigger: req.JobTrigger,
+			Repository: &req.Repository,
+			Docker: &stages.Docker{
+				Cmd:            deploymentDockerCli,
+				DataMountPoint: m.dataMountPoint,
+				SwarmMode:      swarmMode,
+				SwarmAvailable: swarmAvailable,
+			},
+			Payload:      req.Payload,
+			DeployConfig: dc,
+			Metadata:     req.Metadata,
+		},
 	)
+	if err != nil {
+		return err
+	}
 
 	err = stageMgr.RunStages(ctx)
 	if err != nil {

--- a/internal/reconciliation/deploy_lock_test.go
+++ b/internal/reconciliation/deploy_lock_test.go
@@ -21,7 +21,7 @@ func TestDeploySkipsWhenContextCancelledBeforeRepoLockAcquisition(t *testing.T) 
 	t.Parallel()
 
 	repoName := t.Name()
-	j := newJob(newTestManager(t), jobInfo{metadata: notification.Metadata{Repository: repoName}}, nil)
+	j := newJob(newTestManager(t), DeployRequest{Metadata: notification.Metadata{Repository: repoName}}, nil)
 
 	var output bytes.Buffer
 

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -39,25 +39,15 @@ func TestDeploy_RejectsUnverifiedOCIArtifact(t *testing.T) {
 
 	manager := newTestManager(t)
 
-	err := manager.deploy(
-		t.Context(),
-		logger.New(logger.LevelCritical).Logger,
-		nil,
-		container.MountPoint{},
-		nil,
-		nil,
-		nil,
-		notification.Metadata{},
-		stages.JobTriggerWebhook,
-		stages.RepositoryData{
+	err := manager.deploy(t.Context(), DeployRequest{
+		Logger:     logger.New(logger.LevelCritical).Logger,
+		JobTrigger: stages.JobTriggerWebhook,
+		Repository: stages.RepositoryData{
 			Source:     config.SourceTypeOCI,
 			SourceUrl:  "ghcr.io/example/repo:latest",
 			OCITrusted: false,
 		},
-		nil,
-		nil,
-		"",
-	)
+	})
 	if err == nil {
 		t.Fatal("expected deploy to fail for unverified OCI artifact")
 	}
@@ -101,7 +91,6 @@ func TestDeploy(t *testing.T) {
 	encryption.SetupAgeKeyEnvVar(t)
 
 	ctx := t.Context()
-	manager := newTestManager(t)
 
 	c, err := app.GetConfig()
 	if err != nil {
@@ -153,6 +142,19 @@ func TestDeploy(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
+
+	manager := newTestManagerWithDependencies(t, Dependencies{
+		AppConfig: c,
+		DataMountPoint: container.MountPoint{
+			Type:        "bind",
+			Source:      tmpDir,
+			Destination: tmpDir,
+			Mode:        "rw",
+		},
+		DockerCLI:      dockerCli,
+		SecretProvider: secretProvider,
+	})
+
 	// Use a test-unique repository name so this test's reconciliation job key does not
 	// collide with other package tests that may run in parallel.
 	repoName := test.ConvertTestName(t.Name()) + "-repo"
@@ -201,33 +203,23 @@ func TestDeploy(t *testing.T) {
 		}
 	})
 
-	if err := manager.Deploy(ctx, log, c,
-		container.MountPoint{
-			Type:        "bind",
-			Source:      tmpDir,
-			Destination: tmpDir,
-			Mode:        "rw",
-		},
-		dockerCli,
-		nil,
-		secretProvider,
-		notification.Metadata{
+	if err := manager.Deploy(ctx, DeployRequest{
+		Logger: log,
+		Metadata: notification.Metadata{
 			JobID:      jobId,
 			Repository: repoName,
 			Revision:   notification.GetRevision(p.Ref, p.CommitSHAString()),
 		},
-		stages.JobTriggerWebhook,
-		stages.RepositoryData{
+		JobTrigger: stages.JobTriggerWebhook,
+		Repository: stages.RepositoryData{
 			SourceUrl:    p.CloneURL,
 			Name:         repoName,
 			PathInternal: repoPath,
 			PathExternal: repoPath,
 		},
-		dcs,
-
-		&p,
-		"",
-	); err != nil {
+		DeployConfigs: dcs,
+		Payload:       &p,
+	}); err != nil {
 		t.Fatalf("Failed to deploy: %v", err)
 	}
 

--- a/internal/reconciliation/manager.go
+++ b/internal/reconciliation/manager.go
@@ -28,9 +28,22 @@ import (
 // ErrManagerClosed indicates that a deployment was submitted after shutdown began.
 var ErrManagerClosed = errors.New("reconciliation manager is closed")
 
-// Dependencies configures reconciliation lifecycle and deployment admission.
+// Dependencies configures reconciliation lifecycle, deployment admission, and the stable
+// application-level services shared by every deployment the Manager runs: application
+// configuration, the data mount point, the base Docker CLI, the Docker context registry, and
+// an optional secret provider. Per-run values (trigger, repository, deploy configs, payload,
+// notification metadata) are supplied per call via DeployRequest instead.
 type Dependencies struct {
 	MaxConcurrentDeployments uint `default:"1" validate:"min=1"`
+
+	AppConfig      *app.Config          `validate:"required,nostructlevel"`
+	DataMountPoint container.MountPoint `validate:"required"`
+	DockerCLI      command.Cli          `validate:"required,nostructlevel"`
+	// Contexts and SecretProvider are optional: resolveDeployContext falls back to the
+	// default Docker context/CLI when Contexts is nil, and a nil SecretProvider means no
+	// external secret provider is configured.
+	Contexts       *docker.ContextRegistry
+	SecretProvider secretprovider.SecretProvider
 }
 
 // Manager owns reconciliation jobs, active-deployment tracking, scheduler
@@ -45,6 +58,13 @@ type Manager struct {
 	closed         bool
 	deployWG       sync.WaitGroup
 	jobWG          sync.WaitGroup
+
+	// Stable application dependencies shared by every deployment; see Dependencies.
+	appConfig      *app.Config
+	dataMountPoint container.MountPoint
+	dockerCli      command.Cli
+	contexts       *docker.ContextRegistry
+	secretProvider secretprovider.SecretProvider
 }
 
 // NewManager validates dependencies and creates an isolated reconciliation manager.
@@ -62,36 +82,38 @@ func NewManager(dependencies Dependencies) (*Manager, error) {
 		deployments:    deploymentTracker{stacks: make(map[string]int)},
 		schedulerHolds: schedulerHoldRegistry{services: make(map[string]schedulerHoldEntry)},
 		limiter:        NewDeployerLimiter(dependencies.MaxConcurrentDeployments),
+		appConfig:      dependencies.AppConfig,
+		dataMountPoint: dependencies.DataMountPoint,
+		dockerCli:      dependencies.DockerCLI,
+		contexts:       dependencies.Contexts,
+		secretProvider: dependencies.SecretProvider,
 	}, nil
 }
 
 // contextCLIEntry holds a Docker CLI and its resolved metadata for one Docker context.
 type contextCLIEntry struct {
 	cli       command.Cli
-	closeFn   func() // nil for the default context (which is always j.info.dockerCli)
+	closeFn   func() // nil for the default context (which is always j.manager.dockerCli)
 	swarmMode bool
 }
 
-type jobInfo struct {
-	appConfig      *app.Config
-	dataMountPoint container.MountPoint
-	dockerCli      command.Cli
-	contexts       *docker.ContextRegistry
-	secretProvider secretprovider.SecretProvider
-
-	log *slog.Logger
-
-	metadata      notification.Metadata
-	jobTrigger    stages.JobTrigger
-	repoData      stages.RepositoryData
-	deployConfigs []*deployConfig.Config
-	payload       *webhook.ParsedPayload
-	testName      string
+// DeployRequest carries the per-run input for a single reconciliation deployment: the trigger
+// metadata, source repository/payload data, resolved deploy configs, and (for test runs only) a
+// unique test name. Stable application dependencies (app config, Docker CLI, context registry,
+// secret provider) live on the Manager itself instead; see Dependencies.
+type DeployRequest struct {
+	Logger        *slog.Logger `validate:"required,nostructlevel"`
+	Metadata      notification.Metadata
+	JobTrigger    stages.JobTrigger `validate:"required,oneof=webhook poll"`
+	Repository    stages.RepositoryData
+	DeployConfigs []*deployConfig.Config `validate:"dive,required"`
+	Payload       *webhook.ParsedPayload
+	TestName      string
 }
 
 type job struct {
 	manager                  *Manager
-	info                     jobInfo
+	info                     DeployRequest
 	deployConfigGroupByEvent map[string][]*deployConfig.Config // key is the docker event action name (for example "die" or "unhealthy").
 	restartStateMu           sync.Mutex                        // guards unhealthyRestartHistory and restartSuppressUntil against concurrent access from parallel per-context startup recovery goroutines.
 	unhealthyRestartHistory  map[string][]time.Time            // key is the docker container ID, value is the list of timestamps of recent unhealthy restart events for that container.
@@ -106,7 +128,7 @@ type job struct {
 	contextCLIs map[string]contextCLIEntry
 }
 
-func newJob(manager *Manager, info jobInfo, deployConfigGroupByEvent map[string][]*deployConfig.Config) *job {
+func newJob(manager *Manager, info DeployRequest, deployConfigGroupByEvent map[string][]*deployConfig.Config) *job {
 	return &job{
 		manager:                  manager,
 		info:                     info,
@@ -138,7 +160,7 @@ func (j *job) signalReady() {
 	}
 
 	j.readyOnce.Do(func() {
-		j.info.log.Debug("reconciliation event listeners ready")
+		j.info.Logger.Debug("reconciliation event listeners ready")
 		close(j.readyChan)
 	})
 }
@@ -410,13 +432,13 @@ func (r *deploymentTracker) isInProgress(repository, context, stack string) bool
 	return r.stacks[key] > 0
 }
 
-func (m *Manager) addJob(ctx context.Context, info jobInfo) {
-	cfg := getDeployConfigGroupByEvent(info.deployConfigs)
+func (m *Manager) addJob(ctx context.Context, req DeployRequest) {
+	cfg := getDeployConfigGroupByEvent(req.DeployConfigs)
 	if len(cfg) == 0 {
 		return
 	}
 
-	newJob := newJob(m, info, cfg)
+	newJob := newJob(m, req, cfg)
 	jobCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	newJob.cancel = cancel
 
@@ -429,13 +451,13 @@ func (m *Manager) addJob(ctx context.Context, info jobInfo) {
 	}
 
 	m.jobWG.Add(1)
-	old := m.jobs.jobs[info.repoData.Name]
-	m.jobs.jobs[info.repoData.Name] = newJob
+	old := m.jobs.jobs[req.Repository.Name]
+	m.jobs.jobs[req.Repository.Name] = newJob
 	m.jobs.mu.Unlock()
 
 	old.close()
 
-	jobLog := info.log
+	jobLog := req.Logger
 
 	go func() {
 		defer func() {

--- a/internal/reconciliation/manager_test.go
+++ b/internal/reconciliation/manager_test.go
@@ -3,13 +3,10 @@ package reconciliation
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/docker/compose/v5/pkg/api"
-	"github.com/moby/moby/api/types/container"
-
-	"github.com/kimdre/doco-cd/internal/notification"
-	"github.com/kimdre/doco-cd/internal/stages"
 )
 
 func TestNewManagerAppliesDefaultDeploymentLimit(t *testing.T) {
@@ -18,6 +15,24 @@ func TestNewManagerAppliesDefaultDeploymentLimit(t *testing.T) {
 	manager := newTestManager(t)
 	if got := cap(manager.limiter.sem); got != 1 {
 		t.Fatalf("default deployment limit = %d, want 1", got)
+	}
+}
+
+func TestNewManagerValidatesDependencies(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewManager(Dependencies{})
+	if err == nil || !strings.Contains(err.Error(), "validate reconciliation dependencies") {
+		t.Fatalf("NewManager() error = %v, want dependency validation error", err)
+	}
+}
+
+func TestManagerDeployValidatesRequest(t *testing.T) {
+	t.Parallel()
+
+	err := newTestManager(t).Deploy(t.Context(), DeployRequest{})
+	if err == nil || !strings.Contains(err.Error(), "validate deploy request") {
+		t.Fatalf("Deploy() error = %v, want request validation error", err)
 	}
 }
 
@@ -41,16 +56,12 @@ func TestManagerStateIsIsolated(t *testing.T) {
 func TestManagerCloseIsIdempotentAndRejectsDeployments(t *testing.T) {
 	t.Parallel()
 
-	manager, err := NewManager(Dependencies{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	manager := newTestManagerWithDependencies(t, Dependencies{})
 
 	manager.Close()
 	manager.Close()
 
-	err = manager.Deploy(t.Context(), nil, nil, container.MountPoint{}, nil, nil, nil,
-		notification.Metadata{}, "", stages.RepositoryData{}, nil, nil, "")
+	err := manager.Deploy(t.Context(), DeployRequest{})
 	if !errors.Is(err, ErrManagerClosed) {
 		t.Fatalf("Deploy() after Close error = %v, want %v", err, ErrManagerClosed)
 	}
@@ -59,13 +70,10 @@ func TestManagerCloseIsIdempotentAndRejectsDeployments(t *testing.T) {
 func TestManagerCloseCancelsJobsBeforeWaiting(t *testing.T) {
 	t.Parallel()
 
-	manager, err := NewManager(Dependencies{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	manager := newTestManagerWithDependencies(t, Dependencies{})
 
 	jobCtx, cancel := context.WithCancel(context.Background())
-	reconciliationJob := newJob(manager, jobInfo{}, nil)
+	reconciliationJob := newJob(manager, DeployRequest{}, nil)
 	reconciliationJob.cancel = cancel
 	manager.jobs.jobs["repo"] = reconciliationJob
 	manager.jobWG.Add(1)

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -45,15 +45,15 @@ type contextualEvent struct {
 func (j *job) initContextCLIs(ctx context.Context, quiet bool) {
 	contextCLIs := make(map[string]contextCLIEntry)
 
-	for _, dc := range j.info.deployConfigs {
+	for _, dc := range j.info.DeployConfigs {
 		ctxName := docker.NormalizeContextName(dc.Context)
 		if _, already := contextCLIs[ctxName]; already {
 			continue
 		}
 
-		entry := resolveDeployContext(ctx, j.info.contexts, j.info.dockerCli, quiet, ctxName)
+		entry := resolveDeployContext(ctx, j.manager.contexts, j.manager.dockerCli, quiet, ctxName)
 		if entry.err != nil {
-			j.info.log.Error("failed to create Docker CLI for context; skipping event listener for that context",
+			j.info.Logger.Error("failed to create Docker CLI for context; skipping event listener for that context",
 				slog.String("context", docker.DisplayContextName(ctxName)),
 				logger.ErrAttr(entry.err),
 			)
@@ -81,7 +81,7 @@ func (j *job) cliForContext(contextName string) command.Cli {
 		}
 	}
 
-	return j.info.dockerCli
+	return j.manager.dockerCli
 }
 
 // swarmModeForContext returns the swarm mode for the given context name, falling back to the
@@ -99,7 +99,7 @@ func (j *job) swarmModeForContext(contextName string) bool {
 
 // deployConfigsForContext returns the subset of the job's deploy configs that target contextName.
 func (j *job) deployConfigsForContext(contextName string) []*deployConfig.Config {
-	return filterConfigsByContext(j.info.deployConfigs, contextName)
+	return filterConfigsByContext(j.info.DeployConfigs, contextName)
 }
 
 func (j *job) deployConfigsForContextMode(contextName string, swarmMode bool) []*deployConfig.Config {
@@ -107,11 +107,11 @@ func (j *job) deployConfigsForContextMode(contextName string, swarmMode bool) []
 }
 
 func (j *job) run(ctx context.Context) {
-	jobLog := j.info.log
+	jobLog := j.info.Logger
 
 	dockerQuiet := false
-	if j.info.appConfig != nil {
-		dockerQuiet = j.info.appConfig.DockerQuietDeploy
+	if j.manager.appConfig != nil {
+		dockerQuiet = j.manager.appConfig.DockerQuietDeploy
 	}
 
 	j.initContextCLIs(ctx, dockerQuiet)
@@ -229,9 +229,9 @@ func (j *job) run(ctx context.Context) {
 // runContextEventListener connects to the Docker daemon for entry, listens for relevant events,
 // forwards them (tagged with contextName) to out, and automatically reconnects on disconnection.
 func (j *job) runContextEventListener(ctx context.Context, jobLog *slog.Logger, contextName string, entry contextCLIEntry, swarmMode bool, contextDCs []*deployConfig.Config, out chan<- contextualEvent, ready chan<- struct{}) {
-	repositoryLabelValue := gitInternal.GetFullName(j.info.repoData.SourceUrl)
-	if j.info.payload != nil && strings.TrimSpace(j.info.payload.FullName) != "" {
-		repositoryLabelValue = j.info.payload.FullName
+	repositoryLabelValue := gitInternal.GetFullName(j.info.Repository.SourceUrl)
+	if j.info.Payload != nil && strings.TrimSpace(j.info.Payload.FullName) != "" {
+		repositoryLabelValue = j.info.Payload.FullName
 	}
 
 	contextGroupByEvent := getDeployConfigGroupByEvent(contextDCs)
@@ -425,7 +425,7 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 		return
 	}
 
-	if j.manager.deployments.isInProgress(j.info.metadata.Repository, contextName, stackName) {
+	if j.manager.deployments.isInProgress(j.info.Metadata.Repository, contextName, stackName) {
 		jobLog.Debug("suppressing reconciliation event while stack deployment is in progress",
 			slog.String("event", action),
 			slog.String("stack", stackName),
@@ -469,7 +469,7 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 		return
 	}
 
-	stackID := j.info.metadata.Repository + "/" + contextName + "/" + stackName
+	stackID := j.info.Metadata.Repository + "/" + contextName + "/" + stackName
 	stackLock := lock.GetRepoLock(stackID)
 
 	if !stackLock.TryLock(id.New()) {
@@ -543,7 +543,7 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 }
 
 func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConfig.Config, action string, event events.Message, traceID string, contextName string, swarmMode bool) {
-	repoLock := lock.GetRepoLock(j.info.metadata.Repository)
+	repoLock := lock.GetRepoLock(j.info.Metadata.Repository)
 	if !repoLock.LockContext(ctx, traceID) {
 		jobLog.Debug("reconciliation skipped, context cancelled while waiting for repository lock")
 
@@ -561,9 +561,9 @@ func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConf
 	contextDCs := j.deployConfigsForContextMode(contextName, swarmMode)
 
 	if err := cleanupObsoleteAutoDiscoveredContainers(ctx, jobLog,
-		contextCLI, swarmMode, contextName, j.info.repoData.SourceUrl,
+		contextCLI, swarmMode, contextName, j.info.Repository.SourceUrl,
 		contextDCs,
-		j.info.metadata); err != nil {
+		j.info.Metadata); err != nil {
 		jobLog.Error("failed to clean up obsolete auto-discovered containers", logger.ErrAttr(err))
 	}
 
@@ -577,7 +577,7 @@ func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConf
 		actorKind = "service"
 	}
 
-	metadata := j.info.metadata
+	metadata := j.info.Metadata
 	metadata.ReconciliationEvent = action
 	metadata.TraceID = strings.TrimSpace(traceID)
 	metadata.AffectedActorKind = actorKind
@@ -585,10 +585,11 @@ func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConf
 	metadata.AffectedActorName = strings.TrimSpace(event.Actor.Attributes["name"])
 
 	// handleDeploy accepts the base CLI; it handles per-context routing internally.
-	if err := j.manager.handleDeploy(ctx, jobLog, j.info.appConfig,
-		j.info.dataMountPoint, j.info.dockerCli, j.info.contexts,
-		j.info.secretProvider, metadata.JobID, j.info.jobTrigger,
-		j.info.repoData, reconcileDCs, j.info.payload, j.info.testName, metadata); err != nil {
+	req := j.info
+	req.Metadata = metadata
+	req.DeployConfigs = reconcileDCs
+
+	if err := j.manager.handleDeploy(ctx, req); err != nil {
 		jobLog.Error("failed to deploy", logger.ErrAttr(err))
 	}
 }

--- a/internal/reconciliation/reconciliation_integration_test.go
+++ b/internal/reconciliation/reconciliation_integration_test.go
@@ -171,6 +171,7 @@ func TestReconciliationStopEventRestartSuppressionIntegration(t *testing.T) {
 	reconcileJob := newJob(newTestManagerWithDependencies(t, Dependencies{DockerCLI: stack.DockerCli}), DeployRequest{
 		Logger:        jobLog,
 		Metadata:      notification.Metadata{Repository: repositoryName, Stack: stackName, JobID: "test-job"},
+		JobTrigger:    stages.JobTriggerWebhook,
 		Repository:    stages.RepositoryData{SourceUrl: "https://github.com/kimdre/doco-cd_tests.git", Name: repositoryName},
 		Payload:       &webhook.ParsedPayload{FullName: repositoryName},
 		DeployConfigs: []*deployConfig.Config{dc},

--- a/internal/reconciliation/reconciliation_integration_test.go
+++ b/internal/reconciliation/reconciliation_integration_test.go
@@ -168,13 +168,12 @@ func TestReconciliationStopEventRestartSuppressionIntegration(t *testing.T) {
 	dc.Reconciliation.RestartTimeout = 1
 
 	jobLog := logger.New(slog.LevelError).Logger
-	reconcileJob := newJob(newTestManager(t), jobInfo{
-		log:           jobLog,
-		dockerCli:     stack.DockerCli,
-		metadata:      notification.Metadata{Repository: repositoryName, Stack: stackName, JobID: "test-job"},
-		repoData:      stages.RepositoryData{SourceUrl: "https://github.com/kimdre/doco-cd_tests.git", Name: repositoryName},
-		payload:       &webhook.ParsedPayload{FullName: repositoryName},
-		deployConfigs: []*deployConfig.Config{dc},
+	reconcileJob := newJob(newTestManagerWithDependencies(t, Dependencies{DockerCLI: stack.DockerCli}), DeployRequest{
+		Logger:        jobLog,
+		Metadata:      notification.Metadata{Repository: repositoryName, Stack: stackName, JobID: "test-job"},
+		Repository:    stages.RepositoryData{SourceUrl: "https://github.com/kimdre/doco-cd_tests.git", Name: repositoryName},
+		Payload:       &webhook.ParsedPayload{FullName: repositoryName},
+		DeployConfigs: []*deployConfig.Config{dc},
 	}, getDeployConfigGroupByEvent([]*deployConfig.Config{dc}))
 
 	runCtx, cancel := context.WithCancel(ctx)

--- a/internal/reconciliation/reconciliation_restart.go
+++ b/internal/reconciliation/reconciliation_restart.go
@@ -55,7 +55,7 @@ func (j *job) restartContainer(ctx context.Context, jobLog *slog.Logger, event e
 
 	restartLog.Info("restarting " + actorKind)
 
-	metadata := restartNotificationMetadata(j.info.metadata, dc, action, actorKind, containerID, containerName, reconciliationTraceIDFromEvent(event))
+	metadata := restartNotificationMetadata(j.info.Metadata, dc, action, actorKind, containerID, containerName, reconciliationTraceIDFromEvent(event))
 
 	if _, err := cli.Client().ContainerRestart(ctx, containerID, restartOpts); err != nil {
 		j.restartStateMu.Lock()
@@ -240,7 +240,7 @@ func (j *job) shouldSuppressUnhealthyRestart(jobLog *slog.Logger, event events.M
 	)
 
 	actorKind := restartNotificationActorKind(swarmMode)
-	metadata := restartNotificationMetadata(j.info.metadata, dc, action, actorKind, containerID, event.Actor.Attributes["name"], reconciliationTraceIDFromEvent(event))
+	metadata := restartNotificationMetadata(j.info.Metadata, dc, action, actorKind, containerID, event.Actor.Attributes["name"], reconciliationTraceIDFromEvent(event))
 
 	if notifyErr := notification.Send(
 		notification.Warning,

--- a/internal/reconciliation/reconciliation_startup.go
+++ b/internal/reconciliation/reconciliation_startup.go
@@ -26,9 +26,9 @@ func (j *job) restartUnhealthyContainersOnStartup(ctx context.Context, jobLog *s
 		return
 	}
 
-	repositoryLabelValue := gitInternal.GetFullName(j.info.repoData.SourceUrl)
-	if j.info.payload != nil && strings.TrimSpace(j.info.payload.FullName) != "" {
-		repositoryLabelValue = j.info.payload.FullName
+	repositoryLabelValue := gitInternal.GetFullName(j.info.Repository.SourceUrl)
+	if j.info.Payload != nil && strings.TrimSpace(j.info.Payload.FullName) != "" {
+		repositoryLabelValue = j.info.Payload.FullName
 	}
 
 	filterArgs := make(client.Filters)
@@ -177,9 +177,9 @@ func (j *job) redeployMissingServicesOnStartup(ctx context.Context, jobLog *slog
 // findMissingContainersOnStartup lists all running containers for this repository and returns
 // deploy configs whose stacks have no running containers at all.
 func (j *job) findMissingContainersOnStartup(ctx context.Context, jobLog *slog.Logger, cli command.Cli, candidates []*deployConfig.Config) []*deployConfig.Config {
-	repositoryLabelValue := gitInternal.GetFullName(j.info.repoData.SourceUrl)
-	if j.info.payload != nil && strings.TrimSpace(j.info.payload.FullName) != "" {
-		repositoryLabelValue = j.info.payload.FullName
+	repositoryLabelValue := gitInternal.GetFullName(j.info.Repository.SourceUrl)
+	if j.info.Payload != nil && strings.TrimSpace(j.info.Payload.FullName) != "" {
+		repositoryLabelValue = j.info.Payload.FullName
 	}
 
 	filterArgs := make(client.Filters)
@@ -218,9 +218,9 @@ func (j *job) findMissingContainersOnStartup(ctx context.Context, jobLog *slog.L
 // findMissingSwarmServicesOnStartup lists all swarm services for this repository and returns
 // deploy configs whose stacks have no deployed services at all.
 func (j *job) findMissingSwarmServicesOnStartup(ctx context.Context, jobLog *slog.Logger, cli command.Cli, candidates []*deployConfig.Config) []*deployConfig.Config {
-	repositoryLabelValue := gitInternal.GetFullName(j.info.repoData.SourceUrl)
-	if j.info.payload != nil && strings.TrimSpace(j.info.payload.FullName) != "" {
-		repositoryLabelValue = j.info.payload.FullName
+	repositoryLabelValue := gitInternal.GetFullName(j.info.Repository.SourceUrl)
+	if j.info.Payload != nil && strings.TrimSpace(j.info.Payload.FullName) != "" {
+		repositoryLabelValue = j.info.Payload.FullName
 	}
 
 	services, err := swarm.GetServicesByLabel(ctx, cli.Client(), docker.DocoCDLabels.Metadata.Manager, app.Name)

--- a/internal/reconciliation/test_helpers_test.go
+++ b/internal/reconciliation/test_helpers_test.go
@@ -1,11 +1,46 @@
 package reconciliation
 
-import "testing"
+import (
+	"testing"
 
-func newTestManager(t *testing.T) *Manager {
+	"github.com/moby/moby/api/types/container"
+
+	"github.com/kimdre/doco-cd/internal/config/app"
+	"github.com/kimdre/doco-cd/internal/docker"
+)
+
+// newTestManagerWithDependencies creates a Manager for tests, filling in a zero-value AppConfig
+// and a fresh Docker CLI (closed via t.Cleanup) for any dependency left unset in deps, so tests
+// only need to override the fields they care about.
+func newTestManagerWithDependencies(t *testing.T, deps Dependencies) *Manager {
 	t.Helper()
 
-	manager, err := NewManager(Dependencies{})
+	if deps.AppConfig == nil {
+		deps.AppConfig = &app.Config{}
+	}
+
+	if deps.DataMountPoint.Source == "" || deps.DataMountPoint.Destination == "" {
+		dataDir := t.TempDir()
+		deps.DataMountPoint = container.MountPoint{
+			Type:        "bind",
+			Source:      dataDir,
+			Destination: dataDir,
+			Mode:        "rw",
+		}
+	}
+
+	if deps.DockerCLI == nil {
+		dockerCli, err := docker.CreateDockerCli(true)
+		if err != nil {
+			t.Fatalf("failed to create docker cli: %v", err)
+		}
+
+		t.Cleanup(func() { _ = dockerCli.Client().Close() })
+
+		deps.DockerCLI = dockerCli
+	}
+
+	manager, err := NewManager(deps)
 	if err != nil {
 		t.Fatalf("failed to create reconciliation manager: %v", err)
 	}
@@ -13,6 +48,12 @@ func newTestManager(t *testing.T) *Manager {
 	t.Cleanup(manager.Close)
 
 	return manager
+}
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+
+	return newTestManagerWithDependencies(t, Dependencies{})
 }
 
 func newTestDeployerLimiter(t *testing.T, maxConcurrent uint) *DeployerLimiter {

--- a/internal/stages/failure_state_test.go
+++ b/internal/stages/failure_state_test.go
@@ -31,7 +31,7 @@ func TestStageRecordsDeploymentFailure(t *testing.T) {
 func newFailureTestManager(t *testing.T, stack string) *StageManager {
 	t.Helper()
 
-	sm := newTestStageManager()
+	sm := newTestStageManager(t)
 	sm.DeployConfig.Name = stack
 	sm.Repository.Revision = "573a16e"
 

--- a/internal/stages/manager_test.go
+++ b/internal/stages/manager_test.go
@@ -12,20 +12,28 @@ import (
 	"github.com/kimdre/doco-cd/internal/notification"
 )
 
-func newTestStageManager() *StageManager {
-	return NewStageManager(
-		"job-1",
-		JobTriggerWebhook,
-		slog.New(slog.NewTextHandler(io.Discard, nil)),
-		nil,
-		&RepositoryData{Name: "owner/repo"},
-		&Docker{},
-		nil,
-		&app.Config{},
-		&deploy.Config{},
-		nil,
-		notification.Metadata{},
+func newTestStageManager(t *testing.T) *StageManager {
+	t.Helper()
+
+	sm, err := NewStageManager(
+		Dependencies{
+			AppConfig: &app.Config{},
+		},
+		RunInput{
+			Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+			JobID:        "job-1",
+			JobTrigger:   JobTriggerWebhook,
+			Repository:   &RepositoryData{Name: "owner/repo"},
+			Docker:       &Docker{},
+			DeployConfig: &deploy.Config{},
+			Metadata:     notification.Metadata{},
+		},
 	)
+	if err != nil {
+		t.Fatalf("NewStageManager() error = %v", err)
+	}
+
+	return sm
 }
 
 func TestNewMetaData(t *testing.T) {
@@ -44,7 +52,7 @@ func TestNewMetaData(t *testing.T) {
 func TestNewStageManager(t *testing.T) {
 	t.Parallel()
 
-	sm := newTestStageManager()
+	sm := newTestStageManager(t)
 
 	if sm.JobID != "job-1" || sm.JobTrigger != JobTriggerWebhook {
 		t.Fatalf("NewStageManager() stored job metadata incorrectly: %#v", sm)
@@ -59,10 +67,22 @@ func TestNewStageManager(t *testing.T) {
 	}
 }
 
+func TestNewStageManagerValidatesInputs(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewStageManager(Dependencies{}, RunInput{}); err == nil {
+		t.Fatal("NewStageManager() error = nil, want dependency validation error")
+	}
+
+	if _, err := NewStageManager(Dependencies{AppConfig: &app.Config{}}, RunInput{}); err == nil {
+		t.Fatal("NewStageManager() error = nil, want run input validation error")
+	}
+}
+
 func TestStageManagerGetStageMetaData(t *testing.T) {
 	t.Parallel()
 
-	sm := newTestStageManager()
+	sm := newTestStageManager(t)
 
 	tests := []StageName{StageInit, StagePreDeploy, StageDeploy, StageDestroy, StagePostDeploy, StagePostDestroy, StageCleanup}
 	for _, stageName := range tests {
@@ -88,7 +108,7 @@ func TestStageManagerGetStageMetaData(t *testing.T) {
 func TestStageManagerNotifyFailureIncludesTarget(t *testing.T) {
 	t.Parallel()
 
-	sm := newTestStageManager()
+	sm := newTestStageManager(t)
 	sm.Repository.Revision = "abc123"
 	sm.DeployConfig.Name = "app"
 	sm.DeployConfig.Context = "remote-vm"
@@ -121,7 +141,7 @@ func TestStageManagerNotifyFailureIncludesTarget(t *testing.T) {
 func TestStageOrders(t *testing.T) {
 	t.Parallel()
 
-	sm := newTestStageManager()
+	sm := newTestStageManager(t)
 
 	deployOrder := sm.GetDeployStageOrder()
 	if want := []StageName{StageInit, StagePreDeploy, StageDeploy, StagePostDeploy, StageCleanup}; !slices.Equal(deployOrder.Order, want) {

--- a/internal/stages/stage_3_deploy.go
+++ b/internal/stages/stage_3_deploy.go
@@ -30,13 +30,21 @@ func (s *StageManager) RunDeployStage(ctx context.Context, stageLog *slog.Logger
 		}
 	}
 
-	err = docker.DeployStack(stageLog, s.Repository.PathExternal, &ctx, s.Docker.Cmd,
-		s.Payload, s.DeployConfig,
-		s.DeployState.changedServices, s.DeployState.ignoredInfo.NeedSendSignal,
-		latestCommit, app.Version,
-		s.AppConfig.DockerSwarmConfigRetention, s.AppConfig.DockerSwarmSecretRetention,
-		s.Docker.SwarmMode,
-		pkiRoleNormMap(s.DeployConfig.ExternalSecrets, s.DeployConfig.Internal.Environment))
+	err = docker.DeployStack(ctx, docker.DeployRequest{
+		JobLog:                     stageLog,
+		ExternalRepoPath:           s.Repository.PathExternal,
+		DockerCLI:                  s.Docker.Cmd,
+		Payload:                    s.Payload,
+		DeployConfig:               s.DeployConfig,
+		DetectedChanges:            s.DeployState.changedServices,
+		NeedSignal:                 s.DeployState.ignoredInfo.NeedSendSignal,
+		LatestCommit:               latestCommit,
+		AppVersion:                 app.Version,
+		GlobalSwarmConfigRetention: s.AppConfig.DockerSwarmConfigRetention,
+		GlobalSwarmSecretRetention: s.AppConfig.DockerSwarmSecretRetention,
+		SwarmMode:                  s.Docker.SwarmMode,
+		HashNormMap:                pkiRoleNormMap(s.DeployConfig.ExternalSecrets, s.DeployConfig.Internal.Environment),
+	})
 	if err != nil {
 		return fmt.Errorf("failed to deploy stack %s: %w", s.DeployConfig.Name, err)
 	}

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -25,6 +25,8 @@ import (
 	"github.com/kimdre/doco-cd/internal/notification"
 
 	gitInternal "github.com/kimdre/doco-cd/internal/git"
+
+	"github.com/kimdre/doco-cd/internal/common/validation"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
@@ -187,27 +189,53 @@ type StageManager struct {
 
 type NotifyFailureFunc func(log *slog.Logger, err error, metadata notification.Metadata)
 
-// NewStageManager creates and initializes a new StageManager instance for managing stages.ß.
-func NewStageManager(jobID string, jobTrigger JobTrigger, log *slog.Logger,
-	failNotifyFunc NotifyFailureFunc,
-	repoData *RepositoryData, dockerData *Docker, payload *webhook.ParsedPayload,
-	appConfig *app.Config, deployConfig *deploy.Config,
-	secretProvider secretprovider.SecretProvider,
-	metadata notification.Metadata,
-) *StageManager {
+// Dependencies holds the stable services shared by every StageManager run in a process:
+// application configuration, the optional secret provider used to resolve external secret
+// references, and the callback invoked when a deployment fails.
+type Dependencies struct {
+	AppConfig         *app.Config `validate:"required,nostructlevel"`
+	SecretProvider    secretprovider.SecretProvider
+	NotifyFailureFunc NotifyFailureFunc
+}
+
+// RunInput holds the per-deployment input for a single StageManager run: the job identity and
+// trigger, logger, repository data, Docker CLI/data mount point, the parsed webhook payload
+// (may be nil for non-webhook triggers), the resolved deploy config, and notification metadata.
+type RunInput struct {
+	Log          *slog.Logger `validate:"required,nostructlevel"`
+	JobID        string
+	JobTrigger   JobTrigger      `validate:"required,oneof=webhook poll"`
+	Repository   *RepositoryData `validate:"required,nostructlevel"`
+	Docker       *Docker         `validate:"required,nostructlevel"`
+	Payload      *webhook.ParsedPayload
+	DeployConfig *deploy.Config `validate:"required,nostructlevel"`
+	Metadata     notification.Metadata
+}
+
+// NewStageManager validates dependencies and run, then creates and initializes a new
+// StageManager instance for managing stages.
+func NewStageManager(dependencies Dependencies, run RunInput) (*StageManager, error) {
+	if err := validation.Validate(dependencies); err != nil {
+		return nil, fmt.Errorf("validate stage dependencies: %w", err)
+	}
+
+	if err := validation.Validate(run); err != nil {
+		return nil, fmt.Errorf("validate stage run input: %w", err)
+	}
+
 	return &StageManager{
-		Log:               log.With(),
-		JobID:             jobID,
-		JobTrigger:        jobTrigger,
-		NotifyFailureFunc: failNotifyFunc,
-		AppConfig:         appConfig,
-		DeployConfig:      deployConfig,
+		Log:               run.Log.With(),
+		JobID:             run.JobID,
+		JobTrigger:        run.JobTrigger,
+		NotifyFailureFunc: dependencies.NotifyFailureFunc,
+		AppConfig:         dependencies.AppConfig,
+		DeployConfig:      run.DeployConfig,
 		DeployState:       &DeploymentState{},
-		Docker:            dockerData,
-		Payload:           payload,
-		Repository:        repoData,
-		SecretProvider:    secretProvider,
-		Metadata:          metadata,
+		Docker:            run.Docker,
+		Payload:           run.Payload,
+		Repository:        run.Repository,
+		SecretProvider:    dependencies.SecretProvider,
+		Metadata:          run.Metadata,
 		Stages: &Stages{
 			Init: &InitStageData{
 				MetaData: NewMetaData(StageInit),
@@ -231,7 +259,7 @@ func NewStageManager(jobID string, jobTrigger JobTrigger, log *slog.Logger,
 				MetaData: NewMetaData(StageCleanup),
 			},
 		},
-	}
+	}, nil
 }
 
 // GetStageMetaData retrieves the metadata for the specified stage.


### PR DESCRIPTION
## Summary
- store stable deployment dependencies on `reconciliation.Manager`
- replace positional reconciliation and stage arguments with validated request structs
- pass `context.Context` and a typed request into Docker stack deployment
- bundle webhook and poll deployment inputs at the executable boundary

## Validation
- `make fmt`
- `make test-nobitwarden`
- `make build`

Closes part of #1764