### PR TITLE
refactor(docker): centralize runtime capabilities and queries

### DIFF
--- a/cmd/doco-cd/controlplane_test_helpers_test.go
+++ b/cmd/doco-cd/controlplane_test_helpers_test.go
@@ -23,6 +23,15 @@ import (
 func newTestReconciliationManager(t *testing.T, dependencies reconciliation.Dependencies) *reconciliation.Manager {
 	t.Helper()
 
+	if dependencies.Contexts == nil {
+		dependencies.Contexts = docker.NewContextRegistry(dependencies.DockerCLI, docker.ContextRegistryOptions{
+			Quiet:         true,
+			SwarmFeatures: true,
+		})
+
+		t.Cleanup(func() { _ = dependencies.Contexts.Close() })
+	}
+
 	manager, err := reconciliation.NewManager(dependencies)
 	if err != nil {
 		t.Fatalf("failed to create reconciliation manager: %v", err)
@@ -36,7 +45,7 @@ func newTestReconciliationManager(t *testing.T, dependencies reconciliation.Depe
 // newTestDeployment builds a *controlplane.Deployment backed by a fresh
 // reconciliation manager and source preparer, for tests that previously wired
 // a bare *reconciliation.Manager directly into handleEvent/RunPoll.
-func newTestDeployment(t *testing.T, appConfig *app.Config, dataMountPoint container.MountPoint, dockerCli command.Cli, reconciliationDeps reconciliation.Dependencies) *controlplane.Deployment {
+func newTestDeployment(t *testing.T, appConfig *app.Config, dataMountPoint container.MountPoint, reconciliationDeps reconciliation.Dependencies) *controlplane.Deployment {
 	t.Helper()
 
 	manager := newTestReconciliationManager(t, reconciliationDeps)
@@ -49,7 +58,6 @@ func newTestDeployment(t *testing.T, appConfig *app.Config, dataMountPoint conta
 	deployment, err := controlplane.NewDeployment(controlplane.DeploymentDependencies{
 		SourcePreparer: preparer,
 		Reconciler:     manager,
-		DockerCLI:      dockerCli,
 		DataMountPoint: dataMountPoint,
 	})
 	if err != nil {

--- a/cmd/doco-cd/controlplane_test_helpers_test.go
+++ b/cmd/doco-cd/controlplane_test_helpers_test.go
@@ -48,6 +48,15 @@ func newTestReconciliationManager(t *testing.T, dependencies reconciliation.Depe
 func newTestDeployment(t *testing.T, appConfig *app.Config, dataMountPoint container.MountPoint, reconciliationDeps reconciliation.Dependencies) *controlplane.Deployment {
 	t.Helper()
 
+	if reconciliationDeps.Contexts == nil {
+		reconciliationDeps.Contexts = docker.NewContextRegistry(reconciliationDeps.DockerCLI, docker.ContextRegistryOptions{
+			Quiet:         true,
+			SwarmFeatures: true,
+		})
+
+		t.Cleanup(func() { _ = reconciliationDeps.Contexts.Close() })
+	}
+
 	manager := newTestReconciliationManager(t, reconciliationDeps)
 
 	preparer, err := source.NewPreparer(source.Dependencies{AppConfig: appConfig})
@@ -58,6 +67,7 @@ func newTestDeployment(t *testing.T, appConfig *app.Config, dataMountPoint conta
 	deployment, err := controlplane.NewDeployment(controlplane.DeploymentDependencies{
 		SourcePreparer: preparer,
 		Reconciler:     manager,
+		Contexts:       reconciliationDeps.Contexts,
 		DataMountPoint: dataMountPoint,
 	})
 	if err != nil {

--- a/cmd/doco-cd/handler_poll_test.go
+++ b/cmd/doco-cd/handler_poll_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/config/poll"
 	"github.com/kimdre/doco-cd/internal/controlplane"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
@@ -355,7 +354,7 @@ func TestRunPoll(t *testing.T) {
 
 	stackName := test.ConvertTestName(t.Name())
 
-	if swarm.GetModeEnabled() {
+	if SwarmModeEnabled {
 		pollConfig.Reference = git.SwarmModeBranch
 
 		t.Log("Testing in Swarm mode, using 'swarm-mode' reference")
@@ -417,7 +416,7 @@ func TestRunPoll(t *testing.T) {
 	})
 
 	t.Cleanup(func() {
-		if swarm.GetModeEnabled() {
+		if SwarmModeEnabled {
 			err = docker.RemoveSwarmStack(ctx, dockerCli, stackName)
 		} else {
 			err = service.Down(ctx, stackName, downOpts)
@@ -435,7 +434,7 @@ func TestRunPoll(t *testing.T) {
 	}
 
 	// Run initial poll
-	deployment := newTestDeployment(t, appConfig, dataMountPoint, dockerCli, reconciliation.Dependencies{
+	deployment := newTestDeployment(t, appConfig, dataMountPoint, reconciliation.Dependencies{
 		AppConfig:      appConfig,
 		DataMountPoint: dataMountPoint,
 		DockerCLI:      dockerCli,

--- a/cmd/doco-cd/handler_webhook_test.go
+++ b/cmd/doco-cd/handler_webhook_test.go
@@ -32,8 +32,6 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/test"
 
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
-
 	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/encryption"
 	"github.com/kimdre/doco-cd/internal/lock"
@@ -226,7 +224,7 @@ func TestHandlerData_WebhookHandler(t *testing.T) {
 
 	var cloneUrl string
 
-	if swarm.GetModeEnabled() {
+	if SwarmModeEnabled {
 		payloadFile = githubPayloadFileSwarmMode
 		cloneUrl = "https://github.com/kimdre/doco-cd_tests.git"
 		indexPath = path.Join("html", "index.html")
@@ -256,7 +254,7 @@ func TestHandlerData_WebhookHandler(t *testing.T) {
 
 	appConfig.GitCommitStatus = false
 
-	if !swarm.GetModeEnabled() {
+	if !SwarmModeEnabled {
 		// Route the payload's clone URL to the local fixture repo created
 		// above, so this test never clones the live kimdre/doco-cd repo.
 		appConfig.SourceURLRewrites = map[string]string{
@@ -292,7 +290,7 @@ func TestHandlerData_WebhookHandler(t *testing.T) {
 		log:       log,
 		testName:  stackName,
 
-		deployment: newTestDeployment(t, appConfig, mountPoint, dockerCli, reconciliation.Dependencies{
+		deployment: newTestDeployment(t, appConfig, mountPoint, reconciliation.Dependencies{
 			AppConfig:      appConfig,
 			DataMountPoint: mountPoint,
 			DockerCLI:      dockerCli,
@@ -340,7 +338,7 @@ func TestHandlerData_WebhookHandler(t *testing.T) {
 		testContainerPort string
 	)
 
-	if swarm.GetModeEnabled() {
+	if SwarmModeEnabled {
 		t.Log("Testing in Swarm mode")
 
 		inspectName := stackName + "_" + "test"

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -36,8 +36,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 	"github.com/kimdre/doco-cd/internal/secretprovider/openbao"
 
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
-
 	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/docker/registryauth"
 	"github.com/kimdre/doco-cd/internal/filesystem"
@@ -251,28 +249,31 @@ func run() error {
 		}
 	}
 
-	if c.DockerSwarmFeatures {
-		if err := swarm.RefreshModeEnabled(ctx, dockerClient); err != nil {
-			log.Critical("failed to check if docker daemon is a swarm manager", logger.ErrAttr(err))
-			return err
-		}
-	} else {
-		swarm.SetDisableSwarmFeature(true)
+	if !c.DockerSwarmFeatures {
 		log.Debug("swarm features disabled by configuration")
 	}
 
-	contexts := docker.NewContextRegistry(dockerCli, c.DockerQuietDeploy)
+	contexts := docker.NewContextRegistry(dockerCli, docker.ContextRegistryOptions{
+		Quiet:         c.DockerQuietDeploy,
+		SwarmFeatures: c.DockerSwarmFeatures,
+	})
 	defer func() {
 		if closeErr := contexts.Close(); closeErr != nil {
 			log.Error("failed to close docker context clients", logger.ErrAttr(closeErr))
 		}
 	}()
 
+	defaultContext, err := contexts.Get(ctx, docker.DefaultContextName)
+	if err != nil {
+		log.Critical("failed to check default Docker context capabilities", logger.ErrAttr(err))
+		return err
+	}
+
 	log.Debug("negotiated docker versions to use",
 		slog.Group("versions",
 			slog.String("docker_client", dockerClient.ClientVersion()),
 			slog.String("docker_api", dockerCli.CurrentVersion()),
-			slog.Bool("swarm_mode", swarm.GetModeEnabled()),
+			slog.Bool("swarm_mode", defaultContext.SwarmMode),
 		))
 
 	dataMountPoint, err := resolveDataMountPoint(
@@ -375,7 +376,6 @@ func run() error {
 	deployment, err := controlplane.NewDeployment(controlplane.DeploymentDependencies{
 		SourcePreparer: sourcePreparer,
 		Reconciler:     reconciliationManager,
-		DockerCLI:      dockerCli,
 		DataMountPoint: dataMountPoint,
 	})
 	if err != nil {

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -376,6 +376,7 @@ func run() error {
 	deployment, err := controlplane.NewDeployment(controlplane.DeploymentDependencies{
 		SourcePreparer: sourcePreparer,
 		Reconciler:     reconciliationManager,
+		Contexts:       contexts,
 		DataMountPoint: dataMountPoint,
 	})
 	if err != nil {

--- a/cmd/doco-cd/main_test.go
+++ b/cmd/doco-cd/main_test.go
@@ -103,7 +103,10 @@ func selfDeployFixtureFiles(dir string) map[string]string {
 	}
 }
 
-var WorkingDir string
+var (
+	WorkingDir       string
+	SwarmModeEnabled bool
+)
 
 func TestMain(m *testing.M) {
 	var err error
@@ -127,11 +130,12 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Failed to verify docker socket connection: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(ctx, dockerCli.Client()); err != nil {
+	SwarmModeEnabled, err = swarm.ResolveModeEnabled(ctx, dockerCli.Client())
+	if err != nil {
 		log.Fatalf("Failed to check if Docker daemon is in Swarm mode: %v", err)
 	}
 
-	if swarm.GetModeEnabled() {
+	if SwarmModeEnabled {
 		log.Println("Testing in Docker Swarm mode")
 	} else {
 		log.Println("Testing in Docker Standalone mode")
@@ -341,10 +345,6 @@ env_files:
 		}
 	})
 
-	if err := swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		log.Fatalf("Failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
 	encryption.SetupAgeKeyEnvVar(t)
 
 	defaultEnvVars := map[string]string{
@@ -360,7 +360,7 @@ env_files:
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			mode := swarm.GetModeEnabled()
+			mode := SwarmModeEnabled
 			if mode != tc.swarmMode {
 				t.Skipf("Skipping test because it requires swarm mode %v, but current mode is %v", tc.swarmMode, mode)
 			}
@@ -414,7 +414,7 @@ env_files:
 					Volumes:       true,
 				}
 
-				if swarm.GetModeEnabled() {
+				if SwarmModeEnabled {
 					err = docker.RemoveSwarmStack(ctx, dockerCli, stackName)
 				} else if svcErr == nil && service != nil {
 					err = service.Down(ctx, stackName, downOpts)
@@ -436,7 +436,7 @@ env_files:
 				Repository: git.GetRepoName(tc.payload.CloneURL),
 				Revision:   notification.GetRevision(tc.payload.Ref, tc.payload.CommitSHAString()),
 			}
-			deployment := newTestDeployment(t, appConfig, testMountPoint, dockerCli, reconciliation.Dependencies{
+			deployment := newTestDeployment(t, appConfig, testMountPoint, reconciliation.Dependencies{
 				AppConfig:      appConfig,
 				DataMountPoint: testMountPoint,
 				DockerCLI:      dockerCli,

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -25,6 +25,8 @@ import (
 
 const validPollSourceURL = "https://github.com/kimdre/doco-cd_tests.git"
 
+var swarmModeEnabled bool
+
 func TestMain(m *testing.M) {
 	dockerCli, err := docker.CreateDockerCli(false)
 	if err != nil {
@@ -35,7 +37,8 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Failed to verify docker socket connection: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(context.Background(), dockerCli.Client()); err != nil {
+	swarmModeEnabled, err = swarm.ResolveModeEnabled(context.Background(), dockerCli.Client())
+	if err != nil {
 		log.Fatalf("Failed to check if Docker daemon is in Swarm mode: %v", err)
 	}
 
@@ -56,7 +59,7 @@ func TestNewHandlerValidatesDependencies(t *testing.T) {
 
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
-	contexts := docker.NewContextRegistry(dockerCli, true)
+	contexts := docker.NewContextRegistry(dockerCli, docker.ContextRegistryOptions{Quiet: true, SwarmFeatures: true})
 
 	t.Cleanup(func() { _ = contexts.Close() })
 

--- a/internal/api/projects_test.go
+++ b/internal/api/projects_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/test"
 
 	"github.com/kimdre/doco-cd/internal/docker"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/logger"
 	restAPI "github.com/kimdre/doco-cd/internal/restapi"
 )
@@ -100,7 +99,7 @@ func TestHandler_ProjectApiHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			if swarm.GetModeEnabled() {
+			if swarmModeEnabled {
 				t.Skip("Skipping Project API tests in Swarm mode")
 			}
 

--- a/internal/controlplane/deploy.go
+++ b/internal/controlplane/deploy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/common/validation"
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/poll"
+	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/source"
@@ -32,12 +33,18 @@ type Reconciler interface {
 	Deploy(ctx context.Context, req reconciliation.DeployRequest) error
 }
 
+// DockerContextResolver is the capability-aware Docker context surface used by Deployment.
+type DockerContextResolver interface {
+	Get(ctx context.Context, name string) (docker.ContextClient, error)
+}
+
 // DeploymentDependencies configures the source preparer, reconciler, and data
 // mount point used by the protocol-neutral deployment operation.
 type DeploymentDependencies struct {
-	SourcePreparer SourcePreparer       `validate:"required"`
-	Reconciler     Reconciler           `validate:"required"`
-	DataMountPoint container.MountPoint `validate:"required"`
+	SourcePreparer SourcePreparer        `validate:"required"`
+	Reconciler     Reconciler            `validate:"required"`
+	Contexts       DockerContextResolver `validate:"required"`
+	DataMountPoint container.MountPoint  `validate:"required"`
 }
 
 // Deployment is the protocol-neutral deployment operation shared by the
@@ -45,6 +52,7 @@ type DeploymentDependencies struct {
 type Deployment struct {
 	sourcePreparer SourcePreparer
 	reconciler     Reconciler
+	contexts       DockerContextResolver
 	dataMountPoint container.MountPoint
 }
 
@@ -57,6 +65,7 @@ func NewDeployment(dependencies DeploymentDependencies) (*Deployment, error) {
 	return &Deployment{
 		sourcePreparer: dependencies.SourcePreparer,
 		reconciler:     dependencies.Reconciler,
+		contexts:       dependencies.Contexts,
 		dataMountPoint: dependencies.DataMountPoint,
 	}, nil
 }
@@ -89,7 +98,10 @@ type DeploymentError struct {
 	HTTPStatusCode int
 }
 
-var errDeploymentFailed = errors.New("deployment failed")
+var (
+	errSwarmModeCheck   = errors.New("failed to check if docker host is running in swarm mode")
+	errDeploymentFailed = errors.New("deployment failed")
+)
 
 func (e DeploymentError) Error() string {
 	switch {
@@ -166,6 +178,10 @@ func classifySourceFailure(err error) (int, error) {
 func (d *Deployment) Deploy(ctx context.Context, req DeploymentRequest) error {
 	if err := validation.Validate(req); err != nil {
 		return newDeploymentError(source.ErrInvalidRequest, err, http.StatusInternalServerError)
+	}
+
+	if _, err := d.contexts.Get(ctx, docker.DefaultContextName); err != nil {
+		return newDeploymentError(errSwarmModeCheck, err, http.StatusInternalServerError)
 	}
 
 	result, err := d.sourcePreparer.Prepare(ctx, source.Request{

--- a/internal/controlplane/deploy.go
+++ b/internal/controlplane/deploy.go
@@ -7,13 +7,11 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/moby/moby/api/types/container"
 
 	"github.com/kimdre/doco-cd/internal/common/validation"
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/poll"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/source"
@@ -34,25 +32,19 @@ type Reconciler interface {
 	Deploy(ctx context.Context, req reconciliation.DeployRequest) error
 }
 
-// DeploymentDependencies configures the Deployment operation: the source
-// preparer, the reconciler that runs the resolved deploy configs, the Docker
-// CLI used to refresh swarm-mode capability, and the data mount point used to
-// compute the source's internal/external filesystem paths.
+// DeploymentDependencies configures the source preparer, reconciler, and data
+// mount point used by the protocol-neutral deployment operation.
 type DeploymentDependencies struct {
 	SourcePreparer SourcePreparer       `validate:"required"`
 	Reconciler     Reconciler           `validate:"required"`
-	DockerCLI      command.Cli          `validate:"required,nostructlevel"`
 	DataMountPoint container.MountPoint `validate:"required"`
 }
 
 // Deployment is the protocol-neutral deployment operation shared by the
-// webhook and poll transports: it refreshes the default swarm capability,
-// prepares the source, adapts the result into a reconciliation deploy
-// request, and runs it.
+// webhook and poll transports.
 type Deployment struct {
 	sourcePreparer SourcePreparer
 	reconciler     Reconciler
-	dockerCli      command.Cli
 	dataMountPoint container.MountPoint
 }
 
@@ -65,7 +57,6 @@ func NewDeployment(dependencies DeploymentDependencies) (*Deployment, error) {
 	return &Deployment{
 		sourcePreparer: dependencies.SourcePreparer,
 		reconciler:     dependencies.Reconciler,
-		dockerCli:      dependencies.DockerCLI,
 		dataMountPoint: dependencies.DataMountPoint,
 	}, nil
 }
@@ -98,10 +89,7 @@ type DeploymentError struct {
 	HTTPStatusCode int
 }
 
-var (
-	errSwarmModeCheck   = errors.New("failed to check if docker host is running in swarm mode")
-	errDeploymentFailed = errors.New("deployment failed")
-)
+var errDeploymentFailed = errors.New("deployment failed")
 
 func (e DeploymentError) Error() string {
 	switch {
@@ -166,10 +154,10 @@ func classifySourceFailure(err error) (int, error) {
 	}
 }
 
-// Deploy runs a single protocol-neutral deployment: it validates req,
-// refreshes the default swarm capability, prepares the source, adapts the
-// result into a reconciliation.DeployRequest (notifying the deployment target
-// observer for each resolved deploy config), and runs the reconciliation.
+// Deploy runs a single protocol-neutral deployment: it validates req, prepares
+// the source, adapts the result into a reconciliation.DeployRequest (notifying
+// the deployment target observer for each resolved deploy config), and runs
+// the reconciliation.
 //
 // Errors are returned as DeploymentError so callers can preserve the exact
 // HTTP status/message mapping the pre-refactor handler used. A
@@ -178,10 +166,6 @@ func classifySourceFailure(err error) (int, error) {
 func (d *Deployment) Deploy(ctx context.Context, req DeploymentRequest) error {
 	if err := validation.Validate(req); err != nil {
 		return newDeploymentError(source.ErrInvalidRequest, err, http.StatusInternalServerError)
-	}
-
-	if err := swarm.RefreshModeEnabled(ctx, d.dockerCli.Client()); err != nil {
-		return newDeploymentError(errSwarmModeCheck, err, http.StatusInternalServerError)
 	}
 
 	result, err := d.sourcePreparer.Prepare(ctx, source.Request{

--- a/internal/controlplane/deploy_test.go
+++ b/internal/controlplane/deploy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/controlplane"
+	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/reconciliation"
@@ -46,12 +47,23 @@ func (f *fakeReconciler) Deploy(_ context.Context, req reconciliation.DeployRequ
 	return f.err
 }
 
+type fakeDockerContextResolver struct {
+	err   error
+	calls int
+}
+
+func (f *fakeDockerContextResolver) Get(_ context.Context, _ string) (docker.ContextClient, error) {
+	f.calls++
+	return docker.ContextClient{}, f.err
+}
+
 func newTestDeployment(t *testing.T, preparer controlplane.SourcePreparer, reconciler controlplane.Reconciler) *controlplane.Deployment {
 	t.Helper()
 
 	d, err := controlplane.NewDeployment(controlplane.DeploymentDependencies{
 		SourcePreparer: preparer,
 		Reconciler:     reconciler,
+		Contexts:       &fakeDockerContextResolver{},
 		DataMountPoint: container.MountPoint{Type: "bind", Source: "/src", Destination: "/dst"},
 	})
 	if err != nil {
@@ -59,6 +71,39 @@ func newTestDeployment(t *testing.T, preparer controlplane.SourcePreparer, recon
 	}
 
 	return d
+}
+
+func TestDeploy_DockerCapabilityErrorShortCircuitsBeforeSourcePreparation(t *testing.T) {
+	t.Parallel()
+
+	preparer := &fakeSourcePreparer{}
+	reconciler := &fakeReconciler{}
+	contexts := &fakeDockerContextResolver{err: errors.New("docker info failed")}
+
+	d, err := controlplane.NewDeployment(controlplane.DeploymentDependencies{
+		SourcePreparer: preparer,
+		Reconciler:     reconciler,
+		Contexts:       contexts,
+		DataMountPoint: container.MountPoint{Type: "bind", Source: "/src", Destination: "/dst"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = d.Deploy(t.Context(), validDeploymentRequest())
+
+	var deploymentErr controlplane.DeploymentError
+	if !errors.As(err, &deploymentErr) {
+		t.Fatalf("expected DeploymentError, got %v", err)
+	}
+
+	if deploymentErr.HTTPStatusCode != 500 || deploymentErr.Response.Error() != "failed to check if docker host is running in swarm mode" {
+		t.Fatalf("unexpected deployment error: %#v", deploymentErr)
+	}
+
+	if contexts.calls != 1 || preparer.calls != 0 || reconciler.calls != 0 {
+		t.Fatalf("calls: contexts=%d, preparer=%d, reconciler=%d", contexts.calls, preparer.calls, reconciler.calls)
+	}
 }
 
 func validDeploymentRequest() controlplane.DeploymentRequest {

--- a/internal/controlplane/deploy_test.go
+++ b/internal/controlplane/deploy_test.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/docker/cli/cli/command"
 	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/commitstatus"
 	"github.com/kimdre/doco-cd/internal/common/validation"
@@ -20,27 +18,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/source"
 	"github.com/kimdre/doco-cd/internal/stages"
 )
-
-// fakeDockerCli satisfies command.Cli for tests, returning a fakeAPIClient
-// whose Info call reports a non-swarm-manager daemon so
-// Deployment.Deploy's swarm refresh step succeeds without a real Docker
-// daemon and without touching global swarm feature-detection state (which
-// would be unsafe to mutate from parallel tests).
-type fakeDockerCli struct {
-	command.Cli
-}
-
-func (fakeDockerCli) Client() client.APIClient {
-	return fakeAPIClient{}
-}
-
-type fakeAPIClient struct {
-	client.APIClient
-}
-
-func (fakeAPIClient) Info(context.Context, client.InfoOptions) (client.SystemInfoResult, error) {
-	return client.SystemInfoResult{}, nil
-}
 
 type fakeSourcePreparer struct {
 	result source.Result
@@ -75,7 +52,6 @@ func newTestDeployment(t *testing.T, preparer controlplane.SourcePreparer, recon
 	d, err := controlplane.NewDeployment(controlplane.DeploymentDependencies{
 		SourcePreparer: preparer,
 		Reconciler:     reconciler,
-		DockerCLI:      fakeDockerCli{},
 		DataMountPoint: container.MountPoint{Type: "bind", Source: "/src", Destination: "/dst"},
 	})
 	if err != nil {

--- a/internal/docker/cert_rotation_redeploy_test.go
+++ b/internal/docker/cert_rotation_redeploy_test.go
@@ -463,11 +463,7 @@ func TestRotateSwarmProjectCertificatesIntegration(t *testing.T) {
 		t.Fatalf("failed to create Docker CLI: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Skipf("skipping swarm cert rotation integration test: %v", err)
-	}
-
-	if !swarm.GetModeEnabled() {
+	if !resolveTestSwarmMode(t.Context(), t, dockerCli.Client()) {
 		t.Skip("swarm mode is not enabled, skipping cert rotation integration test")
 	}
 

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"maps"
 	"os"
@@ -28,8 +27,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/test"
 
 	"github.com/kimdre/doco-cd/internal/secretprovider"
-
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 
 	"github.com/go-git/go-git/v5/plumbing"
 
@@ -263,11 +260,7 @@ func TestDeployCompose(t *testing.T) {
 		})
 	}
 
-	if err := swarm.RefreshModeEnabled(ctx, dockerClient); err != nil {
-		log.Fatalf("Failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
-	if swarm.GetModeEnabled() {
+	if resolveTestSwarmMode(ctx, t, dockerClient) {
 		t.Skip("Swarm mode is enabled, skipping test")
 	}
 
@@ -401,7 +394,7 @@ compose_files:
 				DeployConfig:     deployConf,
 				LatestCommit:     latestCommit,
 				AppVersion:       "dev",
-				SwarmMode:        swarm.GetModeEnabled(),
+				SwarmMode:        resolveTestSwarmMode(ctx, t, dockerClient),
 			})
 		})
 		if err != nil {
@@ -410,7 +403,7 @@ compose_files:
 
 		t.Log("Verifying deployment")
 
-		serviceLabels, err := GetLabeledServices(ctx, dockerClient, swarm.GetModeEnabled(), DocoCDLabels.Deployment.Name, deployConf.Name)
+		serviceLabels, err := GetLabeledServices(ctx, dockerClient, resolveTestSwarmMode(ctx, t, dockerClient), DocoCDLabels.Deployment.Name, deployConf.Name)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -477,14 +470,14 @@ compose_files:
 
 		t.Log("Destroying deployment")
 
-		err = DestroyStack(jobLog, &ctx, &dockerCli, deployConf, swarm.GetModeEnabled())
+		err = DestroyStack(jobLog, &ctx, &dockerCli, deployConf, resolveTestSwarmMode(ctx, t, dockerClient))
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		t.Log("Verifying destruction")
 
-		serviceLabels, err = GetLabeledServices(ctx, dockerClient, swarm.GetModeEnabled(), DocoCDLabels.Deployment.Name, deployConf.Name)
+		serviceLabels, err = GetLabeledServices(ctx, dockerClient, resolveTestSwarmMode(ctx, t, dockerClient), DocoCDLabels.Deployment.Name, deployConf.Name)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -493,7 +486,7 @@ compose_files:
 			t.Fatalf("expected no labeled containers after destruction, got %d", len(serviceLabels))
 		}
 
-		stats, err := GetLatestDeployStatus(ctx, dockerClient, swarm.GetModeEnabled(), p.CloneURL, stackName)
+		stats, err := GetLatestDeployStatus(ctx, dockerClient, resolveTestSwarmMode(ctx, t, dockerClient), p.CloneURL, stackName)
 		if err != nil {
 			t.Fatalf("GetLatestDeployStatus err: %v", err)
 		}

--- a/internal/docker/context_registry.go
+++ b/internal/docker/context_registry.go
@@ -37,11 +37,16 @@ type ContextClientResult struct {
 	Err error
 }
 
+type ContextRegistryOptions struct {
+	Quiet         bool
+	SwarmFeatures bool
+}
+
 type ContextRegistry struct {
 	mu sync.RWMutex
 
 	baseCli command.Cli
-	quiet   bool
+	options ContextRegistryOptions
 	closed  bool
 
 	available map[string]struct{}
@@ -52,15 +57,21 @@ type ContextRegistry struct {
 	resolveSwarm func(context.Context, client.APIClient) (bool, error)
 }
 
-// NewContextRegistry creates a new ContextRegistry with the given baseCli and quiet flag.
-func NewContextRegistry(baseCli command.Cli, quiet bool) *ContextRegistry {
+// NewContextRegistry creates a new ContextRegistry for the configured Docker runtime features.
+func NewContextRegistry(baseCli command.Cli, options ContextRegistryOptions) *ContextRegistry {
 	registry := &ContextRegistry{
-		baseCli:      baseCli,
-		quiet:        quiet,
-		available:    map[string]struct{}{"": {}},
-		clients:      make(map[string]command.Cli),
-		createCli:    CreateDockerCliWithContext,
-		resolveSwarm: dockerSwarm.ResolveModeEnabled,
+		baseCli:   baseCli,
+		options:   options,
+		available: map[string]struct{}{"": {}},
+		clients:   make(map[string]command.Cli),
+		createCli: CreateDockerCliWithContext,
+		resolveSwarm: func(ctx context.Context, dockerClient client.APIClient) (bool, error) {
+			if !options.SwarmFeatures {
+				return false, nil
+			}
+
+			return dockerSwarm.ResolveModeEnabled(ctx, dockerClient)
+		},
 	}
 
 	if baseCli != nil {
@@ -238,7 +249,7 @@ func (r *ContextRegistry) clientForKnownContext(name string) (command.Cli, error
 		return cli, nil
 	}
 
-	cli, err := r.createCli(r.quiet, name)
+	cli, err := r.createCli(r.options.Quiet, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create docker client for context %q: %w", name, err)
 	}

--- a/internal/docker/context_registry_test.go
+++ b/internal/docker/context_registry_test.go
@@ -22,10 +22,12 @@ func (c contextRegistryTestCli) Client() client.APIClient {
 
 type contextRegistryTestClient struct {
 	client.APIClient
-	closed bool
+	closed    bool
+	infoCalls int
 }
 
 func (c *contextRegistryTestClient) Info(context.Context, client.InfoOptions) (client.SystemInfoResult, error) {
+	c.infoCalls++
 	return client.SystemInfoResult{}, nil
 }
 
@@ -67,7 +69,7 @@ func TestContextRegistryListsAndCachesContexts(t *testing.T) {
 	baseCli := contextRegistryTestCli{apiClient: defaultClient}
 	remoteCli := contextRegistryTestCli{apiClient: remoteClient}
 
-	registry := NewContextRegistry(baseCli, true)
+	registry := NewContextRegistry(baseCli, ContextRegistryOptions{Quiet: true, SwarmFeatures: true})
 	registry.listContexts = func() ([]contextstore.Metadata, error) {
 		return []contextstore.Metadata{{Name: "remote"}, {Name: "default"}}, nil
 	}
@@ -128,7 +130,7 @@ func TestContextRegistryIsolatesContextErrors(t *testing.T) {
 	t.Parallel()
 
 	baseCli := contextRegistryTestCli{apiClient: &contextRegistryTestClient{}}
-	registry := NewContextRegistry(baseCli, true)
+	registry := NewContextRegistry(baseCli, ContextRegistryOptions{Quiet: true, SwarmFeatures: true})
 	registry.listContexts = func() ([]contextstore.Metadata, error) {
 		return []contextstore.Metadata{{Name: "broken"}}, nil
 	}
@@ -173,10 +175,11 @@ func TestContextRegistryDefaultDoesNotRequireContextListing(t *testing.T) {
 	t.Parallel()
 
 	baseCli := contextRegistryTestCli{apiClient: &contextRegistryTestClient{}}
-	registry := NewContextRegistry(baseCli, true)
+	registry := NewContextRegistry(baseCli, ContextRegistryOptions{Quiet: true, SwarmFeatures: true})
 	registry.listContexts = func() ([]contextstore.Metadata, error) {
 		return nil, errors.New("context store unavailable")
 	}
+
 	registry.resolveSwarm = func(_ context.Context, _ client.APIClient) (bool, error) {
 		return false, nil
 	}
@@ -188,5 +191,26 @@ func TestContextRegistryDefaultDoesNotRequireContextListing(t *testing.T) {
 
 	if entry.Cli != baseCli || entry.DisplayName() != "default" {
 		t.Fatalf("unexpected default entry: %#v", entry)
+	}
+}
+
+func TestContextRegistryCanDisableSwarmCapabilities(t *testing.T) {
+	t.Parallel()
+
+	apiClient := &contextRegistryTestClient{}
+	baseCli := contextRegistryTestCli{apiClient: apiClient}
+	registry := NewContextRegistry(baseCli, ContextRegistryOptions{SwarmFeatures: false})
+
+	entry, err := registry.Get(t.Context(), DefaultContextName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if entry.SwarmMode {
+		t.Fatal("expected Swarm capability to be disabled")
+	}
+
+	if apiClient.infoCalls != 0 {
+		t.Fatalf("Docker info calls = %d, want 0", apiClient.infoCalls)
 	}
 }

--- a/internal/docker/git_resource_loader_test.go
+++ b/internal/docker/git_resource_loader_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
 
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/test"
 )
 
@@ -580,11 +579,7 @@ func TestDeployComposeWithGitInclude(t *testing.T) {
 		t.Fatalf("create Docker CLI: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(ctx, dockerCli.Client()); err != nil {
-		t.Fatalf("check Swarm mode: %v", err)
-	}
-
-	if swarm.GetModeEnabled() {
+	if resolveTestSwarmMode(ctx, t, dockerCli.Client()) {
 		t.Skip("Swarm mode is enabled, skipping standalone Compose test")
 	}
 

--- a/internal/docker/runtime_queries.go
+++ b/internal/docker/runtime_queries.go
@@ -6,11 +6,14 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
+
+	"github.com/kimdre/doco-cd/internal/config/app"
 )
 
-func ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, manager, repository string, all bool) ([]container.Summary, error) {
+// ListManagedRepositoryContainers lists all containers that belong to a specific repository.
+func ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, repository string, all bool) ([]container.Summary, error) {
 	filters := make(client.Filters)
-	filters.Add("label", DocoCDLabels.Metadata.Manager+"="+manager)
+	filters.Add("label", DocoCDLabels.Metadata.Manager+"="+app.Name)
 	filters.Add("label", DocoCDLabels.Source.Name+"="+repository)
 
 	result, err := apiClient.ContainerList(ctx, client.ContainerListOptions{
@@ -24,6 +27,7 @@ func ListManagedRepositoryContainers(ctx context.Context, apiClient client.APICl
 	return result.Items, nil
 }
 
+// InspectContainerState inspects the state of a specific container.
 func InspectContainerState(ctx context.Context, apiClient client.APIClient, containerID string) (*container.State, error) {
 	result, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
 	if err != nil {
@@ -33,9 +37,10 @@ func InspectContainerState(ctx context.Context, apiClient client.APIClient, cont
 	return result.Container.State, nil
 }
 
-func ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, manager, repository string) ([]swarm.Service, error) {
+// ListManagedRepositoryServices lists all services that belong to a specific repository.
+func ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, repository string) ([]swarm.Service, error) {
 	filters := make(client.Filters)
-	filters.Add("label", DocoCDLabels.Metadata.Manager+"="+manager)
+	filters.Add("label", DocoCDLabels.Metadata.Manager+"="+app.Name)
 	filters.Add("label", DocoCDLabels.Source.Name+"="+repository)
 
 	result, err := apiClient.ServiceList(ctx, client.ServiceListOptions{Filters: filters})

--- a/internal/docker/runtime_queries.go
+++ b/internal/docker/runtime_queries.go
@@ -1,0 +1,47 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
+)
+
+func ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, manager, repository string, all bool) ([]container.Summary, error) {
+	filters := make(client.Filters)
+	filters.Add("label", DocoCDLabels.Metadata.Manager+"="+manager)
+	filters.Add("label", DocoCDLabels.Source.Name+"="+repository)
+
+	result, err := apiClient.ContainerList(ctx, client.ContainerListOptions{
+		All:     all,
+		Filters: filters,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Items, nil
+}
+
+func InspectContainerState(ctx context.Context, apiClient client.APIClient, containerID string) (*container.State, error) {
+	result, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Container.State, nil
+}
+
+func ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, manager, repository string) ([]swarm.Service, error) {
+	filters := make(client.Filters)
+	filters.Add("label", DocoCDLabels.Metadata.Manager+"="+manager)
+	filters.Add("label", DocoCDLabels.Source.Name+"="+repository)
+
+	result, err := apiClient.ServiceList(ctx, client.ServiceListOptions{Filters: filters})
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Items, nil
+}

--- a/internal/docker/runtime_queries_test.go
+++ b/internal/docker/runtime_queries_test.go
@@ -46,13 +46,13 @@ func TestListManagedRepositoryContainers(t *testing.T) {
 		containers: []container.Summary{{ID: "container-id"}},
 	}
 
-	got, err := ListManagedRepositoryContainers(t.Context(), apiClient, "manager", "owner/repository", true)
+	got, err := ListManagedRepositoryContainers(t.Context(), apiClient, "owner/repository", true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	wantFilters := make(client.Filters)
-	wantFilters.Add("label", DocoCDLabels.Metadata.Manager+"=manager")
+	wantFilters.Add("label", DocoCDLabels.Metadata.Manager+"=doco-cd")
 	wantFilters.Add("label", DocoCDLabels.Source.Name+"=owner/repository")
 
 	if !reflect.DeepEqual(got, apiClient.containers) {
@@ -71,13 +71,13 @@ func TestListManagedRepositoryServices(t *testing.T) {
 		services: []swarm.Service{{ID: "service-id"}},
 	}
 
-	got, err := ListManagedRepositoryServices(t.Context(), apiClient, "manager", "owner/repository")
+	got, err := ListManagedRepositoryServices(t.Context(), apiClient, "owner/repository")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	wantFilters := make(client.Filters)
-	wantFilters.Add("label", DocoCDLabels.Metadata.Manager+"=manager")
+	wantFilters.Add("label", DocoCDLabels.Metadata.Manager+"=doco-cd")
 	wantFilters.Add("label", DocoCDLabels.Source.Name+"=owner/repository")
 
 	if !reflect.DeepEqual(got, apiClient.services) {

--- a/internal/docker/runtime_queries_test.go
+++ b/internal/docker/runtime_queries_test.go
@@ -1,0 +1,106 @@
+package docker
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
+)
+
+type runtimeQueryTestClient struct {
+	client.APIClient
+
+	containers       []container.Summary
+	services         []swarm.Service
+	containerState   *container.State
+	containerOptions client.ContainerListOptions
+	serviceOptions   client.ServiceListOptions
+	inspectedID      string
+}
+
+func (c *runtimeQueryTestClient) ContainerList(_ context.Context, options client.ContainerListOptions) (client.ContainerListResult, error) {
+	c.containerOptions = options
+	return client.ContainerListResult{Items: c.containers}, nil
+}
+
+func (c *runtimeQueryTestClient) ServiceList(_ context.Context, options client.ServiceListOptions) (client.ServiceListResult, error) {
+	c.serviceOptions = options
+	return client.ServiceListResult{Items: c.services}, nil
+}
+
+func (c *runtimeQueryTestClient) ContainerInspect(_ context.Context, containerID string, _ client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+	c.inspectedID = containerID
+
+	return client.ContainerInspectResult{
+		Container: container.InspectResponse{State: c.containerState},
+	}, nil
+}
+
+func TestListManagedRepositoryContainers(t *testing.T) {
+	t.Parallel()
+
+	apiClient := &runtimeQueryTestClient{
+		containers: []container.Summary{{ID: "container-id"}},
+	}
+
+	got, err := ListManagedRepositoryContainers(t.Context(), apiClient, "manager", "owner/repository", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantFilters := make(client.Filters)
+	wantFilters.Add("label", DocoCDLabels.Metadata.Manager+"=manager")
+	wantFilters.Add("label", DocoCDLabels.Source.Name+"=owner/repository")
+
+	if !reflect.DeepEqual(got, apiClient.containers) {
+		t.Fatalf("containers = %#v, want %#v", got, apiClient.containers)
+	}
+
+	if !apiClient.containerOptions.All || !reflect.DeepEqual(apiClient.containerOptions.Filters, wantFilters) {
+		t.Fatalf("container options = %#v, want All=true and filters %#v", apiClient.containerOptions, wantFilters)
+	}
+}
+
+func TestListManagedRepositoryServices(t *testing.T) {
+	t.Parallel()
+
+	apiClient := &runtimeQueryTestClient{
+		services: []swarm.Service{{ID: "service-id"}},
+	}
+
+	got, err := ListManagedRepositoryServices(t.Context(), apiClient, "manager", "owner/repository")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantFilters := make(client.Filters)
+	wantFilters.Add("label", DocoCDLabels.Metadata.Manager+"=manager")
+	wantFilters.Add("label", DocoCDLabels.Source.Name+"=owner/repository")
+
+	if !reflect.DeepEqual(got, apiClient.services) {
+		t.Fatalf("services = %#v, want %#v", got, apiClient.services)
+	}
+
+	if !reflect.DeepEqual(apiClient.serviceOptions.Filters, wantFilters) {
+		t.Fatalf("service filters = %#v, want %#v", apiClient.serviceOptions.Filters, wantFilters)
+	}
+}
+
+func TestInspectContainerState(t *testing.T) {
+	t.Parallel()
+
+	want := &container.State{Status: "running"}
+	apiClient := &runtimeQueryTestClient{containerState: want}
+
+	got, err := InspectContainerState(t.Context(), apiClient, "container-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got != want || apiClient.inspectedID != "container-id" {
+		t.Fatalf("state = %#v, inspected ID = %q", got, apiClient.inspectedID)
+	}
+}

--- a/internal/docker/service_utils_test.go
+++ b/internal/docker/service_utils_test.go
@@ -488,11 +488,7 @@ func TestGetLatestServiceState(t *testing.T) {
 		t.Fatalf("Failed to create Docker CLI: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Fatalf("Failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
-	if swarm.GetModeEnabled() {
+	if resolveTestSwarmMode(t.Context(), t, dockerCli.Client()) {
 		t.Skip("Swarm mode is enabled, skipping test")
 	}
 	// t.Parallel()
@@ -549,7 +545,7 @@ services:
 		}),
 	)
 
-	latest, err := GetLatestDeployStatus(ctx, stack.Client, swarm.GetModeEnabled(), repoName, stackName)
+	latest, err := GetLatestDeployStatus(ctx, stack.Client, resolveTestSwarmMode(ctx, t, stack.Client), repoName, stackName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -580,11 +576,7 @@ func TestGetLatestServiceSwarm(t *testing.T) {
 		t.Fatalf("Failed to create Docker CLI: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Fatalf("Failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
-	if !swarm.GetModeEnabled() {
+	if !resolveTestSwarmMode(t.Context(), t, dockerCli.Client()) {
 		t.Skip("Swarm mode is not enabled, skipping test")
 	}
 
@@ -682,7 +674,7 @@ services:
 
 	dockerClient := dockerCli.Client()
 
-	latest, err := GetLatestDeployStatus(ctx, dockerClient, swarm.GetModeEnabled(), repoName, stackName)
+	latest, err := GetLatestDeployStatus(ctx, dockerClient, resolveTestSwarmMode(ctx, t, dockerClient), repoName, stackName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/docker/swarm/common.go
+++ b/internal/docker/swarm/common.go
@@ -2,7 +2,6 @@ package swarm
 
 import (
 	"context"
-	"sync/atomic"
 
 	"github.com/docker/cli/cli/compose/convert"
 	"github.com/moby/moby/api/types/network"
@@ -14,55 +13,8 @@ const (
 	StackNamespaceLabel = "com.docker.stack.namespace"
 )
 
-var (
-	// disable swarm feature even if the daemon is running in swarm mode.
-	disableSwarmFeature atomic.Bool
-	modeEnabled         atomic.Bool
-)
-
-// SetDisableSwarmFeature, disable swarm feature.
-func SetDisableSwarmFeature(ignore bool) {
-	disableSwarmFeature.Store(ignore)
-}
-
-// GetDisableSwarmFeature returns whether swarm features are explicitly disabled.
-func GetDisableSwarmFeature() bool {
-	return disableSwarmFeature.Load()
-}
-
-// GetModeEnabled, Whether the docker host is running in swarm mode,
-// it will return false if ignoreSwarmFeature is true.
-func GetModeEnabled() bool {
-	return getModeEnabled(disableSwarmFeature.Load(), modeEnabled.Load())
-}
-
-func getModeEnabled(disableSwarmFeature, modeEnabled bool) bool {
-	return !disableSwarmFeature && modeEnabled
-}
-
-func RefreshModeEnabled(ctx context.Context, dockerClient client.APIClient) error {
-	// ignore swarm feature
-	if disableSwarmFeature.Load() {
-		return nil
-	}
-
-	enable, err := checkDaemonIsSwarmManager(ctx, dockerClient)
-	if err != nil {
-		return err
-	}
-
-	modeEnabled.Store(enable)
-
-	return nil
-}
-
-// ResolveModeEnabled returns whether swarm mode should be treated as enabled for
-// the provided docker client, honoring the global disable flag.
+// ResolveModeEnabled returns whether the provided Docker daemon is a Swarm manager.
 func ResolveModeEnabled(ctx context.Context, dockerClient client.APIClient) (bool, error) {
-	if disableSwarmFeature.Load() {
-		return false, nil
-	}
-
 	return checkDaemonIsSwarmManager(ctx, dockerClient)
 }
 

--- a/internal/docker/swarm/common_test.go
+++ b/internal/docker/swarm/common_test.go
@@ -2,77 +2,25 @@ package swarm
 
 import (
 	"testing"
+
+	"github.com/moby/moby/client"
 )
 
-func TestSwarmModeEnabled(t *testing.T) {
+func resolveTestSwarmMode(t *testing.T, apiClient client.APIClient) bool {
+	t.Helper()
+
+	enabled, err := ResolveModeEnabled(t.Context(), apiClient)
+	if err != nil {
+		t.Fatalf("failed to check if Docker daemon is in Swarm mode: %v", err)
+	}
+
+	return enabled
+}
+
+func TestResolveModeEnabled(t *testing.T) {
 	t.Parallel()
-
-	prevDisable := disableSwarmFeature.Load()
-	prevMode := modeEnabled.Load()
-
-	t.Cleanup(func() {
-		disableSwarmFeature.Store(prevDisable)
-		modeEnabled.Store(prevMode)
-	})
-
-	SetDisableSwarmFeature(false)
 
 	dockerCli := getDockerClient(t)
 
-	if err := RefreshModeEnabled(t.Context(), dockerCli); err != nil {
-		t.Fatal(err)
-	}
-
-	want, err := ResolveModeEnabled(t.Context(), dockerCli)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if got := GetModeEnabled(); got != want {
-		t.Fatalf("GetModeEnabled() = %v, want %v", got, want)
-	}
-}
-
-func Test_getModeEnabled(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name                string
-		disableSwarmFeature bool
-		modeEnabled         bool
-		want                bool
-	}{
-		{
-			name:                "disable swarm feature=true, modeEnabled=true",
-			disableSwarmFeature: true,
-			modeEnabled:         true,
-			want:                false,
-		},
-		{
-			name:                "disable swarm feature=true, modeEnabled=false",
-			disableSwarmFeature: true,
-			modeEnabled:         false,
-			want:                false,
-		},
-		{
-			name:                "disable swarm feature=false, modeEnabled=true",
-			disableSwarmFeature: false,
-			modeEnabled:         true,
-			want:                true,
-		},
-		{
-			name:                "disable swarm feature=false, modeEnabled=false",
-			disableSwarmFeature: false,
-			modeEnabled:         false,
-			want:                false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getModeEnabled(tt.disableSwarmFeature, tt.modeEnabled)
-			if got != tt.want {
-				t.Errorf("getModeEnabled() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+	_ = resolveTestSwarmMode(t, dockerCli)
 }

--- a/internal/docker/swarm/deploy_composefile_test.go
+++ b/internal/docker/swarm/deploy_composefile_test.go
@@ -34,11 +34,7 @@ func (notFoundError) NotFound() {}
 func TestValidateExternalNetworks(t *testing.T) {
 	t.Parallel()
 
-	if err := RefreshModeEnabled(t.Context(), getDockerClient(t)); err != nil {
-		t.Fatalf("failed refreshing mode enabled: %v", err)
-	}
-
-	if !GetModeEnabled() {
+	if !resolveTestSwarmMode(t, getDockerClient(t)) {
 		t.Skip("Swarm mode not enabled, skipping test")
 	}
 

--- a/internal/docker/swarm/rollback_integration_test.go
+++ b/internal/docker/swarm/rollback_integration_test.go
@@ -124,11 +124,7 @@ func requireSwarmRollbackIntegrationTestGate(t *testing.T) {
 	}
 
 	dockerClient := getDockerClient(t)
-	if err := RefreshModeEnabled(t.Context(), dockerClient); err != nil {
-		t.Skipf("skipping swarm rollback integration test: %v", err)
-	}
-
-	if !GetModeEnabled() {
+	if !resolveTestSwarmMode(t, dockerClient) {
 		t.Skip("swarm mode is not enabled, skipping rollback integration test")
 	}
 }

--- a/internal/docker/swarm_idempotency_test.go
+++ b/internal/docker/swarm_idempotency_test.go
@@ -61,11 +61,7 @@ func TestDeploySwarmStackIsIdempotent(t *testing.T) {
 		t.Fatalf("Failed to create Docker CLI: %v", err)
 	}
 
-	if err = swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Fatalf("Failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
-	if !swarm.GetModeEnabled() {
+	if !resolveTestSwarmMode(t.Context(), t, dockerCli.Client()) {
 		t.Skip("Swarm mode is not enabled, skipping test")
 	}
 

--- a/internal/docker/swarm_job_test.go
+++ b/internal/docker/swarm_job_test.go
@@ -14,11 +14,7 @@ func TestRunSwarmJob(t *testing.T) {
 		t.Fatalf("Failed to create Docker CLI: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Errorf("Failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
-	if !swarm.GetModeEnabled() {
+	if !resolveTestSwarmMode(t.Context(), t, dockerCli.Client()) {
 		t.Skip("Swarm mode is not enabled, skipping test")
 	}
 
@@ -53,11 +49,7 @@ func TestRunImagePruneJob(t *testing.T) {
 		t.Fatalf("Failed to create Docker CLI: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Errorf("Failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
-	if !swarm.GetModeEnabled() {
+	if !resolveTestSwarmMode(t.Context(), t, dockerCli.Client()) {
 		t.Skip("Swarm mode is not enabled, skipping test")
 	}
 

--- a/internal/docker/swarm_mode_test.go
+++ b/internal/docker/swarm_mode_test.go
@@ -1,0 +1,21 @@
+package docker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/moby/moby/client"
+
+	"github.com/kimdre/doco-cd/internal/docker/swarm"
+)
+
+func resolveTestSwarmMode(ctx context.Context, t *testing.T, apiClient client.APIClient) bool {
+	t.Helper()
+
+	enabled, err := swarm.ResolveModeEnabled(ctx, apiClient)
+	if err != nil {
+		t.Fatalf("failed to check if Docker daemon is in Swarm mode: %v", err)
+	}
+
+	return enabled
+}

--- a/internal/docker/swarm_test.go
+++ b/internal/docker/swarm_test.go
@@ -34,11 +34,7 @@ func TestDeploySwarmStack(t *testing.T) {
 		t.Fatalf("Failed to create Docker CLI: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Fatalf("Failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
-	if !swarm.GetModeEnabled() {
+	if !resolveTestSwarmMode(t.Context(), t, dockerCli.Client()) {
 		t.Skip("Swarm mode is not enabled, skipping test")
 	}
 
@@ -159,11 +155,7 @@ func TestSwarmConfigAndSecretRotationRetention(t *testing.T) {
 		t.Fatalf("failed to create Docker CLI: %v", err)
 	}
 
-	if err := swarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Fatalf("failed to check if Docker daemon is in Swarm mode: %v", err)
-	}
-
-	if !swarm.GetModeEnabled() {
+	if !resolveTestSwarmMode(t.Context(), t, dockerCli.Client()) {
 		t.Skip("Swarm mode is not enabled, skipping test")
 	}
 

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/kimdre/doco-cd/internal/docker"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 )
 
 // resolveDockerContext returns a named context or the injected default Docker CLI.
@@ -46,17 +45,9 @@ func (h *Handler) resolveSwarmDockerContext(ctx context.Context, contextName str
 	return contextClient, nil
 }
 
-// requireDockerSwarm checks named-context state or probes the default daemon directly.
-func requireDockerSwarm(ctx context.Context, contextClient docker.ContextClient) error {
+// requireDockerSwarm checks the capability resolved by ContextRegistry.
+func requireDockerSwarm(_ context.Context, contextClient docker.ContextClient) error {
 	enabled := contextClient.SwarmMode
-	if contextClient.Name == "" {
-		var err error
-
-		enabled, err = swarm.ResolveModeEnabled(ctx, contextClient.Cli.Client())
-		if err != nil {
-			return fmt.Errorf("failed to check Docker Swarm mode: %w", err)
-		}
-	}
 
 	if !enabled {
 		return errors.New("swarm features are disabled or the Docker daemon is not an active swarm manager")

--- a/internal/mcp/jobs_test.go
+++ b/internal/mcp/jobs_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/controlplane"
 	"github.com/kimdre/doco-cd/internal/docker"
-	dockerswarm "github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/scheduler"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
@@ -209,7 +208,7 @@ func TestMCPScheduledJobsTool(t *testing.T) {
 
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
-	if dockerswarm.GetModeEnabled() {
+	if resolveTestSwarmMode(t, dockerCli.Client()) {
 		t.Skip("compose scheduled-job fixture requires standalone mode")
 	}
 
@@ -224,7 +223,7 @@ func TestMCPScheduledJobsTool(t *testing.T) {
 `), test.WithName(projectName))
 
 	h := &Handler{dockerCli: dockerCli, log: logger.New(logger.LevelCritical)}
-	contexts := docker.NewContextRegistry(dockerCli, true)
+	contexts := docker.NewContextRegistry(dockerCli, docker.ContextRegistryOptions{Quiet: true, SwarmFeatures: true})
 
 	t.Cleanup(func() { _ = contexts.Close() })
 

--- a/internal/mcp/projects_test.go
+++ b/internal/mcp/projects_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/controlplane"
 	"github.com/kimdre/doco-cd/internal/docker"
-	dockerswarm "github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/test"
 )
@@ -73,7 +72,7 @@ func TestMCPProjectTools(t *testing.T) {
 
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
-	if dockerswarm.GetModeEnabled() {
+	if resolveTestSwarmMode(t, dockerCli.Client()) {
 		t.Skip("compose project tools require standalone mode")
 	}
 
@@ -154,7 +153,7 @@ func TestMCPDockerReadTools(t *testing.T) {
 
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
-	if dockerswarm.GetModeEnabled() {
+	if resolveTestSwarmMode(t, dockerCli.Client()) {
 		t.Skip("compose project tools require standalone mode")
 	}
 

--- a/internal/mcp/stacks_test.go
+++ b/internal/mcp/stacks_test.go
@@ -318,6 +318,7 @@ func newStackActionTestHandler(t *testing.T, services []dockerswarmtypes.Service
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
 	contexts := docker.NewContextRegistry(dockerCli, docker.ContextRegistryOptions{SwarmFeatures: true})
+
 	t.Cleanup(func() { _ = contexts.Close() })
 
 	return &Handler{dockerCli: dockerCli, contexts: contexts, log: logger.New(logger.LevelCritical)}
@@ -375,6 +376,7 @@ func newStackActionTestHandlerWithFailure(
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
 	contexts := docker.NewContextRegistry(dockerCli, docker.ContextRegistryOptions{SwarmFeatures: true})
+
 	t.Cleanup(func() { _ = contexts.Close() })
 
 	return &Handler{dockerCli: dockerCli, contexts: contexts, log: logger.New(logger.LevelCritical)}

--- a/internal/mcp/stacks_test.go
+++ b/internal/mcp/stacks_test.go
@@ -195,7 +195,11 @@ func TestMCPSwarmToolsRuntimeBehavior(t *testing.T) {
 
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
-	h := &Handler{dockerCli: dockerCli, log: logger.New(logger.LevelCritical)}
+	contexts := docker.NewContextRegistry(dockerCli, docker.ContextRegistryOptions{SwarmFeatures: true})
+
+	t.Cleanup(func() { _ = contexts.Close() })
+
+	h := &Handler{dockerCli: dockerCli, contexts: contexts, log: logger.New(logger.LevelCritical)}
 	server, _ := newMCPTestServerWithHandler(t, true, testMCPAPIKey, 1024, h)
 	session := connectMCPTestClient(t, server)
 

--- a/internal/mcp/stacks_test.go
+++ b/internal/mcp/stacks_test.go
@@ -270,11 +270,6 @@ func TestMCPSwarmToolsDisabledAtRuntime(t *testing.T) {
 
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
-	previousDisableSwarmFeature := dockerswarm.GetDisableSwarmFeature()
-
-	dockerswarm.SetDisableSwarmFeature(true)
-	t.Cleanup(func() { dockerswarm.SetDisableSwarmFeature(previousDisableSwarmFeature) })
-
 	h := &Handler{dockerCli: dockerCli, log: logger.New(logger.LevelCritical)}
 	server, _ := newMCPTestServerWithHandler(t, true, testMCPAPIKey, 1024, h)
 	session := connectMCPTestClient(t, server)
@@ -322,7 +317,10 @@ func newStackActionTestHandler(t *testing.T, services []dockerswarmtypes.Service
 
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
-	return &Handler{dockerCli: dockerCli, log: logger.New(logger.LevelCritical)}
+	contexts := docker.NewContextRegistry(dockerCli, docker.ContextRegistryOptions{SwarmFeatures: true})
+	t.Cleanup(func() { _ = contexts.Close() })
+
+	return &Handler{dockerCli: dockerCli, contexts: contexts, log: logger.New(logger.LevelCritical)}
 }
 
 func newStackActionTestHandlerWithFailure(
@@ -376,5 +374,8 @@ func newStackActionTestHandlerWithFailure(
 
 	t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
-	return &Handler{dockerCli: dockerCli, log: logger.New(logger.LevelCritical)}
+	contexts := docker.NewContextRegistry(dockerCli, docker.ContextRegistryOptions{SwarmFeatures: true})
+	t.Cleanup(func() { _ = contexts.Close() })
+
+	return &Handler{dockerCli: dockerCli, contexts: contexts, log: logger.New(logger.LevelCritical)}
 }

--- a/internal/mcp/test_helpers_test.go
+++ b/internal/mcp/test_helpers_test.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/poll"
 	"github.com/kimdre/doco-cd/internal/controlplane"
 	"github.com/kimdre/doco-cd/internal/docker"
+	dockerswarm "github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/restapi"
@@ -27,6 +29,17 @@ import (
 )
 
 const testMCPPath = "/mcp"
+
+func resolveTestSwarmMode(t *testing.T, apiClient client.APIClient) bool {
+	t.Helper()
+
+	enabled, err := dockerswarm.ResolveModeEnabled(t.Context(), apiClient)
+	if err != nil {
+		t.Fatalf("failed to check if Docker daemon is in Swarm mode: %v", err)
+	}
+
+	return enabled
+}
 
 type apiKeyRoundTripper struct {
 	apiKey string

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/config"
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker"
-	dockerSwarm "github.com/kimdre/doco-cd/internal/docker/swarm"
 
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
@@ -67,13 +66,8 @@ func (m *Manager) deploy(ctx context.Context, req DeployRequest) error {
 		configsByContext[contextName] = append(configsByContext[contextName], dc)
 	}
 
-	dockerQuiet := false
-	if m.appConfig != nil {
-		dockerQuiet = m.appConfig.DockerQuietDeploy
-	}
-
 	for contextName, groupedConfigs := range configsByContext {
-		entry := resolveDeployContext(ctx, m.contexts, m.dockerCli, dockerQuiet, contextName)
+		entry := resolveDeployContext(ctx, m.contexts, contextName)
 		if entry.err != nil {
 			// Isolate per-context failures: an unreachable context must not block
 			// cleanup/deploy for other (healthy) contexts. handleDeploy below fails
@@ -95,32 +89,15 @@ func (m *Manager) deploy(ctx context.Context, req DeployRequest) error {
 					logger.ErrAttr(err))
 			}
 		}
-
-		if entry.closeFn != nil {
-			entry.closeFn()
-		}
 	}
 
 	return m.handleDeploy(ctx, req)
 }
 
 func (m *Manager) handleDeploy(ctx context.Context, req DeployRequest) error {
-	dockerQuiet := false
-	if m.appConfig != nil {
-		dockerQuiet = m.appConfig.DockerQuietDeploy
-	}
-
 	// Build one Docker CLI per distinct context up front and share it across all
 	// deployments targeting that context, instead of creating a client per deployment.
-	contextCLIs := buildDeployContextCLIs(ctx, m.contexts, m.dockerCli, dockerQuiet, req.DeployConfigs)
-
-	defer func() {
-		for contextName, entry := range contextCLIs {
-			if contextName != "" && entry.closeFn != nil {
-				entry.closeFn()
-			}
-		}
-	}()
+	contextCLIs := buildDeployContextCLIs(ctx, m.contexts, req.DeployConfigs)
 
 	// Deployments run concurrently, grouped by repository and reference, and
 	// limited by this manager's deployment limiter.
@@ -212,16 +189,14 @@ func (m *Manager) handleDeploy(ctx context.Context, req DeployRequest) error {
 // shared across all deployments in a handleDeploy batch that target that context.
 type deployContextCLI struct {
 	cli       command.Cli
-	closeFn   func() // nil for the default context (which reuses the base CLI)
 	swarmMode bool
 	err       error // set when the context CLI could not be created/probed
 }
 
 // buildDeployContextCLIs creates one Docker CLI per distinct context referenced in deployConfigs.
-// The default context (empty string) reuses baseCli; custom contexts get a dedicated client whose
-// closeFn must be called by the caller. Errors are captured per context so only the affected
-// deployments fail rather than the whole batch.
-func buildDeployContextCLIs(ctx context.Context, contexts *docker.ContextRegistry, baseCli command.Cli, quiet bool, deployConfigs []*deployConfig.Config) map[string]deployContextCLI {
+// Errors are captured per context so only the affected deployments fail rather
+// than the whole batch.
+func buildDeployContextCLIs(ctx context.Context, contexts *docker.ContextRegistry, deployConfigs []*deployConfig.Config) map[string]deployContextCLI {
 	contextCLIs := make(map[string]deployContextCLI)
 
 	for _, dc := range deployConfigs {
@@ -230,42 +205,21 @@ func buildDeployContextCLIs(ctx context.Context, contexts *docker.ContextRegistr
 			continue
 		}
 
-		contextCLIs[contextName] = resolveDeployContext(ctx, contexts, baseCli, quiet, contextName)
+		contextCLIs[contextName] = resolveDeployContext(ctx, contexts, contextName)
 	}
 
 	return contextCLIs
 }
 
-func resolveDeployContext(ctx context.Context, contexts *docker.ContextRegistry, baseCli command.Cli, quiet bool, contextName string) deployContextCLI {
+func resolveDeployContext(ctx context.Context, contexts *docker.ContextRegistry, contextName string) deployContextCLI {
 	contextName = docker.NormalizeContextName(contextName)
-	if contexts != nil {
-		cc, err := contexts.Get(ctx, contextName)
-		if err != nil {
-			return deployContextCLI{err: err}
-		}
 
-		return deployContextCLI{cli: cc.Cli, swarmMode: cc.SwarmMode}
-	}
-
-	if contextName == "" {
-		return deployContextCLI{cli: baseCli, swarmMode: dockerSwarm.GetModeEnabled()}
-	}
-
-	cli, closeFn, err := dockerCliForContext(baseCli, quiet, contextName)
+	cc, err := contexts.Get(ctx, contextName)
 	if err != nil {
 		return deployContextCLI{err: err}
 	}
 
-	swarmMode, err := dockerSwarm.ResolveModeEnabled(ctx, cli.Client())
-	if err != nil {
-		if closeFn != nil {
-			closeFn()
-		}
-
-		return deployContextCLI{err: fmt.Errorf("failed to check if docker host is running in swarm mode: %w", err)}
-	}
-
-	return deployContextCLI{cli: cli, closeFn: closeFn, swarmMode: swarmMode}
+	return deployContextCLI{cli: cc.Cli, swarmMode: cc.SwarmMode}
 }
 
 func (m *Manager) handleOneDeploy(ctx context.Context, req DeployRequest, deployLog *slog.Logger,
@@ -341,24 +295,6 @@ func groupDeployConfigsByMode(dcs []*deployConfig.Config, swarmAvailable bool) m
 	}
 
 	return grouped
-}
-
-func dockerCliForContext(baseCli command.Cli, quiet bool, contextName string) (command.Cli, func(), error) {
-	contextName = docker.NormalizeContextName(contextName)
-	if contextName == "" {
-		return baseCli, nil, nil
-	}
-
-	contextCli, err := docker.CreateDockerCliWithContext(quiet, contextName)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create docker client for context %q: %w", contextName, err)
-	}
-
-	closeFn := func() {
-		_ = contextCli.Client().Close()
-	}
-
-	return contextCli, closeFn, nil
 }
 
 func failNotifyFunc(deployLog *slog.Logger, err error, metadata notification.Metadata) {

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -3,6 +3,7 @@ package reconciliation
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -11,9 +12,11 @@ import (
 	"time"
 
 	"github.com/containerd/errdefs"
+	"github.com/docker/cli/cli/command"
 	composeapi "github.com/docker/compose/v5/pkg/api"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/moby/moby/api/types/container"
+	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/common/id"
@@ -140,10 +143,7 @@ func TestDeploy(t *testing.T) {
 		CloneURL:  "https://github.com/kimdre/doco-cd_tests.git",
 		Private:   false,
 	}
-	if resolveTestSwarmMode(t, dockerCli.Client()) {
-		p.Ref = git.SwarmModeBranch
-		p.CommitSHA = plumbing.NewHash("244b6f9a5b3dc546ab3822d9c0744846f539c6ef")
-	}
+	swarmMode := resolveTestSwarmMode(t, dockerCli.Client())
 
 	tmpDir := t.TempDir()
 
@@ -172,23 +172,39 @@ func TestDeploy(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if swarmMode {
+		makeDeployFixtureSwarmCompatible(t, repoPath)
+	}
+
 	stackName := test.ConvertTestName(t.Name())
 
 	dcs, err := deployConfig.GetConfigs(repoPath, c.DeployConfigBaseDir, "", p.Ref, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	// Both runtime fixtures contain five deployments.
+	if len(dcs) != 5 {
+		t.Fatalf("expected five deployment configs, got %d", len(dcs))
+	}
+
 	for _, dc := range dcs {
 		dc.Name = stackName + "-" + dc.Name
 	}
 
 	dcs[0].Reconciliation.Enabled = false
-	dcs[1].Reconciliation.Events = []string{"stop"}
-
-	// The default reconciliation events don't include "die".
-	// Explicitly enable it for dcs[2..4] so the test's forceful container
-	// removal (which emits a "die" event) triggers reconciliation as expected.
-	for _, dc := range dcs[2:] {
-		dc.Reconciliation.Events = []string{"die"}
+	if swarmMode {
+		// Service removal emits "remove", normalized to "destroy". App2 subscribes
+		// to a different service event so only app3 through app5 are redeployed.
+		dcs[1].Reconciliation.Events = []string{"update"}
+		for _, dc := range dcs[2:] {
+			dc.Reconciliation.Events = []string{"destroy"}
+		}
+	} else {
+		// Force-removing a container emits "die", not "stop".
+		dcs[1].Reconciliation.Events = []string{"stop"}
+		for _, dc := range dcs[2:] {
+			dc.Reconciliation.Events = []string{"die"}
+		}
 	}
 
 	t.Cleanup(func() {
@@ -200,7 +216,11 @@ func TestDeploy(t *testing.T) {
 
 		for _, dc := range dcs {
 			ctx := context.Background()
-			if err := destroyTestStack(ctx, dockerCli.Client(), dc.Name); err != nil {
+			if swarmMode {
+				if err := removeTestSwarmStack(ctx, dockerCli, dc.Name); err != nil {
+					t.Error("removeTestSwarmStack err", err)
+				}
+			} else if err := destroyTestStack(ctx, dockerCli.Client(), dc.Name); err != nil {
 				t.Error("destroyTestStack err", err)
 			}
 		}
@@ -226,27 +246,97 @@ func TestDeploy(t *testing.T) {
 		t.Fatalf("Failed to deploy: %v", err)
 	}
 
-	wanted := []string{}
+	wanted := make([]string, 0, len(dcs))
 	for _, dc := range dcs {
-		wanted = append(wanted, dc.Name+"-test-1")
+		wanted = append(wanted, dc.Name)
 	}
 
 	firstPartWanted := []string{wanted[2], wanted[3], wanted[4]}
 
 	slices.Sort(wanted)
 
-	waitForRunningContainerNames(ctx, t, dockerCli.Client(), stackName, wanted, 20*time.Second)
+	waitForRunningDeploymentNames(ctx, t, dockerCli.Client(), swarmMode, stackName, wanted, 20*time.Second)
 	waitForReconciliationJobReady(t, manager, repoName, 5*time.Second)
 
-	if err := rmContainer(ctx, t, dockerCli.Client(), wanted); err != nil {
-		t.Fatal("rm container err:", err)
+	if swarmMode {
+		removeSwarmServices(ctx, t, dockerCli.Client(), dcs)
+	} else {
+		if err := rmContainersForDeployments(ctx, t, dockerCli.Client(), wanted); err != nil {
+			t.Fatal("rm container err:", err)
+		}
+
+		waitForRunningDeploymentNames(ctx, t, dockerCli.Client(), false, stackName, nil, 20*time.Second)
 	}
 
-	waitForRunningContainerNames(ctx, t, dockerCli.Client(), stackName, nil, 20*time.Second)
-	waitForRunningContainerNames(ctx, t, dockerCli.Client(), stackName, firstPartWanted, 20*time.Second)
+	reconciliationTimeout := 20 * time.Second
+	if swarmMode {
+		reconciliationTimeout = 60 * time.Second
+	}
+
+	waitForRunningDeploymentNames(ctx, t, dockerCli.Client(), swarmMode, stackName, firstPartWanted, reconciliationTimeout)
 }
 
-func getRunningContainerNames(ctx context.Context, cli client.APIClient, stackName string) ([]string, error) {
+func makeDeployFixtureSwarmCompatible(t *testing.T, repoPath string) {
+	t.Helper()
+
+	for _, relativePath := range []string{
+		"deploy/app1/docker-compose.yml",
+		"deploy/app2/docker-compose.yml",
+	} {
+		path := filepath.Join(repoPath, relativePath)
+
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read Compose fixture %q: %v", relativePath, err)
+		}
+
+		updated := strings.ReplaceAll(string(contents), "    scale: 1\n", "")
+		if updated == string(contents) {
+			t.Fatalf("Compose fixture %q no longer contains the expected Swarm-incompatible scale option", relativePath)
+		}
+
+		// #nosec G703: relativePath comes from the fixed test fixture list above.
+		if err := os.WriteFile(path, []byte(updated), 0o600); err != nil {
+			t.Fatalf("failed to update Compose fixture %q: %v", relativePath, err)
+		}
+	}
+}
+
+func getRunningDeploymentNames(ctx context.Context, cli client.APIClient, swarmMode bool, stackName string) ([]string, error) {
+	if swarmMode {
+		result, err := cli.ServiceList(ctx, client.ServiceListOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		names := make(map[string]struct{})
+
+		for _, service := range result.Items {
+			name := docker.SwarmServiceLabels(service)[docker.DocoCDLabels.Deployment.Name]
+			if !strings.HasPrefix(name, stackName+"-") {
+				continue
+			}
+
+			running, err := swarmServiceHasRunningTask(ctx, cli, service.ID)
+			if err != nil {
+				return nil, err
+			}
+
+			if running {
+				names[name] = struct{}{}
+			}
+		}
+
+		got := make([]string, 0, len(names))
+		for name := range names {
+			got = append(got, name)
+		}
+
+		slices.Sort(got)
+
+		return got, nil
+	}
+
 	result, err := cli.ContainerList(ctx, client.ContainerListOptions{
 		All: false,
 	})
@@ -254,15 +344,18 @@ func getRunningContainerNames(ctx context.Context, cli client.APIClient, stackNa
 		return nil, err
 	}
 
-	stackContainerPrefix := stackName + "-"
-
-	got := []string{}
+	names := make(map[string]struct{})
 
 	for _, c := range result.Items {
-		name := strings.TrimPrefix(c.Names[0], "/")
-		if strings.HasPrefix(name, stackContainerPrefix) {
-			got = append(got, name)
+		name := c.Labels[docker.DocoCDLabels.Deployment.Name]
+		if strings.HasPrefix(name, stackName+"-") {
+			names[name] = struct{}{}
 		}
+	}
+
+	got := make([]string, 0, len(names))
+	for name := range names {
+		got = append(got, name)
 	}
 
 	slices.Sort(got)
@@ -270,26 +363,93 @@ func getRunningContainerNames(ctx context.Context, cli client.APIClient, stackNa
 	return got, nil
 }
 
-func rmContainer(ctx context.Context, t *testing.T, cli client.APIClient, containerNames []string) error {
+func swarmServiceHasRunningTask(ctx context.Context, cli client.APIClient, serviceID string) (bool, error) {
+	result, err := cli.TaskList(ctx, client.TaskListOptions{
+		Filters: make(client.Filters).Add("service", serviceID),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for _, task := range result.Items {
+		if task.DesiredState == swarmTypes.TaskStateRunning && task.Status.State == swarmTypes.TaskStateRunning {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func rmContainersForDeployments(ctx context.Context, t *testing.T, cli client.APIClient, deploymentNames []string) error {
+	result, err := cli.ContainerList(ctx, client.ContainerListOptions{
+		All:     false,
+		Filters: make(client.Filters).Add("label", docker.DocoCDLabels.Metadata.Manager+"="+app.Name),
+	})
+	if err != nil {
+		return err
+	}
+
+	deployments := make(map[string]struct{}, len(deploymentNames))
+	for _, name := range deploymentNames {
+		deployments[name] = struct{}{}
+	}
+
 	wg := sync.WaitGroup{}
-	for _, containerName := range containerNames {
+
+	for _, container := range result.Items {
+		if _, ok := deployments[container.Labels[docker.DocoCDLabels.Deployment.Name]]; !ok {
+			continue
+		}
+
 		wg.Add(1)
 
-		go func(name string) {
+		go func(containerID string) {
 			defer wg.Done()
 
-			_, err := cli.ContainerRemove(ctx, name, client.ContainerRemoveOptions{
+			_, err := cli.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{
 				Force: true,
 			})
 			if err != nil {
-				t.Errorf("rm container %s err: %v", name, err)
+				t.Errorf("rm container %s err: %v", containerID, err)
 			}
-		}(containerName)
+		}(container.ID)
 	}
 
 	wg.Wait()
 
 	return nil
+}
+
+func removeSwarmServices(ctx context.Context, t *testing.T, cli client.APIClient, dcs []*deployConfig.Config) {
+	t.Helper()
+
+	for _, dc := range dcs {
+		services, err := dockerSwarm.GetStackServices(ctx, cli, dc.Name)
+		if err != nil {
+			t.Fatalf("failed to list services for Swarm stack %q: %v", dc.Name, err)
+		}
+
+		for _, service := range services {
+			if _, err := cli.ServiceRemove(ctx, service.ID, client.ServiceRemoveOptions{}); err != nil {
+				t.Fatalf("failed to remove service %q from Swarm stack %q: %v", service.Spec.Name, dc.Name, err)
+			}
+		}
+	}
+}
+
+func removeTestSwarmStack(ctx context.Context, dockerCli command.Cli, stackName string) error {
+	var err error
+
+	for range 5 {
+		err = docker.RemoveSwarmStack(ctx, dockerCli, stackName)
+		if err == nil {
+			return nil
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	return err
 }
 
 func waitForStackDeploymentToFinish(t *testing.T, manager *Manager, repository, context, stack string, timeout time.Duration) {
@@ -333,15 +493,15 @@ func waitForReconciliationJobReady(t *testing.T, manager *Manager, repository st
 	}
 }
 
-func waitForRunningContainerNames(ctx context.Context, t *testing.T, cli client.APIClient, stackName string, want []string, timeout time.Duration) {
+func waitForRunningDeploymentNames(ctx context.Context, t *testing.T, cli client.APIClient, swarmMode bool, stackName string, want []string, timeout time.Duration) {
 	t.Helper()
 
 	deadline := time.Now().Add(timeout)
 
 	for {
-		got, err := getRunningContainerNames(ctx, cli, stackName)
+		got, err := getRunningDeploymentNames(ctx, cli, swarmMode, stackName)
 		if err != nil {
-			t.Fatal("get containers err:", err)
+			t.Fatal("get deployments err:", err)
 		}
 
 		if slices.Equal(want, got) {
@@ -349,7 +509,7 @@ func waitForRunningContainerNames(ctx context.Context, t *testing.T, cli client.
 		}
 
 		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for running containers %v, got %v", want, got)
+			t.Fatalf("timed out waiting for running deployments %v, got %v", want, got)
 		}
 
 		time.Sleep(250 * time.Millisecond)

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -174,8 +174,11 @@ func TestDeploy(t *testing.T) {
 
 	// commit have 5 apps
 	// https://github.com/kimdre/doco-cd_tests/blob/7be81e788a40724cee7542eec00a2af0c4340eba/.doco-cd.yml
+	composeEnabled := false
+
 	for _, dc := range dcs {
 		dc.Name = stackName + "-" + dc.Name
+		dc.Swarm.Enabled = &composeEnabled
 	}
 
 	dcs[0].Reconciliation.Enabled = false

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -380,7 +380,12 @@ func destroyTestStack(ctx context.Context, cli client.APIClient, stackName strin
 		}
 	}
 
-	if err := docker.RemoveLabeledVolumes(ctx, cli, dockerSwarm.GetModeEnabled(), stackName); err != nil {
+	swarmMode, err := dockerSwarm.ResolveModeEnabled(ctx, cli)
+	if err != nil {
+		return err
+	}
+
+	if err := docker.RemoveLabeledVolumes(ctx, cli, swarmMode, stackName); err != nil {
 		return err
 	}
 

--- a/internal/reconciliation/deploy_test.go
+++ b/internal/reconciliation/deploy_test.go
@@ -140,6 +140,10 @@ func TestDeploy(t *testing.T) {
 		CloneURL:  "https://github.com/kimdre/doco-cd_tests.git",
 		Private:   false,
 	}
+	if resolveTestSwarmMode(t, dockerCli.Client()) {
+		p.Ref = git.SwarmModeBranch
+		p.CommitSHA = plumbing.NewHash("244b6f9a5b3dc546ab3822d9c0744846f539c6ef")
+	}
 
 	tmpDir := t.TempDir()
 
@@ -172,13 +176,9 @@ func TestDeploy(t *testing.T) {
 
 	dcs, err := deployConfig.GetConfigs(repoPath, c.DeployConfigBaseDir, "", p.Ref, nil)
 
-	// commit have 5 apps
-	// https://github.com/kimdre/doco-cd_tests/blob/7be81e788a40724cee7542eec00a2af0c4340eba/.doco-cd.yml
-	composeEnabled := false
-
+	// Both runtime fixtures contain five deployments.
 	for _, dc := range dcs {
 		dc.Name = stackName + "-" + dc.Name
-		dc.Swarm.Enabled = &composeEnabled
 	}
 
 	dcs[0].Reconciliation.Enabled = false

--- a/internal/reconciliation/manager.go
+++ b/internal/reconciliation/manager.go
@@ -12,6 +12,8 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
@@ -37,14 +39,34 @@ type Dependencies struct {
 	// It sets the capacity of a semaphore-based limiter (DeployerLimiter).
 	MaxConcurrentDeployments uint `validate:"min=1"`
 
-	AppConfig      *app.Config          `validate:"required,nostructlevel"`
-	DataMountPoint container.MountPoint `validate:"required"`
-	DockerCLI      command.Cli          `validate:"required,nostructlevel"`
-	// Contexts and SecretProvider are optional: resolveDeployContext falls back to the
-	// default Docker context/CLI when Contexts is nil, and a nil SecretProvider means no
-	// external secret provider is configured.
-	Contexts       *docker.ContextRegistry
+	AppConfig      *app.Config             `validate:"required,nostructlevel"`
+	DataMountPoint container.MountPoint    `validate:"required"`
+	DockerCLI      command.Cli             `validate:"required,nostructlevel"`
+	Contexts       *docker.ContextRegistry `validate:"required"`
+	// A nil SecretProvider means no external secret provider is configured.
 	SecretProvider secretprovider.SecretProvider
+	RuntimeQueries RuntimeQueries
+}
+
+// RuntimeQueries is the read-only Docker query surface used by reconciliation.
+type RuntimeQueries interface {
+	ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, manager, repository string, all bool) ([]container.Summary, error)
+	InspectContainerState(ctx context.Context, apiClient client.APIClient, containerID string) (*container.State, error)
+	ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, manager, repository string) ([]swarm.Service, error)
+}
+
+type dockerRuntimeQueries struct{}
+
+func (dockerRuntimeQueries) ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, manager, repository string, all bool) ([]container.Summary, error) {
+	return docker.ListManagedRepositoryContainers(ctx, apiClient, manager, repository, all)
+}
+
+func (dockerRuntimeQueries) InspectContainerState(ctx context.Context, apiClient client.APIClient, containerID string) (*container.State, error) {
+	return docker.InspectContainerState(ctx, apiClient, containerID)
+}
+
+func (dockerRuntimeQueries) ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, manager, repository string) ([]swarm.Service, error) {
+	return docker.ListManagedRepositoryServices(ctx, apiClient, manager, repository)
 }
 
 // Manager owns reconciliation jobs, active-deployment tracking, scheduler
@@ -66,12 +88,17 @@ type Manager struct {
 	dockerCli      command.Cli
 	contexts       *docker.ContextRegistry
 	secretProvider secretprovider.SecretProvider
+	runtimeQueries RuntimeQueries
 }
 
 // NewManager validates dependencies and creates an isolated reconciliation manager.
 func NewManager(dependencies Dependencies) (*Manager, error) {
 	if dependencies.MaxConcurrentDeployments == 0 {
 		dependencies.MaxConcurrentDeployments = 1
+	}
+
+	if dependencies.RuntimeQueries == nil {
+		dependencies.RuntimeQueries = dockerRuntimeQueries{}
 	}
 
 	if err := validation.Validate(dependencies); err != nil {
@@ -88,13 +115,13 @@ func NewManager(dependencies Dependencies) (*Manager, error) {
 		dockerCli:      dependencies.DockerCLI,
 		contexts:       dependencies.Contexts,
 		secretProvider: dependencies.SecretProvider,
+		runtimeQueries: dependencies.RuntimeQueries,
 	}, nil
 }
 
 // contextCLIEntry holds a Docker CLI and its resolved metadata for one Docker context.
 type contextCLIEntry struct {
 	cli       command.Cli
-	closeFn   func() // nil for the default context (which is always j.manager.dockerCli)
 	swarmMode bool
 }
 

--- a/internal/reconciliation/manager.go
+++ b/internal/reconciliation/manager.go
@@ -50,23 +50,23 @@ type Dependencies struct {
 
 // RuntimeQueries is the read-only Docker query surface used by reconciliation.
 type RuntimeQueries interface {
-	ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, manager, repository string, all bool) ([]container.Summary, error)
+	ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, repository string, all bool) ([]container.Summary, error)
 	InspectContainerState(ctx context.Context, apiClient client.APIClient, containerID string) (*container.State, error)
-	ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, manager, repository string) ([]swarm.Service, error)
+	ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, repository string) ([]swarm.Service, error)
 }
 
 type dockerRuntimeQueries struct{}
 
-func (dockerRuntimeQueries) ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, manager, repository string, all bool) ([]container.Summary, error) {
-	return docker.ListManagedRepositoryContainers(ctx, apiClient, manager, repository, all)
+func (dockerRuntimeQueries) ListManagedRepositoryContainers(ctx context.Context, apiClient client.APIClient, repository string, all bool) ([]container.Summary, error) {
+	return docker.ListManagedRepositoryContainers(ctx, apiClient, repository, all)
 }
 
 func (dockerRuntimeQueries) InspectContainerState(ctx context.Context, apiClient client.APIClient, containerID string) (*container.State, error) {
 	return docker.InspectContainerState(ctx, apiClient, containerID)
 }
 
-func (dockerRuntimeQueries) ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, manager, repository string) ([]swarm.Service, error) {
-	return docker.ListManagedRepositoryServices(ctx, apiClient, manager, repository)
+func (dockerRuntimeQueries) ListManagedRepositoryServices(ctx context.Context, apiClient client.APIClient, repository string) ([]swarm.Service, error) {
+	return docker.ListManagedRepositoryServices(ctx, apiClient, repository)
 }
 
 // Manager owns reconciliation jobs, active-deployment tracking, scheduler

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -21,7 +21,6 @@ import (
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 
 	"github.com/kimdre/doco-cd/internal/docker"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	gitInternal "github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/lock"
 	"github.com/kimdre/doco-cd/internal/logger"
@@ -42,7 +41,7 @@ type contextualEvent struct {
 
 // initContextCLIs populates j.contextCLIs with a Docker CLI entry for the default context
 // and for every unique non-default context referenced in the job's deploy configs.
-func (j *job) initContextCLIs(ctx context.Context, quiet bool) {
+func (j *job) initContextCLIs(ctx context.Context) {
 	contextCLIs := make(map[string]contextCLIEntry)
 
 	for _, dc := range j.info.DeployConfigs {
@@ -51,7 +50,7 @@ func (j *job) initContextCLIs(ctx context.Context, quiet bool) {
 			continue
 		}
 
-		entry := resolveDeployContext(ctx, j.manager.contexts, j.manager.dockerCli, quiet, ctxName)
+		entry := resolveDeployContext(ctx, j.manager.contexts, ctxName)
 		if entry.err != nil {
 			j.info.Logger.Error("failed to create Docker CLI for context; skipping event listener for that context",
 				slog.String("context", docker.DisplayContextName(ctxName)),
@@ -63,7 +62,6 @@ func (j *job) initContextCLIs(ctx context.Context, quiet bool) {
 
 		contextCLIs[ctxName] = contextCLIEntry{
 			cli:       entry.cli,
-			closeFn:   entry.closeFn,
 			swarmMode: entry.swarmMode,
 		}
 	}
@@ -84,8 +82,8 @@ func (j *job) cliForContext(contextName string) command.Cli {
 	return j.manager.dockerCli
 }
 
-// swarmModeForContext returns the swarm mode for the given context name, falling back to the
-// globally cached value for the default context.
+// swarmModeForContext returns the capability resolved when this job initialized
+// the requested Docker context.
 func (j *job) swarmModeForContext(contextName string) bool {
 	contextName = docker.NormalizeContextName(contextName)
 	if j.contextCLIs != nil {
@@ -94,7 +92,7 @@ func (j *job) swarmModeForContext(contextName string) bool {
 		}
 	}
 
-	return swarm.GetModeEnabled()
+	return false
 }
 
 // deployConfigsForContext returns the subset of the job's deploy configs that target contextName.
@@ -109,26 +107,13 @@ func (j *job) deployConfigsForContextMode(contextName string, swarmMode bool) []
 func (j *job) run(ctx context.Context) {
 	jobLog := j.info.Logger
 
-	dockerQuiet := false
-	if j.manager.appConfig != nil {
-		dockerQuiet = j.manager.appConfig.DockerQuietDeploy
-	}
-
-	j.initContextCLIs(ctx, dockerQuiet)
+	j.initContextCLIs(ctx)
 
 	// Wait for all event-listener goroutines to exit before closing their Docker
 	// CLIs, so we never close a client that a listener is still using.
 	var listenerWG sync.WaitGroup
 
-	defer func() {
-		listenerWG.Wait()
-
-		for ctxName, entry := range j.contextCLIs {
-			if ctxName != "" && entry.closeFn != nil {
-				entry.closeFn()
-			}
-		}
-	}()
+	defer listenerWG.Wait()
 
 	// Startup recovery: run for every configured context in parallel.
 	// Run both checks concurrently per context, then wait for all to finish
@@ -521,7 +506,7 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 		restartResult := j.restartContainer(ctx, eventLog, event, restartDC, contextCLI, swarmMode)
 		if restartResult.fallbackToDeploy {
 			if event.Actor.ID != "" {
-				waitForContainerRemovalSettled(ctx, eventLog, contextCLI.Client(), event.Actor.ID, containerRemovalSettleTimeout)
+				j.waitForContainerRemovalSettled(ctx, eventLog, contextCLI.Client(), event.Actor.ID, containerRemovalSettleTimeout)
 			}
 
 			j.deploy(ctx, eventLog, stackDCs, action, event, traceID, contextName, swarmMode)
@@ -536,7 +521,7 @@ func (j *job) handleEvent(ctx context.Context, jobLog *slog.Logger, event events
 	// started". Wait briefly for the container to either be fully removed or settle
 	// into a stable state before re-deploying.
 	if event.Actor.ID != "" {
-		waitForContainerRemovalSettled(ctx, eventLog, contextCLI.Client(), event.Actor.ID, containerRemovalSettleTimeout)
+		j.waitForContainerRemovalSettled(ctx, eventLog, contextCLI.Client(), event.Actor.ID, containerRemovalSettleTimeout)
 	}
 
 	j.deploy(ctx, eventLog, stackDCs, action, event, traceID, contextName, swarmMode)

--- a/internal/reconciliation/reconciliation_helpers.go
+++ b/internal/reconciliation/reconciliation_helpers.go
@@ -63,7 +63,7 @@ const containerRemovalSettleTimeout = 15 * time.Second
 // (inspect returns not-found) or no longer reported as "removing", or until the
 // timeout elapses. This prevents a race between Docker's async container teardown
 // and docker compose trying to recreate the container.
-func waitForContainerRemovalSettled(ctx context.Context, jobLog *slog.Logger, cli client.APIClient, containerID string, timeout time.Duration) {
+func (j *job) waitForContainerRemovalSettled(ctx context.Context, jobLog *slog.Logger, cli client.APIClient, containerID string, timeout time.Duration) {
 	if containerID == "" || timeout <= 0 {
 		return
 	}
@@ -71,7 +71,7 @@ func waitForContainerRemovalSettled(ctx context.Context, jobLog *slog.Logger, cl
 	deadline := time.Now().Add(timeout)
 
 	for {
-		inspectResult, err := cli.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+		state, err := j.manager.runtimeQueries.InspectContainerState(ctx, cli, containerID)
 		if err != nil {
 			// Treat any inspect error (most importantly "no such container") as
 			// "container is gone, safe to proceed".
@@ -87,7 +87,6 @@ func waitForContainerRemovalSettled(ctx context.Context, jobLog *slog.Logger, cl
 			return
 		}
 
-		state := inspectResult.Container.State
 		if state == nil || !strings.EqualFold(strings.TrimSpace(string(state.Status)), "removing") {
 			return
 		}

--- a/internal/reconciliation/reconciliation_integration_test.go
+++ b/internal/reconciliation/reconciliation_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/config/app"
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker"
-	dockerSwarm "github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/stages"
@@ -241,7 +240,7 @@ func TestCleanupObsoleteAutoDiscoveredContainers_EmptyDiscoveredConfigs_RemovesS
 		ctx,
 		jobLog,
 		stack.DockerCli,
-		dockerSwarm.GetModeEnabled(),
+		resolveTestSwarmMode(t, stack.DockerCli.Client()),
 		"",
 		repoURL,
 		[]*deployConfig.Config{},
@@ -274,11 +273,7 @@ func requireDockerIntegrationTestGate(t *testing.T) {
 		_ = dockerCli.Client().Close()
 	}()
 
-	if err := dockerSwarm.RefreshModeEnabled(t.Context(), dockerCli.Client()); err != nil {
-		t.Fatalf("failed to inspect Docker swarm mode: %v", err)
-	}
-
-	if dockerSwarm.GetModeEnabled() {
+	if resolveTestSwarmMode(t, dockerCli.Client()) {
 		t.Skip("reconciliation Docker event integration tests require non-Swarm mode")
 	}
 }

--- a/internal/reconciliation/reconciliation_startup.go
+++ b/internal/reconciliation/reconciliation_startup.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/moby/moby/api/types/events"
-	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/common/id"
 	"github.com/kimdre/doco-cd/internal/common/types/set"
@@ -16,7 +15,6 @@ import (
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 
 	"github.com/kimdre/doco-cd/internal/docker"
-	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	gitInternal "github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/logger"
 )
@@ -31,17 +29,15 @@ func (j *job) restartUnhealthyContainersOnStartup(ctx context.Context, jobLog *s
 		repositoryLabelValue = j.info.Payload.FullName
 	}
 
-	filterArgs := make(client.Filters)
-	filterArgs.Add("label", docker.DocoCDLabels.Metadata.Manager+"="+app.Name)
-	filterArgs.Add("label", docker.DocoCDLabels.Source.Name+"="+repositoryLabelValue)
-
-	containerResult, err := cli.Client().ContainerList(ctx, client.ContainerListOptions{All: true, Filters: filterArgs})
+	containers, err := j.manager.runtimeQueries.ListManagedRepositoryContainers(
+		ctx, cli.Client(), app.Name, repositoryLabelValue, true,
+	)
 	if err != nil {
 		jobLog.Error("failed to list containers for startup unhealthy scan", logger.ErrAttr(err))
 		return
 	}
 
-	for _, c := range containerResult.Items {
+	for _, c := range containers {
 		stackName := strings.TrimSpace(c.Labels[docker.DocoCDLabels.Deployment.Name])
 		if stackName == "" {
 			continue
@@ -54,7 +50,7 @@ func (j *job) restartUnhealthyContainersOnStartup(ctx context.Context, jobLog *s
 			continue
 		}
 
-		inspectResult, err := cli.Client().ContainerInspect(ctx, c.ID, client.ContainerInspectOptions{})
+		state, err := j.manager.runtimeQueries.InspectContainerState(ctx, cli.Client(), c.ID)
 		if err != nil {
 			jobLog.Debug("failed to inspect container during startup unhealthy scan",
 				slog.String("container_id", shortID(c.ID)),
@@ -64,9 +60,7 @@ func (j *job) restartUnhealthyContainersOnStartup(ctx context.Context, jobLog *s
 			continue
 		}
 
-		inspect := inspectResult.Container
-
-		if inspect.State == nil || inspect.State.Health == nil || strings.ToLower(strings.TrimSpace(string(inspect.State.Health.Status))) != "unhealthy" {
+		if state == nil || state.Health == nil || strings.ToLower(strings.TrimSpace(string(state.Health.Status))) != "unhealthy" {
 			continue
 		}
 
@@ -182,14 +176,9 @@ func (j *job) findMissingContainersOnStartup(ctx context.Context, jobLog *slog.L
 		repositoryLabelValue = j.info.Payload.FullName
 	}
 
-	filterArgs := make(client.Filters)
-	filterArgs.Add("label", docker.DocoCDLabels.Metadata.Manager+"="+app.Name)
-	filterArgs.Add("label", docker.DocoCDLabels.Source.Name+"="+repositoryLabelValue)
-
-	containerResult, err := cli.Client().ContainerList(ctx, client.ContainerListOptions{
-		All:     false, // running only
-		Filters: filterArgs,
-	})
+	containers, err := j.manager.runtimeQueries.ListManagedRepositoryContainers(
+		ctx, cli.Client(), app.Name, repositoryLabelValue, false,
+	)
 	if err != nil {
 		jobLog.Error("failed to list containers for startup missing scan", logger.ErrAttr(err))
 		return nil
@@ -197,7 +186,7 @@ func (j *job) findMissingContainersOnStartup(ctx context.Context, jobLog *slog.L
 
 	runningStacks := set.New[string]()
 
-	for _, c := range containerResult.Items {
+	for _, c := range containers {
 		if stackName := strings.TrimSpace(c.Labels[docker.DocoCDLabels.Deployment.Name]); stackName != "" {
 			runningStacks.Add(stackName)
 		}
@@ -223,7 +212,9 @@ func (j *job) findMissingSwarmServicesOnStartup(ctx context.Context, jobLog *slo
 		repositoryLabelValue = j.info.Payload.FullName
 	}
 
-	services, err := swarm.GetServicesByLabel(ctx, cli.Client(), docker.DocoCDLabels.Metadata.Manager, app.Name)
+	services, err := j.manager.runtimeQueries.ListManagedRepositoryServices(
+		ctx, cli.Client(), app.Name, repositoryLabelValue,
+	)
 	if err != nil {
 		jobLog.Error("failed to list swarm services for startup missing scan", logger.ErrAttr(err))
 		return nil
@@ -233,11 +224,6 @@ func (j *job) findMissingSwarmServicesOnStartup(ctx context.Context, jobLog *slo
 
 	for _, svc := range services {
 		labels := docker.SwarmServiceLabels(svc)
-
-		// Filter by repository to avoid matching services from other repos on the same swarm.
-		if strings.TrimSpace(labels[docker.DocoCDLabels.Source.Name]) != repositoryLabelValue {
-			continue
-		}
 
 		if stackName := strings.TrimSpace(labels[docker.DocoCDLabels.Deployment.Name]); stackName != "" {
 			existingStacks.Add(stackName)

--- a/internal/reconciliation/reconciliation_startup.go
+++ b/internal/reconciliation/reconciliation_startup.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/common/id"
 	"github.com/kimdre/doco-cd/internal/common/types/set"
 
-	"github.com/kimdre/doco-cd/internal/config/app"
 	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 
 	"github.com/kimdre/doco-cd/internal/docker"
@@ -30,7 +29,7 @@ func (j *job) restartUnhealthyContainersOnStartup(ctx context.Context, jobLog *s
 	}
 
 	containers, err := j.manager.runtimeQueries.ListManagedRepositoryContainers(
-		ctx, cli.Client(), app.Name, repositoryLabelValue, true,
+		ctx, cli.Client(), repositoryLabelValue, true,
 	)
 	if err != nil {
 		jobLog.Error("failed to list containers for startup unhealthy scan", logger.ErrAttr(err))
@@ -177,7 +176,7 @@ func (j *job) findMissingContainersOnStartup(ctx context.Context, jobLog *slog.L
 	}
 
 	containers, err := j.manager.runtimeQueries.ListManagedRepositoryContainers(
-		ctx, cli.Client(), app.Name, repositoryLabelValue, false,
+		ctx, cli.Client(), repositoryLabelValue, false,
 	)
 	if err != nil {
 		jobLog.Error("failed to list containers for startup missing scan", logger.ErrAttr(err))
@@ -213,7 +212,7 @@ func (j *job) findMissingSwarmServicesOnStartup(ctx context.Context, jobLog *slo
 	}
 
 	services, err := j.manager.runtimeQueries.ListManagedRepositoryServices(
-		ctx, cli.Client(), app.Name, repositoryLabelValue,
+		ctx, cli.Client(), repositoryLabelValue,
 	)
 	if err != nil {
 		jobLog.Error("failed to list swarm services for startup missing scan", logger.ErrAttr(err))

--- a/internal/reconciliation/test_helpers_test.go
+++ b/internal/reconciliation/test_helpers_test.go
@@ -4,10 +4,23 @@ import (
 	"testing"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/docker"
+	dockerSwarm "github.com/kimdre/doco-cd/internal/docker/swarm"
 )
+
+func resolveTestSwarmMode(t *testing.T, apiClient client.APIClient) bool {
+	t.Helper()
+
+	enabled, err := dockerSwarm.ResolveModeEnabled(t.Context(), apiClient)
+	if err != nil {
+		t.Fatalf("failed to check if Docker daemon is in Swarm mode: %v", err)
+	}
+
+	return enabled
+}
 
 // newTestManagerWithDependencies creates a Manager for tests, filling in a zero-value AppConfig
 // and a fresh Docker CLI (closed via t.Cleanup) for any dependency left unset in deps, so tests
@@ -38,6 +51,15 @@ func newTestManagerWithDependencies(t *testing.T, deps Dependencies) *Manager {
 		t.Cleanup(func() { _ = dockerCli.Client().Close() })
 
 		deps.DockerCLI = dockerCli
+	}
+
+	if deps.Contexts == nil {
+		deps.Contexts = docker.NewContextRegistry(deps.DockerCLI, docker.ContextRegistryOptions{
+			Quiet:         true,
+			SwarmFeatures: true,
+		})
+
+		t.Cleanup(func() { _ = deps.Contexts.Close() })
 	}
 
 	manager, err := NewManager(deps)

--- a/internal/reconciliation/test_helpers_test.go
+++ b/internal/reconciliation/test_helpers_test.go
@@ -11,6 +11,7 @@ import (
 	dockerSwarm "github.com/kimdre/doco-cd/internal/docker/swarm"
 )
 
+// resolveTestSwarmMode checks if the Docker daemon is in Swarm mode.
 func resolveTestSwarmMode(t *testing.T, apiClient client.APIClient) bool {
 	t.Helper()
 

--- a/internal/scheduler/scheduler_types.go
+++ b/internal/scheduler/scheduler_types.go
@@ -56,8 +56,7 @@ type scheduler struct {
 	contextName string
 	// mode is the runtime this worker manages jobs for. A Swarm manager hosts
 	// both Compose projects and Swarm stacks, so it runs one worker per mode
-	// instead of deriving behavior from the process-global
-	// swarm.GetModeEnabled().
+	// using the capability supplied by ContextRegistry.
 	mode            scheduledJobMode
 	secretProvider  secretprovider.SecretProvider
 	stopHoldTracker ServiceStopHoldTracker


### PR DESCRIPTION
## Summary

- make `docker.ContextRegistry` own configured Swarm capability for the default and named Docker contexts
- remove process-global Swarm capability and disable state
- move reconciliation container/service list and container inspect operations behind focused Docker query helpers
- inject reconciliation's read-only query surface for focused testing

## Behavior preserved

- per-deployment `ResolveSwarmMode` overrides still select Compose or Swarm after daemon capability resolution
- disabled Swarm features avoid daemon capability probes
- context failures remain isolated to the affected deployment or listener
- startup recovery timing and deployment mutation paths are unchanged

## Validation

- `make fmt`
- `make test-nobitwarden`
- `make build`

Closes part of #1764