### PR TITLE
refactor(runtime): inject deployment configuration explicitly

### DIFF
--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -384,7 +384,7 @@ func run() error {
 		return err
 	}
 
-	schedulerManager := scheduler.NewManager(contexts, log.Logger, &wg, secretProvider, reconciliationManager)
+	schedulerManager := scheduler.NewManager(contexts, log.Logger, &wg, secretProvider, reconciliationManager, docker.NewScheduledComposeOptions(c))
 	controlPlaneRuns := controlplane.NewRuns(
 		ctx,
 		log.Logger,
@@ -471,7 +471,7 @@ func run() error {
 				slog.String("secret_provider", c.SecretProvider),
 			)
 		} else {
-			watcher := certrotation.New(contexts, log.Logger, h.secretProvider, c.CertRotationThreshold, c.CertRotationCheckInterval)
+			watcher := certrotation.New(contexts, log.Logger, h.secretProvider, c.CertRotationThreshold, c.CertRotationCheckInterval, docker.NewCertificateRotationOptions(c))
 
 			graceful.SafeGo(&wg, log.Logger, func() {
 				watcher.Start(ctx)

--- a/internal/certrotation/watcher.go
+++ b/internal/certrotation/watcher.go
@@ -41,6 +41,9 @@ type Watcher struct {
 	secretProvider secretprovider.SecretProvider
 	threshold      time.Duration
 	checkInterval  time.Duration
+	// certOptions bundles the Docker-owned settings needed to reload and redeploy the rotated
+	// project (see docker.CertificateRotationOptions), resolved explicitly at composition time.
+	certOptions docker.CertificateRotationOptions
 
 	// now and listContexts are overridable in tests.
 	now          func() time.Time
@@ -55,6 +58,7 @@ func New(
 	log *slog.Logger,
 	secretProvider secretprovider.SecretProvider,
 	threshold, checkInterval time.Duration,
+	certOptions docker.CertificateRotationOptions,
 ) *Watcher {
 	w := &Watcher{
 		contexts:       contexts,
@@ -62,6 +66,7 @@ func New(
 		secretProvider: secretProvider,
 		threshold:      threshold,
 		checkInterval:  checkInterval,
+		certOptions:    certOptions,
 		now:            time.Now,
 	}
 
@@ -183,7 +188,7 @@ func (w *Watcher) checkAndRotateContextMode(ctx context.Context, result docker.C
 			slog.Bool("swarm_mode", swarmMode),
 		)
 
-		if err := docker.RotateProjectCertificates(ctx, result.Name, result.Cli, labels, w.secretProvider, swarmMode); err != nil {
+		if err := docker.RotateProjectCertificates(ctx, result.Name, result.Cli, labels, w.secretProvider, swarmMode, w.certOptions); err != nil {
 			contextLog.Error("failed to rotate certificate",
 				slog.String("project", project),
 				slog.Bool("swarm_mode", swarmMode),

--- a/internal/docker/cert_rotation_redeploy.go
+++ b/internal/docker/cert_rotation_redeploy.go
@@ -168,14 +168,14 @@ func rotateSwarmProjectCertificates(
 // failures are only logged, not returned, since the certificate has already been redeployed
 // successfully by the time this runs.
 func pruneSwarmStackRevisions(ctx context.Context, dockerCli command.Cli, stackName string, deployConfig *deploy.Config, opts CertificateRotationOptions) {
-	if retention := deployConfig.ResolveSwarmConfigRetention(opts.DockerSwarmConfigRetention); retention >= 0 {
+	if retention := deployConfig.ResolveSwarmConfigRetention(opts.SwarmRetention.Config); retention >= 0 {
 		if err := PruneStackConfigs(ctx, dockerCli.Client(), stackName, retention); err != nil {
 			slog.Warn("failed to prune swarm stack configs after cert rotation",
 				slog.String("project", stackName), logger.ErrAttr(err))
 		}
 	}
 
-	if retention := deployConfig.ResolveSwarmSecretRetention(opts.DockerSwarmSecretRetention); retention >= 0 {
+	if retention := deployConfig.ResolveSwarmSecretRetention(opts.SwarmRetention.Secret); retention >= 0 {
 		if err := PruneStackSecrets(ctx, dockerCli.Client(), stackName, retention); err != nil {
 			slog.Warn("failed to prune swarm stack secrets after cert rotation",
 				slog.String("project", stackName), logger.ErrAttr(err))

--- a/internal/docker/cert_rotation_redeploy.go
+++ b/internal/docker/cert_rotation_redeploy.go
@@ -45,9 +45,10 @@ func RotateProjectCertificates(
 	labels map[string]string,
 	secretProvider secretprovider.SecretProvider,
 	swarmMode bool,
+	opts CertificateRotationOptions,
 ) error {
 	if swarmMode {
-		return rotateSwarmProjectCertificates(ctx, contextName, dockerCli, labels, secretProvider)
+		return rotateSwarmProjectCertificates(ctx, contextName, dockerCli, labels, secretProvider, opts)
 	}
 
 	ref, err := composeScheduledServiceRefFromLabels(labels)
@@ -65,7 +66,7 @@ func RotateProjectCertificates(
 	lock.LockStack(stackLockKey)
 	defer lock.UnlockStack(stackLockKey)
 
-	project, deployConfig, err := loadComposeScheduledProjectAll(ctx, dockerCli, ref, secretProvider)
+	project, deployConfig, err := loadComposeScheduledProjectAll(ctx, dockerCli, ref, secretProvider, opts.Scheduled)
 	if err != nil {
 		return fmt.Errorf("reload deploy config for cert rotation of %s: %w", ref.Project, err)
 	}
@@ -116,6 +117,7 @@ func rotateSwarmProjectCertificates(
 	dockerCli command.Cli,
 	labels map[string]string,
 	secretProvider secretprovider.SecretProvider,
+	certOpts CertificateRotationOptions,
 ) error {
 	ref, err := composeScheduledServiceRefFromSwarmLabels(labels)
 	if err != nil {
@@ -127,7 +129,7 @@ func rotateSwarmProjectCertificates(
 	lock.LockStack(stackLockKey)
 	defer lock.UnlockStack(stackLockKey)
 
-	project, deployConfig, err := loadComposeScheduledProjectAll(ctx, dockerCli, ref, secretProvider)
+	project, deployConfig, err := loadComposeScheduledProjectAll(ctx, dockerCli, ref, secretProvider, certOpts.Scheduled)
 	if err != nil {
 		return fmt.Errorf("reload deploy config for cert rotation of %s: %w", ref.Project, err)
 	}
@@ -156,7 +158,7 @@ func rotateSwarmProjectCertificates(
 		return fmt.Errorf("redeploy swarm stack %s for cert rotation: %w", ref.Project, err)
 	}
 
-	pruneSwarmStackRevisions(ctx, dockerCli, ref.Project, deployConfig)
+	pruneSwarmStackRevisions(ctx, dockerCli, ref.Project, deployConfig, certOpts)
 
 	return nil
 }
@@ -165,23 +167,15 @@ func rotateSwarmProjectCertificates(
 // rotation redeploy, honoring the same retention settings as a normal Swarm deploy. Prune
 // failures are only logged, not returned, since the certificate has already been redeployed
 // successfully by the time this runs.
-func pruneSwarmStackRevisions(ctx context.Context, dockerCli command.Cli, stackName string, deployConfig *deploy.Config) {
-	appConfig, err := app.GetConfig()
-	if err != nil {
-		slog.Warn("skipping swarm config/secret prune after cert rotation: failed to load app config",
-			slog.String("project", stackName), logger.ErrAttr(err))
-
-		return
-	}
-
-	if retention := deployConfig.ResolveSwarmConfigRetention(appConfig.DockerSwarmConfigRetention); retention >= 0 {
+func pruneSwarmStackRevisions(ctx context.Context, dockerCli command.Cli, stackName string, deployConfig *deploy.Config, opts CertificateRotationOptions) {
+	if retention := deployConfig.ResolveSwarmConfigRetention(opts.DockerSwarmConfigRetention); retention >= 0 {
 		if err := PruneStackConfigs(ctx, dockerCli.Client(), stackName, retention); err != nil {
 			slog.Warn("failed to prune swarm stack configs after cert rotation",
 				slog.String("project", stackName), logger.ErrAttr(err))
 		}
 	}
 
-	if retention := deployConfig.ResolveSwarmSecretRetention(appConfig.DockerSwarmSecretRetention); retention >= 0 {
+	if retention := deployConfig.ResolveSwarmSecretRetention(opts.DockerSwarmSecretRetention); retention >= 0 {
 		if err := PruneStackSecrets(ctx, dockerCli.Client(), stackName, retention); err != nil {
 			slog.Warn("failed to prune swarm stack secrets after cert rotation",
 				slog.String("project", stackName), logger.ErrAttr(err))

--- a/internal/docker/cert_rotation_redeploy_test.go
+++ b/internal/docker/cert_rotation_redeploy_test.go
@@ -26,7 +26,7 @@ func TestRotateProjectCertificates_MissingLabels(t *testing.T) {
 
 // TestPruneSwarmStackRevisions_RetentionHonoredIndependentOfEnvVar proves that Swarm
 // config/secret revision retention is controlled solely by
-// CertificateRotationOptions.DockerSwarmConfigRetention/DockerSwarmSecretRetention, not by
+// CertificateRotationOptions.SwarmRetention, not by
 // reading the DOCKER_SWARM_CONFIG_RETENTION/DOCKER_SWARM_SECRET_RETENTION environment variables
 // directly. A stale environment value that would enable pruning must have no effect: when the
 // options explicitly disable pruning (-1) and the deploy config has no override, no attempt is
@@ -39,8 +39,10 @@ func TestPruneSwarmStackRevisions_RetentionHonoredIndependentOfEnvVar(t *testing
 	t.Setenv("DOCKER_SWARM_SECRET_RETENTION", "5")
 
 	opts := CertificateRotationOptions{
-		DockerSwarmConfigRetention: -1,
-		DockerSwarmSecretRetention: -1,
+		SwarmRetention: SwarmRetentionOptions{
+			Config: -1,
+			Secret: -1,
+		},
 	}
 	deployConfig := &deploy.Config{}
 

--- a/internal/docker/cert_rotation_redeploy_test.go
+++ b/internal/docker/cert_rotation_redeploy_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 	"github.com/kimdre/doco-cd/internal/lock"
@@ -17,14 +18,37 @@ import (
 )
 
 func TestRotateProjectCertificates_MissingLabels(t *testing.T) {
-	err := RotateProjectCertificates(context.Background(), "", nil, map[string]string{}, nil, false)
+	err := RotateProjectCertificates(context.Background(), "", nil, map[string]string{}, nil, false, CertificateRotationOptions{})
 	if err == nil {
 		t.Fatal("expected an error for missing deployment labels")
 	}
 }
 
+// TestPruneSwarmStackRevisions_RetentionHonoredIndependentOfEnvVar proves that Swarm
+// config/secret revision retention is controlled solely by
+// CertificateRotationOptions.DockerSwarmConfigRetention/DockerSwarmSecretRetention, not by
+// reading the DOCKER_SWARM_CONFIG_RETENTION/DOCKER_SWARM_SECRET_RETENTION environment variables
+// directly. A stale environment value that would enable pruning must have no effect: when the
+// options explicitly disable pruning (-1) and the deploy config has no override, no attempt is
+// made to reach the Docker daemon at all. dockerCli is passed as nil here; if the retention
+// resolution incorrectly fell back to reading the environment variables (which are set to a
+// pruning-enabled value below), calling dockerCli.Client() on the nil interface would panic and
+// fail the test.
+func TestPruneSwarmStackRevisions_RetentionHonoredIndependentOfEnvVar(t *testing.T) {
+	t.Setenv("DOCKER_SWARM_CONFIG_RETENTION", "5")
+	t.Setenv("DOCKER_SWARM_SECRET_RETENTION", "5")
+
+	opts := CertificateRotationOptions{
+		DockerSwarmConfigRetention: -1,
+		DockerSwarmSecretRetention: -1,
+	}
+	deployConfig := &deploy.Config{}
+
+	pruneSwarmStackRevisions(context.Background(), nil, "stack", deployConfig, opts)
+}
+
 func TestRotateProjectCertificates_SwarmMissingLabels(t *testing.T) {
-	err := RotateProjectCertificates(context.Background(), "", nil, map[string]string{}, nil, true)
+	err := RotateProjectCertificates(context.Background(), "", nil, map[string]string{}, nil, true, CertificateRotationOptions{})
 	if err == nil {
 		t.Fatal("expected an error for missing deployment labels in swarm mode")
 	}
@@ -60,7 +84,7 @@ func TestRotateProjectCertificates_ContextNamespacesLock(t *testing.T) {
 	done := make(chan error, 1)
 
 	go func() {
-		done <- RotateProjectCertificates(context.Background(), "docker01", nil, labels, nil, true)
+		done <- RotateProjectCertificates(context.Background(), "docker01", nil, labels, nil, true, CertificateRotationOptions{})
 	}()
 
 	select {
@@ -81,8 +105,10 @@ func TestRotateProjectCertificates_ContextNamespacesLock(t *testing.T) {
 // file list to find the project at all.
 func TestRotateProjectCertificates_SwarmReloadFallsBackToConfiguredComposeFiles(t *testing.T) {
 	dataMountPath := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
-	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+	scheduledOpts := ScheduledComposeOptions{
+		ComposeLoad:         ComposeLoadOptions{DataMountPath: dataMountPath},
+		DeployConfigBaseDir: "/",
+	}
 
 	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
 
@@ -132,7 +158,7 @@ external_secrets:
 
 	provider := newStubProvider(map[string]string{"CERT": certPEM}, nil)
 
-	project, _, err := loadComposeScheduledProjectAll(context.Background(), nil, ref, provider)
+	project, _, err := loadComposeScheduledProjectAll(context.Background(), nil, ref, provider, scheduledOpts)
 	if err != nil {
 		t.Fatalf("unexpected error reloading project: %v", err)
 	}
@@ -154,8 +180,10 @@ external_secrets:
 // off to deployCompose (which requires a live Docker daemon and is out of scope for this unit test).
 func TestRotateProjectCertificates_ReloadReissuesCertAndRelabels(t *testing.T) {
 	dataMountPath := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
-	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+	scheduledOpts := ScheduledComposeOptions{
+		ComposeLoad:         ComposeLoadOptions{DataMountPath: dataMountPath},
+		DeployConfigBaseDir: "/",
+	}
 
 	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
 
@@ -200,7 +228,7 @@ external_secrets:
 
 	provider := newStubProvider(map[string]string{"CERT": certPEM}, nil)
 
-	project, deployConfig, err := loadComposeScheduledProjectAll(context.Background(), nil, ref, provider)
+	project, deployConfig, err := loadComposeScheduledProjectAll(context.Background(), nil, ref, provider, scheduledOpts)
 	if err != nil {
 		t.Fatalf("unexpected error reloading project: %v", err)
 	}
@@ -245,8 +273,10 @@ external_secrets:
 // relies on that label to find the correct .doco-cd.<target>.yml file.
 func TestRotateProjectCertificates_ReloadPreservesConfigTargetLabel(t *testing.T) {
 	dataMountPath := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
-	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+	scheduledOpts := ScheduledComposeOptions{
+		ComposeLoad:         ComposeLoadOptions{DataMountPath: dataMountPath},
+		DeployConfigBaseDir: "/",
+	}
 
 	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
 
@@ -292,7 +322,7 @@ external_secrets:
 
 	provider := newStubProvider(map[string]string{"CERT": certPEM}, nil)
 
-	project, deployConfig, err := loadComposeScheduledProjectAll(context.Background(), nil, ref, provider)
+	project, deployConfig, err := loadComposeScheduledProjectAll(context.Background(), nil, ref, provider, scheduledOpts)
 	if err != nil {
 		t.Fatalf("unexpected error reloading project: %v", err)
 	}
@@ -322,8 +352,10 @@ external_secrets:
 // services with no relation to the rotated certificate are excluded.
 func TestServicesUsingRotatableCerts(t *testing.T) {
 	dataMountPath := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
-	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+	scheduledOpts := ScheduledComposeOptions{
+		ComposeLoad:         ComposeLoadOptions{DataMountPath: dataMountPath},
+		DeployConfigBaseDir: "/",
+	}
 
 	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
 
@@ -385,7 +417,7 @@ external_secrets:
 
 	provider := newStubProvider(map[string]string{"CERT": certPEM}, nil)
 
-	project, deployConfig, err := loadComposeScheduledProjectAll(context.Background(), nil, ref, provider)
+	project, deployConfig, err := loadComposeScheduledProjectAll(context.Background(), nil, ref, provider, scheduledOpts)
 	if err != nil {
 		t.Fatalf("unexpected error reloading project: %v", err)
 	}
@@ -440,8 +472,12 @@ func TestRotateSwarmProjectCertificatesIntegration(t *testing.T) {
 	stackName := test.ConvertTestName(t.Name())
 
 	dataMountPath := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
-	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+	certOpts := CertificateRotationOptions{
+		Scheduled: ScheduledComposeOptions{
+			ComposeLoad:         ComposeLoadOptions{DataMountPath: dataMountPath},
+			DeployConfigBaseDir: "/",
+		},
+	}
 
 	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
 	workingDir := filepath.Join(repoRoot, "stacks", stackName)
@@ -488,7 +524,7 @@ external_secrets:
 		}
 	})
 
-	if err := RotateProjectCertificates(t.Context(), "", dockerCli, labels, provider, true); err != nil {
+	if err := RotateProjectCertificates(t.Context(), "", dockerCli, labels, provider, true, certOpts); err != nil {
 		t.Fatalf("unexpected error rotating swarm project certificates: %v", err)
 	}
 

--- a/internal/docker/compose_deploy.go
+++ b/internal/docker/compose_deploy.go
@@ -315,8 +315,8 @@ func resolveDeploymentMetricsDeploymentLabel(deployName string) string {
 // repository path used to resolve compose file locations, the Docker CLI, the parsed webhook
 // payload (may be nil for non-webhook triggers), the resolved deploy config, detected service
 // changes and signal targets from change detection, the latest commit, the running app version,
-// Swarm config/secret retention counts, whether Swarm mode is active, and the PKI role
-// normalization map.
+// the ComposeLoadOptions used to reload the compose project, Swarm config/secret retention counts,
+// whether Swarm mode is active, and the PKI role normalization map.
 type DeployRequest struct {
 	JobLog                     *slog.Logger `validate:"required,nostructlevel"`
 	ExternalRepoPath           string       `validate:"required"`
@@ -327,6 +327,7 @@ type DeployRequest struct {
 	NeedSignal                 []SignalService
 	LatestCommit               string
 	AppVersion                 string `validate:"required"`
+	ComposeLoad                ComposeLoadOptions
 	GlobalSwarmConfigRetention int
 	GlobalSwarmSecretRetention int
 	SwarmMode                  bool
@@ -348,6 +349,7 @@ func DeployStack(ctx context.Context, req DeployRequest) error {
 		needSignal                 = req.NeedSignal
 		latestCommit               = req.LatestCommit
 		appVersion                 = req.AppVersion
+		composeLoad                = req.ComposeLoad
 		globalSwarmConfigRetention = req.GlobalSwarmConfigRetention
 		globalSwarmSecretRetention = req.GlobalSwarmSecretRetention
 		swarmMode                  = req.SwarmMode
@@ -387,7 +389,7 @@ func DeployStack(ctx context.Context, req DeployRequest) error {
 	deploymentPhase.Set("loading compose configuration")
 
 	project, err := LoadCompose(ctx, dockerCli, externalRepoPath, externalWorkingDir, deployConfig.Name, deployConfig.ComposeFiles,
-		deployConfig.EnvFiles, deployConfig.Profiles, deployConfig.Internal.Environment)
+		deployConfig.EnvFiles, deployConfig.Profiles, deployConfig.Internal.Environment, composeLoad)
 	if err != nil {
 		return fmt.Errorf("failed to load compose config: %w", err)
 	}

--- a/internal/docker/compose_deploy.go
+++ b/internal/docker/compose_deploy.go
@@ -315,23 +315,22 @@ func resolveDeploymentMetricsDeploymentLabel(deployName string) string {
 // repository path used to resolve compose file locations, the Docker CLI, the parsed webhook
 // payload (may be nil for non-webhook triggers), the resolved deploy config, detected service
 // changes and signal targets from change detection, the latest commit, the running app version,
-// the ComposeLoadOptions used to reload the compose project, Swarm config/secret retention counts,
+// the ComposeLoadOptions used to reload the compose project, Swarm retention settings,
 // whether Swarm mode is active, and the PKI role normalization map.
 type DeployRequest struct {
-	JobLog                     *slog.Logger `validate:"required,nostructlevel"`
-	ExternalRepoPath           string       `validate:"required"`
-	DockerCLI                  command.Cli  `validate:"required,nostructlevel"`
-	Payload                    *webhook.ParsedPayload
-	DeployConfig               *deploy.Config `validate:"required,nostructlevel"`
-	DetectedChanges            []Change
-	NeedSignal                 []SignalService
-	LatestCommit               string
-	AppVersion                 string `validate:"required"`
-	ComposeLoad                ComposeLoadOptions
-	GlobalSwarmConfigRetention int
-	GlobalSwarmSecretRetention int
-	SwarmMode                  bool
-	HashNormMap                map[string]string
+	JobLog           *slog.Logger `validate:"required,nostructlevel"`
+	ExternalRepoPath string       `validate:"required"`
+	DockerCLI        command.Cli  `validate:"required,nostructlevel"`
+	Payload          *webhook.ParsedPayload
+	DeployConfig     *deploy.Config `validate:"required,nostructlevel"`
+	DetectedChanges  []Change
+	NeedSignal       []SignalService
+	LatestCommit     string
+	AppVersion       string `validate:"required"`
+	ComposeLoad      ComposeLoadOptions
+	SwarmRetention   SwarmRetentionOptions
+	SwarmMode        bool
+	HashNormMap      map[string]string
 }
 
 func DeployStack(ctx context.Context, req DeployRequest) error {
@@ -340,20 +339,19 @@ func DeployStack(ctx context.Context, req DeployRequest) error {
 	}
 
 	var (
-		jobLog                     = req.JobLog
-		externalRepoPath           = req.ExternalRepoPath
-		dockerCli                  = req.DockerCLI
-		payload                    = req.Payload
-		deployConfig               = req.DeployConfig
-		detectedChanges            = req.DetectedChanges
-		needSignal                 = req.NeedSignal
-		latestCommit               = req.LatestCommit
-		appVersion                 = req.AppVersion
-		composeLoad                = req.ComposeLoad
-		globalSwarmConfigRetention = req.GlobalSwarmConfigRetention
-		globalSwarmSecretRetention = req.GlobalSwarmSecretRetention
-		swarmMode                  = req.SwarmMode
-		hashNormMap                = req.HashNormMap
+		jobLog           = req.JobLog
+		externalRepoPath = req.ExternalRepoPath
+		dockerCli        = req.DockerCLI
+		payload          = req.Payload
+		deployConfig     = req.DeployConfig
+		detectedChanges  = req.DetectedChanges
+		needSignal       = req.NeedSignal
+		latestCommit     = req.LatestCommit
+		appVersion       = req.AppVersion
+		composeLoad      = req.ComposeLoad
+		swarmRetention   = req.SwarmRetention
+		swarmMode        = req.SwarmMode
+		hashNormMap      = req.HashNormMap
 	)
 
 	startTime := time.Now()
@@ -434,8 +432,8 @@ func DeployStack(ctx context.Context, req DeployRequest) error {
 
 	// When SwarmModeEnabled is true, we deploy the stack using Docker Swarm.
 	if swarmMode {
-		swarmConfigRetention := deployConfig.ResolveSwarmConfigRetention(globalSwarmConfigRetention)
-		swarmSecretRetention := deployConfig.ResolveSwarmSecretRetention(globalSwarmSecretRetention)
+		swarmConfigRetention := deployConfig.ResolveSwarmConfigRetention(swarmRetention.Config)
+		swarmSecretRetention := deployConfig.ResolveSwarmSecretRetention(swarmRetention.Secret)
 
 		deploymentPhase.Set("deploying swarm stack")
 

--- a/internal/docker/compose_ipv6_test.go
+++ b/internal/docker/compose_ipv6_test.go
@@ -71,7 +71,7 @@ networks:
 			filePath := filepath.Join(tmpDir, "compose.yaml")
 			createComposeFile(t, filePath, tc.compose)
 
-			project, err := LoadCompose(context.Background(), nil, tmpDir, tmpDir, "test-stack", []string{filePath}, nil, nil, map[string]string{})
+			project, err := LoadCompose(context.Background(), nil, tmpDir, tmpDir, "test-stack", []string{filePath}, nil, nil, map[string]string{}, ComposeLoadOptions{})
 			if err != nil {
 				t.Fatalf("LoadCompose() error = %v", err)
 			}

--- a/internal/docker/compose_kill_test.go
+++ b/internal/docker/compose_kill_test.go
@@ -22,7 +22,7 @@ func TestComposeSignal(t *testing.T) {
 
 	stackName := test.ConvertTestName(t.Name())
 
-	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{})
+	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{}, ComposeLoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docker/compose_load.go
+++ b/internal/docker/compose_load.go
@@ -17,28 +17,29 @@ import (
 	"github.com/docker/cli/cli/command"
 
 	"github.com/kimdre/doco-cd/internal/common/types/slice"
-	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/encryption"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 )
 
 // LoadCompose parses and loads Compose files as specified by the Docker Compose specification.
-// dockerCli is required to load OCI artifact includes.
+// dockerCli is required to load OCI artifact includes. opts bundles the Docker-owned settings
+// (env passthrough, Git/OCI remote include configuration) needed beyond the compose project
+// parameters themselves; callers resolve it explicitly (see NewComposeLoadOptions) instead of
+// LoadCompose reading the application configuration itself.
 func LoadCompose(ctx context.Context, dockerCli command.Cli, repoPath, workingDir, projectName string, composeFiles,
-	envFiles, profiles []string, environment map[string]string,
+	envFiles, profiles []string, environment map[string]string, opts ComposeLoadOptions,
 ) (*types.Project, error) {
+	var (
+		absComposeFiles []string
+		err             error
+	)
+
 	// Resolve compose file paths to absolute paths relative to workingDir.
 	// This is necessary because the compose-go library's LoadConfigFiles internally
 	// uses filepath.Abs which resolves relative paths against os.Getwd(), not against
 	// the specified working directory. Without this, concurrent deployments with
 	// different working directories would fail since they share the same process
 	// working directory.
-	c, err := app.GetConfig()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get app config: %w", err)
-	}
-
-	var absComposeFiles []string
 
 	// If the user changed the default compose files, we throw an error of the custom compose file is not found
 	throwError := !reflect.DeepEqual(composeFiles, cli.DefaultFileNames)
@@ -100,7 +101,7 @@ func LoadCompose(ctx context.Context, dockerCli command.Cli, repoPath, workingDi
 	}
 
 	// Remote include support (Git repositories and OCI artifacts).
-	for _, remoteLoader := range newRemoteResourceLoaders(c, dockerCli, repoPath) {
+	for _, remoteLoader := range newRemoteResourceLoaders(opts, dockerCli, repoPath) {
 		projectOptions = append(projectOptions, cli.WithResourceLoader(remoteLoader))
 	}
 
@@ -119,7 +120,7 @@ func LoadCompose(ctx context.Context, dockerCli command.Cli, repoPath, workingDi
 		}
 	}
 
-	if c.PassEnv {
+	if opts.PassEnv {
 		err = cli.WithOsEnv(options)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get OS environment variables for interpolation: %w", err)

--- a/internal/docker/compose_load_options.go
+++ b/internal/docker/compose_load_options.go
@@ -1,0 +1,121 @@
+package docker
+
+import (
+	"github.com/go-git/go-git/v5/plumbing/transport"
+
+	"github.com/kimdre/doco-cd/internal/config/app"
+)
+
+// ComposeLoadOptions bundles the Docker-owned settings LoadCompose needs beyond the individual
+// compose project parameters (compose/env files, profiles, environment). These settings originate
+// in the application configuration, but callers resolve and pass them in explicitly at a
+// composition/stage boundary (see NewComposeLoadOptions) instead of letting LoadCompose read the
+// application configuration itself. This keeps LoadCompose free of hidden environment reads.
+type ComposeLoadOptions struct {
+	// PassEnv controls whether the doco-cd process's own OS environment variables are passed
+	// through to the compose project for variable interpolation.
+	PassEnv bool
+	// SkipTLSVerify skips TLS verification when following Git remote includes.
+	SkipTLSVerify bool
+	// HttpProxy configures the proxy used when following Git remote includes.
+	HttpProxy transport.ProxyOptions
+	// GitCloneSubmodules controls whether submodules are cloned for Git remote includes.
+	GitCloneSubmodules bool
+	// GitCloneDepth limits the number of commits fetched for Git remote includes. 0 means a full clone.
+	GitCloneDepth int
+	// SSHPrivateKey and SSHPrivateKeyPassphrase configure SSH authentication for Git remote includes.
+	SSHPrivateKey           string
+	SSHPrivateKeyPassphrase string
+	// GitAccessToken configures HTTP(S) authentication for Git remote includes.
+	GitAccessToken string
+	// OciInsecureRegistries lists registries for OCI Compose includes with TLS verification disabled.
+	OciInsecureRegistries []string
+	// DataHostPath and DataMountPath are used as a fallback base directory for the Git include
+	// cache when the repository path passed to LoadCompose is empty. DataHostPath (the Docker
+	// daemon host path) is preferred since the cache must be reachable outside the container by
+	// the daemon performing the checkout.
+	DataHostPath  string
+	DataMountPath string
+}
+
+// NewComposeLoadOptions builds the ComposeLoadOptions LoadCompose needs from the application
+// configuration. Call this once at a composition/stage boundary and pass the result down
+// explicitly, rather than letting deep Docker helpers read the application configuration
+// themselves.
+func NewComposeLoadOptions(c *app.Config) ComposeLoadOptions {
+	if c == nil {
+		return ComposeLoadOptions{}
+	}
+
+	return ComposeLoadOptions{
+		PassEnv:                 c.PassEnv,
+		SkipTLSVerify:           c.SkipTLSVerification,
+		HttpProxy:               c.HttpProxy,
+		GitCloneSubmodules:      c.GitCloneSubmodules,
+		GitCloneDepth:           c.GitCloneDepth,
+		SSHPrivateKey:           c.SSHPrivateKey,
+		SSHPrivateKeyPassphrase: c.SSHPrivateKeyPassphrase,
+		GitAccessToken:          c.GitAccessToken,
+		OciInsecureRegistries:   c.OciInsecureRegistries,
+		DataHostPath:            c.DataHostPath,
+		DataMountPath:           c.DataMountPath,
+	}
+}
+
+// ScheduledComposeOptions bundles the Docker-owned settings needed to reload the Compose project
+// for a scheduled job (see RunComposeScheduledContainer/RunComposeOneOffFromServiceDefinition) or
+// for certificate rotation (see CertificateRotationOptions), beyond what LoadCompose itself needs.
+type ScheduledComposeOptions struct {
+	// ComposeLoad is passed through to the LoadCompose call used to reload the project.
+	ComposeLoad ComposeLoadOptions
+	// DeployConfigBaseDir is the base directory (relative to the repository root) where
+	// deployment configuration files are searched for.
+	DeployConfigBaseDir string
+	// InterpolateExternalSecrets enables Compose-style interpolation in legacy external secret
+	// references using the doco-cd process environment.
+	InterpolateExternalSecrets bool
+}
+
+// NewScheduledComposeOptions builds ScheduledComposeOptions from the application configuration.
+// Call this once at a composition/stage boundary and pass the result down explicitly.
+func NewScheduledComposeOptions(c *app.Config) ScheduledComposeOptions {
+	if c == nil {
+		return ScheduledComposeOptions{}
+	}
+
+	return ScheduledComposeOptions{
+		ComposeLoad:                NewComposeLoadOptions(c),
+		DeployConfigBaseDir:        c.DeployConfigBaseDir,
+		InterpolateExternalSecrets: c.InterpolateExternalSecrets,
+	}
+}
+
+// CertificateRotationOptions bundles the Docker-owned settings needed by RotateProjectCertificates
+// beyond the deployment labels it is given: the settings needed to reload the scheduled Compose
+// project (see ScheduledComposeOptions) plus the global Swarm config/secret revision retention
+// defaults used to prune superseded revisions after a Swarm rotation redeploy.
+type CertificateRotationOptions struct {
+	// Scheduled is passed through to reload the deploy config/compose project being rotated.
+	Scheduled ScheduledComposeOptions
+	// DockerSwarmConfigRetention is the global default number of old Swarm config revisions to
+	// keep per resource (excluding the active one). -1 disables automatic pruning.
+	DockerSwarmConfigRetention int
+	// DockerSwarmSecretRetention is the global default number of old Swarm secret revisions to
+	// keep per resource (excluding the active one). -1 disables automatic pruning.
+	DockerSwarmSecretRetention int
+}
+
+// NewCertificateRotationOptions builds CertificateRotationOptions from the application
+// configuration. Call this once at a composition/stage boundary and pass the result down
+// explicitly.
+func NewCertificateRotationOptions(c *app.Config) CertificateRotationOptions {
+	if c == nil {
+		return CertificateRotationOptions{}
+	}
+
+	return CertificateRotationOptions{
+		Scheduled:                  NewScheduledComposeOptions(c),
+		DockerSwarmConfigRetention: c.DockerSwarmConfigRetention,
+		DockerSwarmSecretRetention: c.DockerSwarmSecretRetention,
+	}
+}

--- a/internal/docker/compose_load_options.go
+++ b/internal/docker/compose_load_options.go
@@ -90,19 +90,34 @@ func NewScheduledComposeOptions(c *app.Config) ScheduledComposeOptions {
 	}
 }
 
-// CertificateRotationOptions bundles the Docker-owned settings needed by RotateProjectCertificates
-// beyond the deployment labels it is given: the settings needed to reload the scheduled Compose
-// project (see ScheduledComposeOptions) plus the global Swarm config/secret revision retention
-// defaults used to prune superseded revisions after a Swarm rotation redeploy.
+// SwarmRetentionOptions holds the global defaults for pruning superseded Swarm config and secret
+// revisions after a deployment.
+type SwarmRetentionOptions struct {
+	// Config is the global default number of old Swarm config revisions to
+	// keep per resource (excluding the active one). -1 disables automatic pruning.
+	Config int
+	// Secret is the global default number of old Swarm secret revisions to
+	// keep per resource (excluding the active one). -1 disables automatic pruning.
+	Secret int
+}
+
+// NewSwarmRetentionOptions builds SwarmRetentionOptions from the application configuration.
+func NewSwarmRetentionOptions(c *app.Config) SwarmRetentionOptions {
+	if c == nil {
+		return SwarmRetentionOptions{}
+	}
+
+	return SwarmRetentionOptions{
+		Config: c.DockerSwarmConfigRetention,
+		Secret: c.DockerSwarmSecretRetention,
+	}
+}
+
+// CertificateRotationOptions bundles the settings needed by RotateProjectCertificates to reload
+// the project and apply the shared Swarm retention policy after a rotation redeploy.
 type CertificateRotationOptions struct {
-	// Scheduled is passed through to reload the deploy config/compose project being rotated.
-	Scheduled ScheduledComposeOptions
-	// DockerSwarmConfigRetention is the global default number of old Swarm config revisions to
-	// keep per resource (excluding the active one). -1 disables automatic pruning.
-	DockerSwarmConfigRetention int
-	// DockerSwarmSecretRetention is the global default number of old Swarm secret revisions to
-	// keep per resource (excluding the active one). -1 disables automatic pruning.
-	DockerSwarmSecretRetention int
+	Scheduled      ScheduledComposeOptions
+	SwarmRetention SwarmRetentionOptions
 }
 
 // NewCertificateRotationOptions builds CertificateRotationOptions from the application
@@ -114,8 +129,7 @@ func NewCertificateRotationOptions(c *app.Config) CertificateRotationOptions {
 	}
 
 	return CertificateRotationOptions{
-		Scheduled:                  NewScheduledComposeOptions(c),
-		DockerSwarmConfigRetention: c.DockerSwarmConfigRetention,
-		DockerSwarmSecretRetention: c.DockerSwarmSecretRetention,
+		Scheduled:      NewScheduledComposeOptions(c),
+		SwarmRetention: NewSwarmRetentionOptions(c),
 	}
 }

--- a/internal/docker/compose_load_options_test.go
+++ b/internal/docker/compose_load_options_test.go
@@ -1,0 +1,108 @@
+package docker
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+
+	"github.com/kimdre/doco-cd/internal/config/app"
+)
+
+func TestNewComposeLoadOptions(t *testing.T) {
+	t.Parallel()
+
+	config := &app.Config{
+		PassEnv:                    true,
+		SkipTLSVerification:        true,
+		HttpProxy:                   transport.ProxyOptions{URL: "https://proxy.example.com"},
+		GitCloneSubmodules:         true,
+		GitCloneDepth:              5,
+		SSHPrivateKey:              "private-key",
+		SSHPrivateKeyPassphrase:    "passphrase",
+		GitAccessToken:             "access-token",
+		OciInsecureRegistries:      []string{"registry.example.com"},
+		DataHostPath:               "/host/data",
+		DataMountPath:              "/data",
+		DeployConfigBaseDir:        "/deploy",
+		InterpolateExternalSecrets: true,
+		DockerSwarmConfigRetention: 3,
+		DockerSwarmSecretRetention: 4,
+	}
+
+	want := ComposeLoadOptions{
+		PassEnv:                 true,
+		SkipTLSVerify:           true,
+		HttpProxy:               transport.ProxyOptions{URL: "https://proxy.example.com"},
+		GitCloneSubmodules:      true,
+		GitCloneDepth:           5,
+		SSHPrivateKey:           "private-key",
+		SSHPrivateKeyPassphrase: "passphrase",
+		GitAccessToken:          "access-token",
+		OciInsecureRegistries:   []string{"registry.example.com"},
+		DataHostPath:            "/host/data",
+		DataMountPath:           "/data",
+	}
+
+	if got := NewComposeLoadOptions(config); !reflect.DeepEqual(got, want) {
+		t.Fatalf("NewComposeLoadOptions() = %+v, want %+v", got, want)
+	}
+}
+
+func TestNewScheduledComposeOptions(t *testing.T) {
+	t.Parallel()
+
+	config := &app.Config{
+		PassEnv:                    true,
+		DeployConfigBaseDir:        "/deploy",
+		InterpolateExternalSecrets: true,
+	}
+
+	want := ScheduledComposeOptions{
+		ComposeLoad:                ComposeLoadOptions{PassEnv: true},
+		DeployConfigBaseDir:        "/deploy",
+		InterpolateExternalSecrets: true,
+	}
+
+	if got := NewScheduledComposeOptions(config); !reflect.DeepEqual(got, want) {
+		t.Fatalf("NewScheduledComposeOptions() = %+v, want %+v", got, want)
+	}
+}
+
+func TestNewCertificateRotationOptions(t *testing.T) {
+	t.Parallel()
+
+	config := &app.Config{
+		DeployConfigBaseDir:        "/deploy",
+		DockerSwarmConfigRetention: 3,
+		DockerSwarmSecretRetention: 4,
+	}
+
+	want := CertificateRotationOptions{
+		Scheduled: ScheduledComposeOptions{
+			DeployConfigBaseDir: "/deploy",
+		},
+		DockerSwarmConfigRetention: 3,
+		DockerSwarmSecretRetention: 4,
+	}
+
+	if got := NewCertificateRotationOptions(config); !reflect.DeepEqual(got, want) {
+		t.Fatalf("NewCertificateRotationOptions() = %+v, want %+v", got, want)
+	}
+}
+
+func TestRuntimeOptionsConstructorsAllowNilConfig(t *testing.T) {
+	t.Parallel()
+
+	if got := NewComposeLoadOptions(nil); !reflect.DeepEqual(got, ComposeLoadOptions{}) {
+		t.Fatalf("NewComposeLoadOptions(nil) = %+v, want zero value", got)
+	}
+
+	if got := NewScheduledComposeOptions(nil); !reflect.DeepEqual(got, ScheduledComposeOptions{}) {
+		t.Fatalf("NewScheduledComposeOptions(nil) = %+v, want zero value", got)
+	}
+
+	if got := NewCertificateRotationOptions(nil); !reflect.DeepEqual(got, CertificateRotationOptions{}) {
+		t.Fatalf("NewCertificateRotationOptions(nil) = %+v, want zero value", got)
+	}
+}

--- a/internal/docker/compose_load_options_test.go
+++ b/internal/docker/compose_load_options_test.go
@@ -82,12 +82,32 @@ func TestNewCertificateRotationOptions(t *testing.T) {
 		Scheduled: ScheduledComposeOptions{
 			DeployConfigBaseDir: "/deploy",
 		},
-		DockerSwarmConfigRetention: 3,
-		DockerSwarmSecretRetention: 4,
+		SwarmRetention: SwarmRetentionOptions{
+			Config: 3,
+			Secret: 4,
+		},
 	}
 
 	if got := NewCertificateRotationOptions(config); !reflect.DeepEqual(got, want) {
 		t.Fatalf("NewCertificateRotationOptions() = %+v, want %+v", got, want)
+	}
+}
+
+func TestNewSwarmRetentionOptions(t *testing.T) {
+	t.Parallel()
+
+	config := &app.Config{
+		DockerSwarmConfigRetention: 3,
+		DockerSwarmSecretRetention: 4,
+	}
+
+	want := SwarmRetentionOptions{
+		Config: 3,
+		Secret: 4,
+	}
+
+	if got := NewSwarmRetentionOptions(config); !reflect.DeepEqual(got, want) {
+		t.Fatalf("NewSwarmRetentionOptions() = %+v, want %+v", got, want)
 	}
 }
 
@@ -100,6 +120,10 @@ func TestRuntimeOptionsConstructorsAllowNilConfig(t *testing.T) {
 
 	if got := NewScheduledComposeOptions(nil); !reflect.DeepEqual(got, ScheduledComposeOptions{}) {
 		t.Fatalf("NewScheduledComposeOptions(nil) = %+v, want zero value", got)
+	}
+
+	if got := NewSwarmRetentionOptions(nil); !reflect.DeepEqual(got, SwarmRetentionOptions{}) {
+		t.Fatalf("NewSwarmRetentionOptions(nil) = %+v, want zero value", got)
 	}
 
 	if got := NewCertificateRotationOptions(nil); !reflect.DeepEqual(got, CertificateRotationOptions{}) {

--- a/internal/docker/compose_load_options_test.go
+++ b/internal/docker/compose_load_options_test.go
@@ -15,7 +15,7 @@ func TestNewComposeLoadOptions(t *testing.T) {
 	config := &app.Config{
 		PassEnv:                    true,
 		SkipTLSVerification:        true,
-		HttpProxy:                   transport.ProxyOptions{URL: "https://proxy.example.com"},
+		HttpProxy:                  transport.ProxyOptions{URL: "https://proxy.example.com"},
 		GitCloneSubmodules:         true,
 		GitCloneDepth:              5,
 		SSHPrivateKey:              "private-key",

--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -16,7 +16,6 @@ import (
 	containerTypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 
-	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 	"github.com/kimdre/doco-cd/internal/git"
@@ -47,13 +46,14 @@ func RunComposeScheduledContainer(
 	labels map[string]string,
 	waitForExit bool,
 	secretProvider secretprovider.SecretProvider,
+	opts ScheduledComposeOptions,
 ) error {
 	ref, err := composeScheduledServiceRefFromLabels(labels)
 	if err != nil {
 		return err
 	}
 
-	project, err := loadComposeScheduledProject(ctx, dockerCli, ref, secretProvider)
+	project, err := loadComposeScheduledProject(ctx, dockerCli, ref, secretProvider, opts)
 	if err != nil {
 		return err
 	}
@@ -108,13 +108,14 @@ func RunComposeOneOffFromServiceDefinition(
 	dockerCli command.Cli,
 	labels map[string]string,
 	secretProvider secretprovider.SecretProvider,
+	opts ScheduledComposeOptions,
 ) error {
 	ref, err := composeScheduledServiceRefFromLabels(labels)
 	if err != nil {
 		return err
 	}
 
-	project, err := loadComposeScheduledProject(ctx, dockerCli, ref, secretProvider)
+	project, err := loadComposeScheduledProject(ctx, dockerCli, ref, secretProvider, opts)
 	if err != nil {
 		return err
 	}
@@ -208,8 +209,9 @@ func loadComposeScheduledProject(
 	dockerCli command.Cli,
 	ref composeScheduledServiceRef,
 	secretProvider secretprovider.SecretProvider,
+	opts ScheduledComposeOptions,
 ) (*types.Project, error) {
-	project, _, err := loadComposeScheduledProjectAll(ctx, dockerCli, ref, secretProvider)
+	project, _, err := loadComposeScheduledProjectAll(ctx, dockerCli, ref, secretProvider, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -234,6 +236,7 @@ func loadComposeScheduledProjectAll(
 	dockerCli command.Cli,
 	ref composeScheduledServiceRef,
 	secretProvider secretprovider.SecretProvider,
+	opts ScheduledComposeOptions,
 ) (*types.Project, *deploy.Config, error) {
 	if ref.WorkingDir == "" {
 		return nil, nil, fmt.Errorf("%w: missing %q label",
@@ -242,7 +245,7 @@ func loadComposeScheduledProjectAll(
 		)
 	}
 
-	deployConfig, repoPath, err := loadComposeScheduledDeployConfig(ctx, ref, secretProvider)
+	deployConfig, repoPath, err := loadComposeScheduledDeployConfig(ctx, ref, secretProvider, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -262,7 +265,7 @@ func loadComposeScheduledProjectAll(
 	}
 
 	project, err := LoadCompose(ctx, dockerCli, repoPath, ref.WorkingDir, ref.Project, configFiles,
-		deployConfig.EnvFiles, deployConfig.Profiles, deployConfig.Internal.Environment)
+		deployConfig.EnvFiles, deployConfig.Profiles, deployConfig.Internal.Environment, opts.ComposeLoad)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load compose project for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
 	}
@@ -389,31 +392,29 @@ func loadComposeScheduledDeployConfig(
 	ctx context.Context,
 	ref composeScheduledServiceRef,
 	secretProvider secretprovider.SecretProvider,
+	opts ScheduledComposeOptions,
 ) (*deploy.Config, string, error) {
 	if strings.TrimSpace(ref.RepositoryURL) == "" || strings.TrimSpace(ref.DeploymentName) == "" {
 		return nil, "", fmt.Errorf("%w: missing deployment repository and/or name label",
 			ErrComposeScheduledMetadataUnavailable)
 	}
 
-	appConfig, err := app.GetConfig()
-	if err != nil {
-		return nil, "", fmt.Errorf("load app config for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
-	}
+	dataMountPath := opts.ComposeLoad.DataMountPath
 
 	sourceRepoPath, err := filesystem.VerifyAndSanitizePath(
-		filepath.Join(appConfig.DataMountPath, git.GetRepoName(ref.RepositoryURL)),
-		appConfig.DataMountPath,
+		filepath.Join(dataMountPath, git.GetRepoName(ref.RepositoryURL)),
+		dataMountPath,
 	)
 	if err != nil {
 		return nil, "", fmt.Errorf("resolve source repository path for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
 	}
 
-	repoPath, err := resolveScheduledComposeRepoRoot(ref.WorkingDir, appConfig.DataMountPath, sourceRepoPath)
+	repoPath, err := resolveScheduledComposeRepoRoot(ref.WorkingDir, dataMountPath, sourceRepoPath)
 	if err != nil {
 		return nil, "", err
 	}
 
-	configs, err := deploy.GetConfigs(sourceRepoPath, appConfig.DeployConfigBaseDir, ref.ConfigTarget, ref.Reference, nil)
+	configs, err := deploy.GetConfigs(sourceRepoPath, opts.DeployConfigBaseDir, ref.ConfigTarget, ref.Reference, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("load deploy config for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
 	}
@@ -431,7 +432,7 @@ func loadComposeScheduledDeployConfig(
 	// correct deployment config file.
 	deployConfig.Internal.ConfigTarget = ref.ConfigTarget
 
-	if err = prepareComposeScheduledDeployConfig(ctx, deployConfig, sourceRepoPath, repoPath, secretProvider); err != nil {
+	if err = prepareComposeScheduledDeployConfig(ctx, deployConfig, sourceRepoPath, repoPath, secretProvider, opts); err != nil {
 		return nil, "", err
 	}
 
@@ -460,6 +461,7 @@ func prepareComposeScheduledDeployConfig(
 	sourceRepoPath string,
 	repoPath string,
 	secretProvider secretprovider.SecretProvider,
+	opts ScheduledComposeOptions,
 ) error {
 	if deployConfig == nil {
 		return fmt.Errorf("%w: missing deployment config", ErrComposeScheduledMetadataUnavailable)
@@ -489,12 +491,7 @@ func prepareComposeScheduledDeployConfig(
 		return nil
 	}
 
-	appConfig, err := app.GetConfig()
-	if err != nil {
-		return fmt.Errorf("load app config for scheduled service %s: %w", deployConfig.Name, err)
-	}
-
-	interpolatedRefs, err := secrettypes.InterpolateExternalSecretRefs(deployConfig.ExternalSecrets, appConfig.InterpolateExternalSecrets)
+	interpolatedRefs, err := secrettypes.InterpolateExternalSecretRefs(deployConfig.ExternalSecrets, opts.InterpolateExternalSecrets)
 	if err != nil {
 		return fmt.Errorf("interpolate external secrets for scheduled service %s: %w", deployConfig.Name, err)
 	}

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -299,7 +299,7 @@ func TestLoadComposeScheduledProject_RequiresComposeMetadata(t *testing.T) {
 		_, err := loadComposeScheduledProject(context.Background(), nil, composeScheduledServiceRef{
 			Project: "project-a",
 			Service: "backup",
-		}, nil)
+		}, nil, ScheduledComposeOptions{})
 		if !errors.Is(err, ErrComposeScheduledMetadataUnavailable) {
 			t.Fatalf("expected ErrComposeScheduledMetadataUnavailable, got %v", err)
 		}
@@ -312,7 +312,7 @@ func TestLoadComposeScheduledProject_RequiresComposeMetadata(t *testing.T) {
 			Project:    "project-a",
 			Service:    "backup",
 			WorkingDir: "/some/dir",
-		}, nil)
+		}, nil, ScheduledComposeOptions{})
 		if !errors.Is(err, ErrComposeScheduledMetadataUnavailable) {
 			t.Fatalf("expected ErrComposeScheduledMetadataUnavailable, got %v", err)
 		}
@@ -325,7 +325,7 @@ func TestLoadComposeScheduledProject_RequiresComposeMetadata(t *testing.T) {
 			Project:     "project-a",
 			Service:     "backup",
 			ConfigFiles: []string{"/some/compose.yaml"},
-		}, nil)
+		}, nil, ScheduledComposeOptions{})
 		if !errors.Is(err, ErrComposeScheduledMetadataUnavailable) {
 			t.Fatalf("expected ErrComposeScheduledMetadataUnavailable, got %v", err)
 		}
@@ -355,7 +355,7 @@ func TestPrepareComposeScheduledDeployConfig(t *testing.T) {
 			},
 		}
 
-		if err := prepareComposeScheduledDeployConfig(context.Background(), cfg, sourceRepoPath, sourceRepoPath, provider); err != nil {
+		if err := prepareComposeScheduledDeployConfig(context.Background(), cfg, sourceRepoPath, sourceRepoPath, provider, ScheduledComposeOptions{}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -386,7 +386,7 @@ func TestPrepareComposeScheduledDeployConfig(t *testing.T) {
 			},
 		}
 
-		err := prepareComposeScheduledDeployConfig(context.Background(), cfg, t.TempDir(), t.TempDir(), provider)
+		err := prepareComposeScheduledDeployConfig(context.Background(), cfg, t.TempDir(), t.TempDir(), provider, ScheduledComposeOptions{})
 		if !errors.Is(err, providerErr) {
 			t.Fatalf("expected provider error, got %v", err)
 		}
@@ -406,7 +406,7 @@ func TestPrepareComposeScheduledDeployConfig(t *testing.T) {
 			EnvFiles:         []string{".env"},
 		}
 
-		if err := prepareComposeScheduledDeployConfig(context.Background(), cfg, repoPath, repoPath, nil); err != nil {
+		if err := prepareComposeScheduledDeployConfig(context.Background(), cfg, repoPath, repoPath, nil, ScheduledComposeOptions{}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -418,8 +418,10 @@ func TestPrepareComposeScheduledDeployConfig(t *testing.T) {
 
 func TestLoadComposeScheduledProject_InterpolatesDeployConfigEnvironment(t *testing.T) {
 	dataMountPath := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
-	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+	opts := ScheduledComposeOptions{
+		ComposeLoad:         ComposeLoadOptions{DataMountPath: dataMountPath},
+		DeployConfigBaseDir: "/",
+	}
 
 	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
 
@@ -453,7 +455,7 @@ environment:
 		RepositoryURL:  "https://example.com/owner/repo",
 		DeploymentName: "adguard-dns",
 		Reference:      "refs/heads/main",
-	}, nil)
+	}, nil, opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -476,8 +478,10 @@ environment:
 // regression test for https://github.com/kimdre/doco-cd/issues/1737.
 func TestLoadComposeScheduledProject_FallsBackWhenLabeledComposeFileIsStale(t *testing.T) {
 	dataMountPath := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
-	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+	opts := ScheduledComposeOptions{
+		ComposeLoad:         ComposeLoadOptions{DataMountPath: dataMountPath},
+		DeployConfigBaseDir: "/",
+	}
 
 	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
 
@@ -509,7 +513,7 @@ compose_files:
 		RepositoryURL:  "https://example.com/owner/repo",
 		DeploymentName: "imap-backup",
 		Reference:      "refs/heads/main",
-	}, nil)
+	}, nil, opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -526,8 +530,10 @@ compose_files:
 // its deploy config at run time.
 func TestLoadComposeScheduledProject_ResolvesExternalSecrets(t *testing.T) {
 	dataMountPath := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", dataMountPath)
-	t.Setenv("DEPLOY_CONFIG_BASE_DIR", "/")
+	opts := ScheduledComposeOptions{
+		ComposeLoad:         ComposeLoadOptions{DataMountPath: dataMountPath},
+		DeployConfigBaseDir: "/",
+	}
 
 	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
 
@@ -569,7 +575,7 @@ external_secrets:
 		RepositoryURL:  "https://example.com/owner/repo",
 		DeploymentName: "backup-job",
 		Reference:      "refs/heads/main",
-	}, newStubProvider(map[string]string{"MY_SECRET": "resolved-secret"}, nil))
+	}, newStubProvider(map[string]string{"MY_SECRET": "resolved-secret"}, nil), opts)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -585,6 +591,81 @@ external_secrets:
 
 	if *svc.Environment["MY_SECRET"] != "resolved-secret" {
 		t.Fatalf("expected MY_SECRET to be resolved from external secret provider, got %q", *svc.Environment["MY_SECRET"])
+	}
+}
+
+// TestLoadComposeScheduledProject_InterpolateExternalSecretsHonoredIndependentOfEnvVar
+// proves that legacy external secret reference interpolation is controlled solely by
+// ScheduledComposeOptions.InterpolateExternalSecrets, not by reading the
+// INTERPOLATE_EXTERNAL_SECRETS environment variable directly. A legacy reference containing
+// an unset variable is left untouched (and so resolves without error) when the option is
+// false, even if a stale INTERPOLATE_EXTERNAL_SECRETS=true is set in the environment; it only
+// fails interpolation (as expected) when the option is explicitly enabled.
+func TestLoadComposeScheduledProject_InterpolateExternalSecretsHonoredIndependentOfEnvVar(t *testing.T) {
+	dataMountPath := t.TempDir()
+
+	repoRoot := filepath.Join(dataMountPath, "example.com", "owner", "repo")
+	workingDir := filepath.Join(repoRoot, "stacks", "nas", "backup")
+
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(workingDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	composePath := filepath.Join(workingDir, "compose.yml")
+	createComposeFile(t, composePath, `services:
+  backup:
+    image: busybox:latest
+    environment:
+      MY_SECRET: ${MY_SECRET}
+`)
+
+	// The legacy reference contains an unguarded variable that is never set in the
+	// process environment; interpolating it must fail because it becomes a
+	// required-but-absent variable.
+	createComposeFile(t, filepath.Join(repoRoot, ".doco-cd.yml"), `name: backup-job
+reference: refs/heads/main
+working_dir: stacks/nas/backup
+compose_files:
+  - compose.yml
+external_secrets:
+  MY_SECRET: item-$UNSET_SECRET_SUFFIX
+`)
+
+	ref := composeScheduledServiceRef{
+		Project:        "backup-job",
+		Service:        "backup",
+		WorkingDir:     workingDir,
+		ConfigFiles:    []string{composePath},
+		RepositoryURL:  "https://example.com/owner/repo",
+		DeploymentName: "backup-job",
+		Reference:      "refs/heads/main",
+	}
+	provider := newStubProvider(map[string]string{"MY_SECRET": "resolved-secret"}, nil)
+
+	// A stale INTERPOLATE_EXTERNAL_SECRETS=true must have no effect: production code no
+	// longer reads this environment variable, only the explicit
+	// ScheduledComposeOptions.InterpolateExternalSecrets field.
+	t.Setenv("INTERPOLATE_EXTERNAL_SECRETS", "true")
+
+	disabledOpts := ScheduledComposeOptions{
+		ComposeLoad:                ComposeLoadOptions{DataMountPath: dataMountPath},
+		DeployConfigBaseDir:        "/",
+		InterpolateExternalSecrets: false,
+	}
+
+	if _, err := loadComposeScheduledProject(context.Background(), nil, ref, provider, disabledOpts); err != nil {
+		t.Fatalf("expected no error with InterpolateExternalSecrets=false despite INTERPOLATE_EXTERNAL_SECRETS=true, got: %v", err)
+	}
+
+	enabledOpts := disabledOpts
+	enabledOpts.InterpolateExternalSecrets = true
+
+	if _, err := loadComposeScheduledProject(context.Background(), nil, ref, provider, enabledOpts); err == nil {
+		t.Fatal("expected an error with InterpolateExternalSecrets=true and an unset reference variable, got nil")
 	}
 }
 

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -112,7 +112,7 @@ func TestLoadCompose(t *testing.T) {
 
 	stackName := test.ConvertTestName(t.Name())
 
-	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{})
+	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{}, ComposeLoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,6 +126,54 @@ func TestLoadCompose(t *testing.T) {
 
 	if len(project.Services) != 1 {
 		t.Fatalf("expected 1 service, got %d", len(project.Services))
+	}
+}
+
+// TestLoadCompose_PassEnvHonoredIndependentOfEnvVar proves that whether the doco-cd process's
+// own OS environment variables are passed through for interpolation is controlled solely by
+// ComposeLoadOptions.PassEnv, not by reading the PASS_ENV environment variable directly. A stale
+// PASS_ENV=true left over from a previous process invocation must not leak OS environment
+// variables into the compose project when the caller explicitly passes PassEnv: false, and setting
+// PassEnv: true must pass them through regardless of what PASS_ENV is set to.
+func TestLoadCompose_PassEnvHonoredIndependentOfEnvVar(t *testing.T) {
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+
+	filePath := filepath.Join(tmpDir, "test.compose.yaml")
+
+	composeYAML := `services:
+  test:
+    image: nginx:latest
+    environment:
+      MARKER: ${DOCO_CD_TEST_PASSENV_MARKER}
+`
+	createComposeFile(t, filePath, composeYAML)
+
+	stackName := test.ConvertTestName(t.Name())
+
+	// A stale PASS_ENV=true must have no effect: production code no longer reads this
+	// environment variable, only the explicit ComposeLoadOptions.PassEnv field.
+	t.Setenv("PASS_ENV", "true")
+	t.Setenv("DOCO_CD_TEST_PASSENV_MARKER", "marker-value")
+
+	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{}, ComposeLoadOptions{PassEnv: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := project.Services["test"].Environment["MARKER"]; ok && got != nil && *got != "" {
+		t.Fatalf("expected MARKER to be unset when PassEnv=false despite PASS_ENV=true, got %q", *got)
+	}
+
+	project, err = LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{}, ComposeLoadOptions{PassEnv: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := project.Services["test"].Environment["MARKER"]
+	if got == nil || *got != "marker-value" {
+		t.Fatalf("expected MARKER to be %q when PassEnv=true, got %v", "marker-value", got)
 	}
 }
 
@@ -268,7 +316,7 @@ func TestDeployCompose(t *testing.T) {
 
 	stackName := test.ConvertTestName(t.Name())
 
-	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{}, []string{}, map[string]string{})
+	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{}, []string{}, map[string]string{}, ComposeLoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -471,6 +519,7 @@ compose_files:
 			deployConf.EnvFiles,
 			deployConf.Profiles,
 			deployConf.Internal.Environment,
+			ComposeLoadOptions{},
 		)
 		if err != nil {
 			t.Fatalf("failed to load expected project: %v", err)
@@ -1602,7 +1651,7 @@ func TestProjectFilesHaveChanges(t *testing.T) {
 				t.Fatalf("Failed to get changed files: %v", err)
 			}
 
-			project, err := LoadCompose(t.Context(), nil, tmpDir, tmpDir, d.Name, d.ComposeFiles, d.EnvFiles, d.Profiles, map[string]string{})
+			project, err := LoadCompose(t.Context(), nil, tmpDir, tmpDir, d.Name, d.ComposeFiles, d.EnvFiles, d.Profiles, map[string]string{}, ComposeLoadOptions{})
 			if err != nil {
 				t.Fatalf("Failed to load compose file: %v", err)
 			}
@@ -1940,7 +1989,7 @@ func TestInjectSecretsToProject(t *testing.T) {
 
 			t.Log("Resolved secrets:", resolvedSecrets)
 
-			project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, test.ConvertTestName(t.Name()), []string{filePath}, []string{".env"}, []string{}, resolvedSecrets)
+			project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, test.ConvertTestName(t.Name()), []string{filePath}, []string{".env"}, []string{}, resolvedSecrets, ComposeLoadOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/docker/git_resource_loader.go
+++ b/internal/docker/git_resource_loader.go
@@ -21,8 +21,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/moby/buildkit/frontend/dockerfile/dfgitutil"
 
-	"github.com/kimdre/doco-cd/internal/config/app"
-
 	"github.com/kimdre/doco-cd/internal/git"
 )
 
@@ -85,26 +83,26 @@ type gitResourceLoaderConfig struct {
 
 // newRemoteResourceLoaders configures Git includes independently of the Docker CLI.
 // OCI includes require the Docker CLI for registry credentials.
-func newRemoteResourceLoaders(c *app.Config, dockerCli command.Cli, repoPath string) []loader.ResourceLoader {
-	cacheBase := resolveIncludeCacheBase(c, repoPath)
+func newRemoteResourceLoaders(opts ComposeLoadOptions, dockerCli command.Cli, repoPath string) []loader.ResourceLoader {
+	cacheBase := resolveIncludeCacheBase(opts, repoPath)
 
 	remoteLoaders := []loader.ResourceLoader{
 		newGitResourceLoader(gitResourceLoaderConfig{
 			CacheBase:       cacheBase,
-			SkipTLSVerify:   c.SkipTLSVerification,
-			ProxyOptions:    c.HttpProxy,
-			CloneSubmodules: c.GitCloneSubmodules,
-			CloneDepth:      c.GitCloneDepth,
-			PrivateKey:      c.SSHPrivateKey,
-			KeyPassphrase:   c.SSHPrivateKeyPassphrase,
-			AccessToken:     c.GitAccessToken,
+			SkipTLSVerify:   opts.SkipTLSVerify,
+			ProxyOptions:    opts.HttpProxy,
+			CloneSubmodules: opts.GitCloneSubmodules,
+			CloneDepth:      opts.GitCloneDepth,
+			PrivateKey:      opts.SSHPrivateKey,
+			KeyPassphrase:   opts.SSHPrivateKeyPassphrase,
+			AccessToken:     opts.GitAccessToken,
 		}),
 	}
 	if dockerCli != nil {
 		remoteLoaders = append(remoteLoaders, loggingResourceLoader{
 			kind: "oci",
 			loader: remote.NewOCIRemoteLoader(dockerCli, false, api.OCIOptions{
-				InsecureRegistries: c.OciInsecureRegistries,
+				InsecureRegistries: opts.OciInsecureRegistries,
 			}),
 		})
 	}
@@ -112,7 +110,7 @@ func newRemoteResourceLoaders(c *app.Config, dockerCli command.Cli, repoPath str
 	return remoteLoaders
 }
 
-func resolveIncludeCacheBase(c *app.Config, repoPath string) string {
+func resolveIncludeCacheBase(opts ComposeLoadOptions, repoPath string) string {
 	repoPath = strings.TrimSpace(repoPath)
 	if repoPath != "" {
 		absRepoPath, err := filepath.Abs(repoPath)
@@ -121,14 +119,12 @@ func resolveIncludeCacheBase(c *app.Config, repoPath string) string {
 		}
 	}
 
-	if c != nil {
-		if base := strings.TrimSpace(c.DataHostPath); base != "" {
-			return base
-		}
+	if base := strings.TrimSpace(opts.DataHostPath); base != "" {
+		return base
+	}
 
-		if base := strings.TrimSpace(c.DataMountPath); base != "" {
-			return base
-		}
+	if base := strings.TrimSpace(opts.DataMountPath); base != "" {
+		return base
 	}
 
 	return os.TempDir()

--- a/internal/docker/git_resource_loader_test.go
+++ b/internal/docker/git_resource_loader_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
 
-	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/test"
 )
@@ -118,7 +117,7 @@ func TestGitResourceLoaderAcceptsDockerComposeGitReferences(t *testing.T) {
 func TestNewRemoteResourceLoadersWithoutDockerCLIIncludesGitOnly(t *testing.T) {
 	repoPath := filepath.Join(t.TempDir(), "repo")
 
-	loaders := newRemoteResourceLoaders(&app.Config{DataMountPath: t.TempDir()}, nil, repoPath)
+	loaders := newRemoteResourceLoaders(ComposeLoadOptions{DataMountPath: t.TempDir()}, nil, repoPath)
 	if len(loaders) != 1 {
 		t.Fatalf("expected only the Git loader without a Docker CLI, got %d loaders", len(loaders))
 	}
@@ -144,7 +143,7 @@ func TestNewRemoteResourceLoadersDoesNotLogCacheBaseWithoutIncludeUsage(t *testi
 		slog.SetDefault(previousDefault)
 	})
 
-	newRemoteResourceLoaders(&app.Config{DataMountPath: t.TempDir()}, nil, filepath.Join(t.TempDir(), "repo"))
+	newRemoteResourceLoaders(ComposeLoadOptions{DataMountPath: t.TempDir()}, nil, filepath.Join(t.TempDir(), "repo"))
 
 	var entry map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &entry); err == nil {
@@ -160,7 +159,7 @@ func TestNewRemoteResourceLoadersDoesNotLogCacheBaseWithoutIncludeUsage(t *testi
 
 func TestResolveIncludeCacheBaseUsesRepoParent(t *testing.T) {
 	repoPath := filepath.Join(t.TempDir(), "repo")
-	got := resolveIncludeCacheBase(&app.Config{DataMountPath: "/data", DataHostPath: "/host-data"}, repoPath)
+	got := resolveIncludeCacheBase(ComposeLoadOptions{DataMountPath: "/data", DataHostPath: "/host-data"}, repoPath)
 	want := filepath.Dir(repoPath)
 
 	if got != want {
@@ -169,14 +168,14 @@ func TestResolveIncludeCacheBaseUsesRepoParent(t *testing.T) {
 }
 
 func TestResolveIncludeCacheBaseFallsBackToDataHostPath(t *testing.T) {
-	got := resolveIncludeCacheBase(&app.Config{DataMountPath: "/data", DataHostPath: "/host-data"}, "")
+	got := resolveIncludeCacheBase(ComposeLoadOptions{DataMountPath: "/data", DataHostPath: "/host-data"}, "")
 	if got != "/host-data" {
 		t.Fatalf("expected /host-data, got %q", got)
 	}
 }
 
 func TestResolveIncludeCacheBaseFallsBackToDataMountPath(t *testing.T) {
-	got := resolveIncludeCacheBase(&app.Config{DataMountPath: "/data"}, "")
+	got := resolveIncludeCacheBase(ComposeLoadOptions{DataMountPath: "/data"}, "")
 	if got != "/data" {
 		t.Fatalf("expected /data, got %q", got)
 	}
@@ -421,8 +420,6 @@ func TestLoadComposeWithRealPublicGitIncludeFullRoundtrip(t *testing.T) {
 	skipUnlessGitIncludeIntegration(t)
 
 	workingDirectory := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", t.TempDir())
-	t.Setenv("WEBHOOK_SECRET", "test-secret")
 
 	// docker-compose.yml at the root of this repo defines the "doco-cd" service
 	// and has no .env or extends dependencies, making it a safe integration target.
@@ -445,6 +442,7 @@ func TestLoadComposeWithRealPublicGitIncludeFullRoundtrip(t *testing.T) {
 		nil,
 		nil,
 		map[string]string{},
+		ComposeLoadOptions{},
 	)
 	if err != nil {
 		t.Fatalf("LoadCompose with real Git include: %v", err)
@@ -463,8 +461,6 @@ func TestLoadComposeWithGitIncludeWithoutDockerCLI(t *testing.T) {
 	defer restoreTransport()
 
 	workingDirectory := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", t.TempDir())
-	t.Setenv("WEBHOOK_SECRET", "test-secret")
 
 	rootComposePath := filepath.Join(workingDirectory, "compose.yaml")
 
@@ -483,6 +479,7 @@ func TestLoadComposeWithGitIncludeWithoutDockerCLI(t *testing.T) {
 		nil,
 		nil,
 		map[string]string{},
+		ComposeLoadOptions{},
 	)
 	if err != nil {
 		t.Fatalf("load compose with Git include: %v", err)
@@ -609,12 +606,8 @@ func TestDeployComposeWithGitInclude(t *testing.T) {
 	restoreTransport := installLocalGitTransport(t, repo)
 	defer restoreTransport()
 
-	// Set env vars required by LoadCompose → app.GetConfig().
-	workDir := t.TempDir()
-	t.Setenv("DATA_MOUNT_PATH", t.TempDir())
-	t.Setenv("WEBHOOK_SECRET", "test-secret")
-
 	// Root compose file whose only job is to include the Git-hosted one.
+	workDir := t.TempDir()
 	rootComposePath := filepath.Join(workDir, "compose.yaml")
 	rootCompose := "include:\n  - path: git://example.test/repo.git#main\n"
 
@@ -630,6 +623,7 @@ func TestDeployComposeWithGitInclude(t *testing.T) {
 		[]string{rootComposePath},
 		nil, nil,
 		map[string]string{},
+		ComposeLoadOptions{},
 	)
 	if err != nil {
 		t.Fatalf("LoadCompose: %v", err)

--- a/internal/docker/service_utils_test.go
+++ b/internal/docker/service_utils_test.go
@@ -535,7 +535,7 @@ services:
 
 	stackName := test.ConvertTestName(t.Name())
 
-	_, err = LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{})
+	_, err = LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{}, ComposeLoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -628,7 +628,7 @@ services:
 
 	stackName := test.ConvertTestName(t.Name())
 
-	project, err := LoadCompose(t.Context(), nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{})
+	project, err := LoadCompose(t.Context(), nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{}, ComposeLoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docker/swarm_idempotency_test.go
+++ b/internal/docker/swarm_idempotency_test.go
@@ -101,7 +101,7 @@ func TestDeploySwarmStackIsIdempotent(t *testing.T) {
 
 	filePath := filepath.Join(worktree.Filesystem.Root(), "docker-compose.yml")
 
-	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{})
+	project, err := LoadCompose(ctx, nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{}, ComposeLoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docker/swarm_test.go
+++ b/internal/docker/swarm_test.go
@@ -75,7 +75,7 @@ func TestDeploySwarmStack(t *testing.T) {
 	repoPath := worktree.Filesystem.Root()
 	filePath := filepath.Join(repoPath, "docker-compose.yml")
 
-	project, err := LoadCompose(t.Context(), nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{})
+	project, err := LoadCompose(t.Context(), nil, tmpDir, tmpDir, stackName, []string{filePath}, []string{".env"}, []string{}, map[string]string{}, ComposeLoadOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcp/jobs_test.go
+++ b/internal/mcp/jobs_test.go
@@ -228,7 +228,7 @@ func TestMCPScheduledJobsTool(t *testing.T) {
 
 	t.Cleanup(func() { _ = contexts.Close() })
 
-	schedulerManager := scheduler.NewManager(contexts, h.log.Logger, nil, nil, nil)
+	schedulerManager := scheduler.NewManager(contexts, h.log.Logger, nil, nil, nil, docker.ScheduledComposeOptions{})
 	h.controlPlaneRuns = newTestControlPlaneRuns(t, testControlPlaneRunsOptions{
 		dockerCli: dockerCli,
 		log:       h.log,

--- a/internal/scheduler/scheduler_api.go
+++ b/internal/scheduler/scheduler_api.go
@@ -184,11 +184,11 @@ func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (
 	return runID, nil
 }
 
-func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, secretProvider secretprovider.SecretProvider, runtime *runtimeStore, stackName string) ([]JobInfo, error) {
+func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, secretProvider secretprovider.SecretProvider, runtime *runtimeStore, stackName string, composeOptions docker.ScheduledComposeOptions) ([]JobInfo, error) {
 	var result []JobInfo
 
 	for _, mode := range modes {
-		jobs, err := newSchedulerForMode(cc, mode, log, nil, secretProvider, nil, runtime).listJobs(ctx, stackName)
+		jobs, err := newSchedulerForMode(cc, mode, log, nil, secretProvider, nil, runtime, composeOptions).listJobs(ctx, stackName)
 		if err != nil {
 			return nil, err
 		}
@@ -199,13 +199,13 @@ func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.C
 	return result, nil
 }
 
-func triggerNowForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, jobName, stackName string, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker, runtime *runtimeStore) (string, error) {
+func triggerNowForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, jobName, stackName string, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker, runtime *runtimeStore, composeOptions docker.ScheduledComposeOptions) (string, error) {
 	workers := make(map[scheduledJobMode]*scheduler, len(modes))
 
 	var jobs []scheduledJob
 
 	for _, mode := range modes {
-		worker := newSchedulerForMode(cc, mode, log, nil, secretProvider, stopHoldTracker, runtime)
+		worker := newSchedulerForMode(cc, mode, log, nil, secretProvider, stopHoldTracker, runtime, composeOptions)
 
 		discovered, err := worker.discoverJobs(ctx)
 		if err != nil {

--- a/internal/scheduler/scheduler_execution.go
+++ b/internal/scheduler/scheduler_execution.go
@@ -47,7 +47,7 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 	case scheduledJobModeContainer:
 		switch cfg.ExecutionMode {
 		case docker.JobExecutionModeOneOff:
-			err := docker.RunComposeOneOffFromServiceDefinition(ctx, s.dockerCli, job.labels, s.secretProvider)
+			err := docker.RunComposeOneOffFromServiceDefinition(ctx, s.dockerCli, job.labels, s.secretProvider, s.composeOptions)
 			if err == nil {
 				return nil
 			}
@@ -58,7 +58,7 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 
 			return docker.RunContainerOneOffFromExisting(ctx, s.dockerCli.Client(), job.id)
 		default:
-			err := docker.RunComposeScheduledContainer(ctx, s.dockerCli, job.id, job.labels, len(cfg.StopServices) > 0, s.secretProvider)
+			err := docker.RunComposeScheduledContainer(ctx, s.dockerCli, job.id, job.labels, len(cfg.StopServices) > 0, s.secretProvider, s.composeOptions)
 			if err == nil {
 				return nil
 			}

--- a/internal/scheduler/scheduler_manager.go
+++ b/internal/scheduler/scheduler_manager.go
@@ -32,6 +32,9 @@ type Manager struct {
 	secretProvider  secretprovider.SecretProvider
 	stopHoldTracker ServiceStopHoldTracker
 	runtime         *runtimeStore
+	// composeOptions bundles the Docker-owned settings needed to reload scheduled Compose
+	// projects (see docker.ScheduledComposeOptions), resolved explicitly at composition time.
+	composeOptions docker.ScheduledComposeOptions
 
 	mu      sync.Mutex
 	workers map[string]managedWorker // key = normalized context name + runtime mode
@@ -50,7 +53,7 @@ type managedWorker struct {
 // NewManager creates a scheduler Manager bound to registry. log and wg are
 // required for Start (running background workers) but may be omitted if the
 // Manager is only used for on-demand ListJobs/TriggerNow calls.
-func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker) *Manager {
+func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker, composeOptions docker.ScheduledComposeOptions) *Manager {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -62,6 +65,7 @@ func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.Wai
 		secretProvider:  secretProvider,
 		stopHoldTracker: stopHoldTracker,
 		runtime:         newRuntimeStore(),
+		composeOptions:  composeOptions,
 		workers:         map[string]managedWorker{},
 	}
 }
@@ -134,7 +138,7 @@ func (m *Manager) refreshWorkers(ctx context.Context) {
 				continue
 			}
 
-			worker := newSchedulerForMode(result.ContextClient, mode, m.log, m.wg, m.secretProvider, m.stopHoldTracker, m.runtime)
+			worker := newSchedulerForMode(result.ContextClient, mode, m.log, m.wg, m.secretProvider, m.stopHoldTracker, m.runtime, m.composeOptions)
 			workerCtx, cancel := context.WithCancel(ctx)
 			m.nextID++
 			workerID := m.nextID
@@ -180,7 +184,7 @@ func (m *Manager) ListJobs(ctx context.Context, contextName, stackName string) (
 		return nil, fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
 	}
 
-	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, m.secretProvider, m.runtime, stackName)
+	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, m.secretProvider, m.runtime, stackName, m.composeOptions)
 }
 
 // TriggerNow executes one configured scheduled job immediately on the given
@@ -196,7 +200,7 @@ func (m *Manager) TriggerNow(ctx context.Context, contextName, jobName, stackNam
 		return "", fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
 	}
 
-	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, jobName, stackName, secretProvider, m.stopHoldTracker, m.runtime)
+	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, jobName, stackName, secretProvider, m.stopHoldTracker, m.runtime, m.composeOptions)
 }
 
 // stopWorkers requests cancellation for every managed worker. Each worker

--- a/internal/scheduler/scheduler_runtime_test.go
+++ b/internal/scheduler/scheduler_runtime_test.go
@@ -241,8 +241,8 @@ func TestUpdateRuntimeRunStatus(t *testing.T) {
 func TestManagerRuntimeStateIsIsolated(t *testing.T) {
 	t.Parallel()
 
-	first := NewManager(nil, nil, nil, nil, nil)
-	second := NewManager(nil, nil, nil, nil, nil)
+	first := NewManager(nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
+	second := NewManager(nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	key := "container:project/service"
 
 	first.runtime.setLastRun(key, time.Now())
@@ -276,7 +276,7 @@ func TestRuntimeStoreClearContextModePreservesOtherPartitions(t *testing.T) {
 func TestManagerStopWorkersClearsRuntimeState(t *testing.T) {
 	t.Parallel()
 
-	manager := NewManager(nil, nil, nil, nil, nil)
+	manager := NewManager(nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	key := schedulerWorkerKey("remote", scheduledJobModeContainer)
 	jobKey := "remote::container:shared/job"
 	cancelled := false
@@ -311,7 +311,7 @@ func TestManagerStopWorkersClearsRuntimeState(t *testing.T) {
 func TestManagerOldWorkerCannotClearReplacementState(t *testing.T) {
 	t.Parallel()
 
-	manager := NewManager(nil, nil, nil, nil, nil)
+	manager := NewManager(nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	key := schedulerWorkerKey("remote", scheduledJobModeContainer)
 	jobKey := "remote::container:shared/job"
 	manager.workers[key] = managedWorker{

--- a/internal/scheduler/scheduler_types.go
+++ b/internal/scheduler/scheduler_types.go
@@ -66,6 +66,10 @@ type scheduler struct {
 	startedAt       time.Time
 	runtime         *runtimeStore
 	runs            sync.WaitGroup
+	// composeOptions bundles the Docker-owned settings needed to reload the compose project for
+	// a scheduled run (see docker.ScheduledComposeOptions), resolved explicitly by the caller
+	// instead of being read from the application configuration deep inside the Docker package.
+	composeOptions docker.ScheduledComposeOptions
 
 	states map[string]scheduledJobState
 
@@ -132,7 +136,7 @@ type JobInfo struct {
 // newSchedulerForMode builds a scheduler worker bound to a single Docker
 // context and runtime mode. log and wg may be nil for short-lived, one-shot
 // workers (e.g. a single ListJobs/TriggerNow call) that never call run().
-func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker, runtime *runtimeStore) *scheduler {
+func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker, runtime *runtimeStore, composeOptions docker.ScheduledComposeOptions) *scheduler {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -153,6 +157,7 @@ func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *sl
 		wg:              wg,
 		startedAt:       schedulerNow(),
 		runtime:         runtime,
+		composeOptions:  composeOptions,
 		states:          map[string]scheduledJobState{},
 		stopHolds:       map[stopHoldKey]*stopHoldState{},
 	}

--- a/internal/scheduler/scheduler_types_test.go
+++ b/internal/scheduler/scheduler_types_test.go
@@ -21,7 +21,7 @@ func TestJobKeyPrefix(t *testing.T) {
 func TestNewSchedulerForMode_NormalizesContextAndCarriesMode(t *testing.T) {
 	t.Parallel()
 
-	s := newSchedulerForMode(docker.ContextClient{Name: "Default", SwarmMode: true}, scheduledJobModeSwarm, nil, nil, nil, nil, nil)
+	s := newSchedulerForMode(docker.ContextClient{Name: "Default", SwarmMode: true}, scheduledJobModeSwarm, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	if s.contextName != "" {
 		t.Fatalf("newSchedulerForMode() contextName = %q, want empty string for the default context", s.contextName)
 	}
@@ -30,7 +30,7 @@ func TestNewSchedulerForMode_NormalizesContextAndCarriesMode(t *testing.T) {
 		t.Fatalf("newSchedulerForMode() mode = %q, want %q", s.mode, scheduledJobModeSwarm)
 	}
 
-	remote := newSchedulerForMode(docker.ContextClient{Name: "remote", SwarmMode: false}, scheduledJobModeContainer, nil, nil, nil, nil, nil)
+	remote := newSchedulerForMode(docker.ContextClient{Name: "remote", SwarmMode: false}, scheduledJobModeContainer, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	if remote.contextName != "remote" {
 		t.Fatalf("newSchedulerForMode() contextName = %q, want %q", remote.contextName, "remote")
 	}

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -17,7 +17,6 @@ import (
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
 
 	"github.com/kimdre/doco-cd/internal/config"
-	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/git"
 )
@@ -127,12 +126,7 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 	if s.SecretProvider != nil && len(s.DeployConfig.ExternalSecrets) > 0 {
 		stageLog.Debug("resolving external secrets", slog.Any("external_secrets", s.DeployConfig.ExternalSecrets))
 
-		appConfig, err := app.GetConfig()
-		if err != nil {
-			return fmt.Errorf("failed to get app config: %w", err)
-		}
-
-		interpolatedRefs, err := secrettypes.InterpolateExternalSecretRefs(s.DeployConfig.ExternalSecrets, appConfig.InterpolateExternalSecrets)
+		interpolatedRefs, err := secrettypes.InterpolateExternalSecretRefs(s.DeployConfig.ExternalSecrets, s.AppConfig.InterpolateExternalSecrets)
 		if err != nil {
 			return fmt.Errorf("failed to interpolate external secret references: %w", err)
 		}
@@ -437,7 +431,7 @@ func (s *StageManager) loadComposeProjectHash(ctx context.Context) (string, erro
 	s.Docker.Project, err = docker.LoadCompose(
 		ctx, s.Docker.Cmd, s.Repository.PathExternal, extAbsWorkingDir, s.DeployConfig.Name,
 		s.DeployConfig.ComposeFiles, s.DeployConfig.EnvFiles,
-		s.DeployConfig.Profiles, s.DeployConfig.Internal.Environment)
+		s.DeployConfig.Profiles, s.DeployConfig.Internal.Environment, docker.NewComposeLoadOptions(s.AppConfig))
 	if err != nil {
 		return "", fmt.Errorf("failed to load compose project: %w", err)
 	}

--- a/internal/stages/stage_3_deploy.go
+++ b/internal/stages/stage_3_deploy.go
@@ -40,6 +40,7 @@ func (s *StageManager) RunDeployStage(ctx context.Context, stageLog *slog.Logger
 		NeedSignal:                 s.DeployState.ignoredInfo.NeedSendSignal,
 		LatestCommit:               latestCommit,
 		AppVersion:                 app.Version,
+		ComposeLoad:                docker.NewComposeLoadOptions(s.AppConfig),
 		GlobalSwarmConfigRetention: s.AppConfig.DockerSwarmConfigRetention,
 		GlobalSwarmSecretRetention: s.AppConfig.DockerSwarmSecretRetention,
 		SwarmMode:                  s.Docker.SwarmMode,

--- a/internal/stages/stage_3_deploy.go
+++ b/internal/stages/stage_3_deploy.go
@@ -31,20 +31,19 @@ func (s *StageManager) RunDeployStage(ctx context.Context, stageLog *slog.Logger
 	}
 
 	err = docker.DeployStack(ctx, docker.DeployRequest{
-		JobLog:                     stageLog,
-		ExternalRepoPath:           s.Repository.PathExternal,
-		DockerCLI:                  s.Docker.Cmd,
-		Payload:                    s.Payload,
-		DeployConfig:               s.DeployConfig,
-		DetectedChanges:            s.DeployState.changedServices,
-		NeedSignal:                 s.DeployState.ignoredInfo.NeedSendSignal,
-		LatestCommit:               latestCommit,
-		AppVersion:                 app.Version,
-		ComposeLoad:                docker.NewComposeLoadOptions(s.AppConfig),
-		GlobalSwarmConfigRetention: s.AppConfig.DockerSwarmConfigRetention,
-		GlobalSwarmSecretRetention: s.AppConfig.DockerSwarmSecretRetention,
-		SwarmMode:                  s.Docker.SwarmMode,
-		HashNormMap:                pkiRoleNormMap(s.DeployConfig.ExternalSecrets, s.DeployConfig.Internal.Environment),
+		JobLog:           stageLog,
+		ExternalRepoPath: s.Repository.PathExternal,
+		DockerCLI:        s.Docker.Cmd,
+		Payload:          s.Payload,
+		DeployConfig:     s.DeployConfig,
+		DetectedChanges:  s.DeployState.changedServices,
+		NeedSignal:       s.DeployState.ignoredInfo.NeedSendSignal,
+		LatestCommit:     latestCommit,
+		AppVersion:       app.Version,
+		ComposeLoad:      docker.NewComposeLoadOptions(s.AppConfig),
+		SwarmRetention:   docker.NewSwarmRetentionOptions(s.AppConfig),
+		SwarmMode:        s.Docker.SwarmMode,
+		HashNormMap:      pkiRoleNormMap(s.DeployConfig.ExternalSecrets, s.DeployConfig.Internal.Environment),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to deploy stack %s: %w", s.DeployConfig.Name, err)


### PR DESCRIPTION
Closes part of #1764.

## Summary
- replace hidden runtime `app.GetConfig()` calls with explicit Docker-owned option values
- inject Compose loading, scheduled-run, and certificate-rotation settings from application composition
- use the existing stage configuration directly for external-secret interpolation
- make tests supply runtime settings without mutating process-global environment configuration

## Behavior preserved
- Compose environment interpolation and Git/OCI remote includes
- scheduled Compose project/config reloads and external-secret resolution
- certificate-rotation Swarm config/secret retention

## Validation
- affected Docker, scheduler, certificate-rotation, and stages package suites
- full project build