### PR TITLE
refactor(notification): make notification state instance-owned

### DIFF
--- a/cmd/doco-cd/controlplane_test_helpers_test.go
+++ b/cmd/doco-cd/controlplane_test_helpers_test.go
@@ -23,6 +23,15 @@ import (
 func newTestReconciliationManager(t *testing.T, dependencies reconciliation.Dependencies) *reconciliation.Manager {
 	t.Helper()
 
+	if dependencies.Notifier == nil {
+		notifier, err := notification.New(notification.Config{})
+		if err != nil {
+			t.Fatalf("failed to create test notifier: %v", err)
+		}
+
+		dependencies.Notifier = notifier
+	}
+
 	if dependencies.Contexts == nil {
 		dependencies.Contexts = docker.NewContextRegistry(dependencies.DockerCLI, docker.ContextRegistryOptions{
 			Quiet:         true,
@@ -40,6 +49,17 @@ func newTestReconciliationManager(t *testing.T, dependencies reconciliation.Depe
 	t.Cleanup(manager.Close)
 
 	return manager
+}
+
+func newTestNotifier(t *testing.T) notification.Sender {
+	t.Helper()
+
+	notifier, err := notification.New(notification.Config{})
+	if err != nil {
+		t.Fatalf("failed to create test notifier: %v", err)
+	}
+
+	return notifier
 }
 
 // newTestDeployment builds a *controlplane.Deployment backed by a fresh

--- a/cmd/doco-cd/handler_poll.go
+++ b/cmd/doco-cd/handler_poll.go
@@ -241,7 +241,7 @@ func watcherClosedFallback(ctx context.Context, logger *slog.Logger, configuredI
 	return fallbackInterval, false
 }
 
-func pollError(jobLog *slog.Logger, metadata notification.Metadata, err error) {
+func pollError(jobLog *slog.Logger, metadata notification.Metadata, err error, notifier notification.Sender) {
 	prometheus.PollErrors.WithLabelValues(metadata.Repository).Inc()
 
 	if metadata.Stack != "" {
@@ -256,6 +256,10 @@ func pollError(jobLog *slog.Logger, metadata notification.Metadata, err error) {
 		return
 	}
 
+	if notifier == nil {
+		return
+	}
+
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -265,7 +269,7 @@ func pollError(jobLog *slog.Logger, metadata notification.Metadata, err error) {
 
 		sendLog := jobLog.With()
 
-		err = notification.Send(notification.Failure, "Poll Job failed", err.Error(), metadata)
+		err = notifier.Send(notification.Failure, "Poll Job failed", err.Error(), metadata)
 		if err != nil {
 			sendLog.Error("failed to send notification", log.ErrAttr(err))
 		}
@@ -277,7 +281,7 @@ func pollError(jobLog *slog.Logger, metadata notification.Metadata, err error) {
 // "poll-watch" when triggered by the local repository filesystem watcher) and is
 // reported in the "polling <entity>" log line's trigger.event field.
 func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config, logger *slog.Logger, metadata notification.Metadata,
-	triggerReason string, deployment *controlplane.Deployment,
+	triggerReason string, deployment *controlplane.Deployment, notifier notification.Sender,
 ) error {
 	startTime := time.Now()
 	sourceType := config.NormalizeSourceType(pollConfig.Source)
@@ -352,7 +356,7 @@ func RunPoll(ctx context.Context, pollConfig poll.Config, appConfig *app.Config,
 	elapsedTime := time.Since(startTime)
 
 	if deployErr != nil {
-		pollError(jobLog, metadata, deployErr)
+		pollError(jobLog, metadata, deployErr, notifier)
 		jobLog.Warn("job completed with errors", log.ErrAttr(deployErr), slog.String("elapsed_time", elapsedTime.Truncate(time.Millisecond).String()), slog.String("next_run", nextRun))
 	} else {
 		jobLog.Info("job completed successfully", slog.String("elapsed_time", elapsedTime.Truncate(time.Millisecond).String()), slog.String("next_run", nextRun))

--- a/cmd/doco-cd/handler_poll_test.go
+++ b/cmd/doco-cd/handler_poll_test.go
@@ -440,14 +440,14 @@ func TestRunPoll(t *testing.T) {
 		DockerCLI:      dockerCli,
 		SecretProvider: secretProvider,
 	})
-	if err := RunPoll(ctx, pollConfig, appConfig, log.With(), metadata, pollTriggerDefault, deployment); err != nil {
+	if err := RunPoll(ctx, pollConfig, appConfig, log.With(), metadata, pollTriggerDefault, deployment, newTestNotifier(t)); err != nil {
 		t.Fatalf("Initial poll deployment failed: %v", err)
 	}
 
 	pollConfig.Reference = "destroy"
 
 	// Run the second poll to destroy
-	if err := RunPoll(ctx, pollConfig, appConfig, log.With(), metadata, pollTriggerDefault, deployment); err != nil {
+	if err := RunPoll(ctx, pollConfig, appConfig, log.With(), metadata, pollTriggerDefault, deployment, newTestNotifier(t)); err != nil {
 		t.Fatalf("Second poll deployment failed: %v", err)
 	}
 }

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -249,6 +249,7 @@ type orchestrationHandler struct {
 	log              *logger.Logger // Logger for logging messages
 	secretProvider   secretprovider.SecretProvider
 	deployment       *controlplane.Deployment
+	notifier         notification.Sender
 	testName         string // Overwrites the deployConfig.Name to make test deployments unique and prevent conflicts between tests when running in parallel. Not used in production.
 }
 
@@ -260,20 +261,21 @@ func reportHealthFailure(
 	jobID string,
 	failureType error,
 	cause error,
+	notifier notification.Sender,
 ) {
 	onError(w, log, failureType.Error(), cause.Error(), http.StatusServiceUnavailable, notification.Metadata{
 		JobID:      jobID,
 		Repository: "healthcheck",
 		Stack:      "",
 		Revision:   "",
-	}, cause)
+	}, cause, notifier)
 }
 
 // onError handles errors by logging them, sending a JSON error response, and sending a notification.
 // cause is the error behind the response: when a failure notification was already
 // sent for it deeper down, the HTTP response and the log stay the same and only
 // the second notification is dropped.
-func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any, statusCode int, metadata notification.Metadata, cause error) {
+func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any, statusCode int, metadata notification.Metadata, cause error, notifier notification.Sender) {
 	prometheus.WebhookErrorsTotal.WithLabelValues(metadata.Repository).Inc()
 	log.Error(errMsg)
 	restAPI.JSONError(w,
@@ -294,6 +296,10 @@ func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any
 		return
 	}
 
+	if notifier == nil {
+		return
+	}
+
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -301,7 +307,7 @@ func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any
 			}
 		}()
 
-		err := notification.Send(notification.Failure, "Deployment Failed", errMsg, metadata)
+		err := notifier.Send(notification.Failure, "Deployment Failed", errMsg, metadata)
 		if err != nil {
 			log.Error("failed to send notification", logger.ErrAttr(err))
 		}
@@ -311,7 +317,7 @@ func onError(w http.ResponseWriter, log *slog.Logger, errMsg string, details any
 // handleEvent executes the deployment process for a given webhook event.
 func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter, appConfig *app.Config,
 	payload webhook.ParsedPayload, customTarget string, metadata notification.Metadata,
-	testName string, deployment *controlplane.Deployment,
+	testName string, deployment *controlplane.Deployment, notifier notification.Sender,
 ) (controlplane.RunResult, error) {
 	startTime := time.Now()
 
@@ -338,7 +344,7 @@ func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 		sourceRef, cloneURLOverrideApplied = resolveWebhookGitCloneURL(payload, appConfig)
 		if !isWebhookGitCloneURLAllowed(sourceRef, cloneURLOverrideApplied) {
 			err := errors.New("local filesystem Git URLs in webhook payloads require a configured source URL rewrite")
-			onError(w, jobLog.With(logger.ErrAttr(err)), "webhook clone URL is not allowed", err, http.StatusForbidden, metadata, err)
+			onError(w, jobLog.With(logger.ErrAttr(err)), "webhook clone URL is not allowed", err, http.StatusForbidden, metadata, err, notifier)
 
 			return controlplane.FailedRun(err.Error()), nil
 		}
@@ -372,7 +378,7 @@ func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 	if sourceType == config.SourceTypeGit && shouldUsePayloadSSHURL(cloneURLOverrideApplied, payload.SSHUrl, resolvedSSH) {
 		sshAuth, authErr := git.GetAuthMethod(payload.SSHUrl, appConfig.SSHPrivateKey, appConfig.SSHPrivateKeyPassphrase, appConfig.GitAccessToken)
 		if authErr != nil {
-			onError(w, jobLog.With(logger.ErrAttr(authErr)), "failed to resolve SSH auth method", authErr.Error(), http.StatusInternalServerError, metadata, authErr)
+			onError(w, jobLog.With(logger.ErrAttr(authErr)), "failed to resolve SSH auth method", authErr.Error(), http.StatusInternalServerError, metadata, authErr, notifier)
 
 			return controlplane.FailedRun("failed to resolve SSH auth method: " + authErr.Error()), nil
 		}
@@ -412,12 +418,12 @@ func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 		// In synchronous mode we should return an error to the caller
 		// For async mode, w is noopResponseWriter and JSONError is a no-op
 		if de, ok := errors.AsType[controlplane.DeploymentError](deployErr); ok {
-			onError(w, jobLog.With(logger.ErrAttr(de.Cause)), de.Response.Error(), de.Cause.Error(), de.HTTPStatusCode, metadata, de.Cause)
+			onError(w, jobLog.With(logger.ErrAttr(de.Cause)), de.Response.Error(), de.Cause.Error(), de.HTTPStatusCode, metadata, de.Cause, notifier)
 
 			return controlplane.FailedRun(de.Error()), nil
 		}
 
-		onError(w, jobLog.With(logger.ErrAttr(deployErr)), "deployment failed", deployErr.Error(), http.StatusInternalServerError, metadata, deployErr)
+		onError(w, jobLog.With(logger.ErrAttr(deployErr)), "deployment failed", deployErr.Error(), http.StatusInternalServerError, metadata, deployErr, notifier)
 
 		return controlplane.FailedRun(deployErr.Error()), nil
 	}
@@ -512,7 +518,7 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 			})
 		}
 
-		onError(w, jobLog.With(slog.String("ip", h.requestIP(r)), logger.ErrAttr(err)), errMsg, err.Error(), statusCode, metadata, err)
+		onError(w, jobLog.With(slog.String("ip", h.requestIP(r)), logger.ErrAttr(err)), errMsg, err.Error(), statusCode, metadata, err, h.notifier)
 		h.controlPlaneRuns.MarkFailed(jobID, errMsg+": "+err.Error())
 
 		return
@@ -570,7 +576,7 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 
 		defer repoLock.Unlock()
 
-		return handleEvent(ctx, jobLog, w, h.appConfig, payload, customTarget, metadata, h.testName, h.deployment)
+		return handleEvent(ctx, jobLog, w, h.appConfig, payload, customTarget, metadata, h.testName, h.deployment, h.notifier)
 	}
 
 	mode := controlplane.RunAsynchronous

--- a/cmd/doco-cd/main.go
+++ b/cmd/doco-cd/main.go
@@ -154,6 +154,19 @@ func run() error {
 		return err
 	}
 
+	notifier, err := notification.New(notification.Config{
+		APIURL:                string(c.AppriseApiURL),
+		NotifyURLs:            c.AppriseNotifyUrls,
+		NotifyLevel:           c.AppriseNotifyLevel,
+		BodyTemplate:          c.AppriseNotifyBodyTemplate,
+		FailureRepeatInterval: c.AppriseNotifyRepeatInterval,
+	})
+	if err != nil {
+		log.Critical("failed to configure notifications", logger.ErrAttr(err))
+
+		return fmt.Errorf("failed to configure notifications: %w", err)
+	}
+
 	git.ConfigureAuthResolver(
 		c.GitAuthDomains,
 		c.SSHPrivateKey,
@@ -324,7 +337,7 @@ func run() error {
 
 	graceful.SafeGo(&wg, log.Logger,
 		func() {
-			notificationForNewAppVersion(log.Logger)
+			notificationForNewAppVersion(log.Logger, notifier)
 		},
 	)
 
@@ -356,6 +369,7 @@ func run() error {
 		DockerCLI:                dockerCli,
 		Contexts:                 contexts,
 		SecretProvider:           secretProvider,
+		Notifier:                 notifier,
 		MaxConcurrentDeployments: c.MaxConcurrentDeployments,
 	})
 	if err != nil {
@@ -385,7 +399,7 @@ func run() error {
 		return err
 	}
 
-	schedulerManager := scheduler.NewManager(contexts, log.Logger, &wg, secretProvider, reconciliationManager, docker.NewScheduledComposeOptions(c))
+	schedulerManager := scheduler.NewManager(contexts, log.Logger, &wg, secretProvider, notifier, reconciliationManager, docker.NewScheduledComposeOptions(c))
 	controlPlaneRuns := controlplane.NewRuns(
 		ctx,
 		log.Logger,
@@ -406,7 +420,7 @@ func run() error {
 					_ command.Cli, _ *docker.ContextRegistry, logger *slog.Logger, metadata notification.Metadata,
 					_ secretprovider.SecretProvider, triggerReason string,
 				) error {
-					return RunPoll(ctx, pollConfig, appConfig, logger, metadata, triggerReason, deployment)
+					return RunPoll(ctx, pollConfig, appConfig, logger, metadata, triggerReason, deployment, notifier)
 				},
 			},
 		},
@@ -425,15 +439,18 @@ func run() error {
 		log:              log,
 		secretProvider:   secretProvider,
 		deployment:       deployment,
+		notifier:         notifier,
 	}
 
 	apiHandler, err := api.NewHandler(api.Dependencies{
-		AppConfig:             c,
-		Logger:                log,
-		DockerCLI:             dockerCli,
-		Contexts:              contexts,
-		Runs:                  controlPlaneRuns,
-		HealthFailureReporter: reportHealthFailure,
+		AppConfig: c,
+		Logger:    log,
+		DockerCLI: dockerCli,
+		Contexts:  contexts,
+		Runs:      controlPlaneRuns,
+		HealthFailureReporter: func(w http.ResponseWriter, log *slog.Logger, jobID string, failureType, cause error) {
+			reportHealthFailure(w, log, jobID, failureType, cause, notifier)
+		},
 	})
 	if err != nil {
 		log.Critical("failed to create API handler", logger.ErrAttr(err))

--- a/cmd/doco-cd/main_test.go
+++ b/cmd/doco-cd/main_test.go
@@ -460,6 +460,7 @@ env_files:
 					metadata,
 					stackName,
 					deployment,
+					newTestNotifier(t),
 				); err != nil {
 					return err
 				}

--- a/cmd/doco-cd/version.go
+++ b/cmd/doco-cd/version.go
@@ -80,7 +80,7 @@ func getLatestAppReleaseVersionFromURL(releaseApiURL string, httpClient *http.Cl
 	return "", errors.New("no stable release found")
 }
 
-func notificationForNewAppVersion(log *slog.Logger) {
+func notificationForNewAppVersion(log *slog.Logger, notifier notification.Sender) {
 	latestVersion, err := getLatestAppReleaseVersion()
 	if err != nil {
 		log.Error("failed to get latest application release version", logger.ErrAttr(err))
@@ -94,7 +94,7 @@ func notificationForNewAppVersion(log *slog.Logger) {
 			// App-level ping, not a deployment: it carries no stack/context/revision,
 			// so skip any custom body template and use the built-in body (just the
 			// message). Otherwise a deploy-shaped template renders empty fields.
-			err = notification.Send(notification.Info,
+			err = notifier.Send(notification.Info,
 				"New version of doco-cd is available",
 				fmt.Sprintf("Current Version: %s\nLatest Version: %s\n\nhttps://github.com/kimdre/doco-cd/releases", app.Version, latestVersion),
 				notification.Metadata{},

--- a/internal/config/app/app_config.go
+++ b/internal/config/app/app_config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/poll"
 	"github.com/kimdre/doco-cd/internal/git"
-	"github.com/kimdre/doco-cd/internal/notification"
 )
 
 const Name = "doco-cd" // Name of the application
@@ -226,18 +225,6 @@ func GetConfig() (*Config, error) {
 		if !path.IsAbs(cfg.DataHostPath) {
 			return nil, fmt.Errorf("DATA_HOST_PATH must be an absolute Unix path: %q", cfg.DataHostPath)
 		}
-	}
-
-	notification.SetFailureRepeatInterval(cfg.AppriseNotifyRepeatInterval)
-
-	err = notification.SetAppriseConfig(
-		string(cfg.AppriseApiURL),
-		cfg.AppriseNotifyUrls,
-		cfg.AppriseNotifyLevel,
-		cfg.AppriseNotifyBodyTemplate,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to configure notifications: %w", err)
 	}
 
 	return &cfg, nil

--- a/internal/mcp/jobs_test.go
+++ b/internal/mcp/jobs_test.go
@@ -227,7 +227,7 @@ func TestMCPScheduledJobsTool(t *testing.T) {
 
 	t.Cleanup(func() { _ = contexts.Close() })
 
-	schedulerManager := scheduler.NewManager(contexts, h.log.Logger, nil, nil, nil, docker.ScheduledComposeOptions{})
+	schedulerManager := scheduler.NewManager(contexts, h.log.Logger, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	h.controlPlaneRuns = newTestControlPlaneRuns(t, testControlPlaneRunsOptions{
 		dockerCli: dockerCli,
 		log:       h.log,

--- a/internal/notification/failure_repeat.go
+++ b/internal/notification/failure_repeat.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -21,30 +20,10 @@ import (
 // before it is sent again as a reminder.
 const DefaultFailureRepeatInterval = time.Hour
 
-var (
-	failureMu             sync.Mutex
-	lastFailures          = map[string]failureRecord{}
-	failureRepeatInterval = DefaultFailureRepeatInterval
-)
-
 // failureRecord is the last failure notification sent for one stack.
 type failureRecord struct {
 	fingerprint string
 	sentAt      time.Time
-}
-
-// SetFailureRepeatInterval sets how long an unchanged failure is suppressed.
-// Zero or less turns suppression off entirely: every failure is sent, as it was
-// before this existed.
-func SetFailureRepeatInterval(interval time.Duration) {
-	failureMu.Lock()
-	defer failureMu.Unlock()
-
-	failureRepeatInterval = interval
-
-	if interval <= 0 {
-		lastFailures = map[string]failureRecord{}
-	}
 }
 
 // failureKey identifies the thing that failed. The stack is what an operator
@@ -66,22 +45,22 @@ func failureFingerprint(title, message string) string {
 // shouldSendFailure reports whether this failure is worth sending: it is new,
 // it differs from the last one for the same stack, or the reminder interval has
 // passed. It records what it lets through.
-func shouldSendFailure(key, fingerprint string, now time.Time) bool {
-	failureMu.Lock()
-	defer failureMu.Unlock()
+func (n *Notifier) shouldSendFailure(key, fingerprint string, now time.Time) bool {
+	n.failureMu.Lock()
+	defer n.failureMu.Unlock()
 
-	if failureRepeatInterval <= 0 {
+	if n.failureRepeatInterval <= 0 {
 		return true
 	}
 
-	pruneFailures(now)
+	n.pruneFailures(now)
 
-	last, found := lastFailures[key]
-	if found && last.fingerprint == fingerprint && now.Sub(last.sentAt) < failureRepeatInterval {
+	last, found := n.lastFailures[key]
+	if found && last.fingerprint == fingerprint && now.Sub(last.sentAt) < n.failureRepeatInterval {
 		return false
 	}
 
-	lastFailures[key] = failureRecord{fingerprint: fingerprint, sentAt: now}
+	n.lastFailures[key] = failureRecord{fingerprint: fingerprint, sentAt: now}
 
 	return true
 }
@@ -89,20 +68,20 @@ func shouldSendFailure(key, fingerprint string, now time.Time) bool {
 // pruneFailures drops records that cannot suppress anything anymore. Past the
 // repeat interval the next failure is sent whatever the record says, so keeping
 // it only grows the map for stacks that are renamed, removed or fixed without a
-// success notification. Caller holds failureMu.
-func pruneFailures(now time.Time) {
-	for key, record := range lastFailures {
-		if now.Sub(record.sentAt) >= failureRepeatInterval {
-			delete(lastFailures, key)
+// success notification. Caller holds n.failureMu.
+func (n *Notifier) pruneFailures(now time.Time) {
+	for key, record := range n.lastFailures {
+		if now.Sub(record.sentAt) >= n.failureRepeatInterval {
+			delete(n.lastFailures, key)
 		}
 	}
 }
 
 // clearFailure forgets the last failure of a stack, so the next one is sent
 // immediately instead of being taken for a repeat.
-func clearFailure(key string) {
-	failureMu.Lock()
-	defer failureMu.Unlock()
+func (n *Notifier) clearFailure(key string) {
+	n.failureMu.Lock()
+	defer n.failureMu.Unlock()
 
-	delete(lastFailures, key)
+	delete(n.lastFailures, key)
 }

--- a/internal/notification/failure_repeat_test.go
+++ b/internal/notification/failure_repeat_test.go
@@ -6,112 +6,114 @@ import (
 	"time"
 )
 
-// resetFailureState clears the suppression state so tests do not leak into each
-// other. They cannot run in parallel: the state is package level, like the
-// apprise config the other tests here mutate.
-func resetFailureState(t *testing.T, interval time.Duration) {
+func newFailureTestNotifier(t *testing.T, interval time.Duration) *Notifier {
 	t.Helper()
 
-	failureMu.Lock()
-	lastFailures = map[string]failureRecord{}
-	failureRepeatInterval = interval
-	failureMu.Unlock()
+	notifier, err := New(Config{FailureRepeatInterval: interval})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	t.Cleanup(func() {
-		failureMu.Lock()
-		lastFailures = map[string]failureRecord{}
-		failureRepeatInterval = DefaultFailureRepeatInterval
-		failureMu.Unlock()
-	})
+	return notifier
 }
 
 func TestShouldSendFailure_SuppressesUnchangedRepeat(t *testing.T) {
-	resetFailureState(t, time.Hour)
+	t.Parallel()
+
+	notifier := newFailureTestNotifier(t, time.Hour)
 
 	now := time.Now()
 	key := failureKey(Metadata{Repository: "acme/deploy", Target: "prod", Stack: "app"})
 	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
 
-	if !shouldSendFailure(key, fingerprint, now) {
+	if !notifier.shouldSendFailure(key, fingerprint, now) {
 		t.Fatal("first failure must be sent")
 	}
 
-	if shouldSendFailure(key, fingerprint, now.Add(30*time.Second)) {
+	if notifier.shouldSendFailure(key, fingerprint, now.Add(30*time.Second)) {
 		t.Error("same failure 30s later must be suppressed")
 	}
 
-	if shouldSendFailure(key, fingerprint, now.Add(59*time.Minute)) {
+	if notifier.shouldSendFailure(key, fingerprint, now.Add(59*time.Minute)) {
 		t.Error("same failure inside the repeat interval must be suppressed")
 	}
 }
 
 func TestShouldSendFailure_RemindsAfterInterval(t *testing.T) {
-	resetFailureState(t, time.Hour)
+	t.Parallel()
+
+	notifier := newFailureTestNotifier(t, time.Hour)
 
 	now := time.Now()
 	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
 	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
 
-	shouldSendFailure(key, fingerprint, now)
+	notifier.shouldSendFailure(key, fingerprint, now)
 
-	if !shouldSendFailure(key, fingerprint, now.Add(time.Hour)) {
+	if !notifier.shouldSendFailure(key, fingerprint, now.Add(time.Hour)) {
 		t.Fatal("failure must be sent again once the repeat interval passed")
 	}
 
-	if shouldSendFailure(key, fingerprint, now.Add(time.Hour+time.Second)) {
+	if notifier.shouldSendFailure(key, fingerprint, now.Add(time.Hour+time.Second)) {
 		t.Error("reminder must restart the interval")
 	}
 }
 
 func TestShouldSendFailure_DifferentFaultOrStackIsSent(t *testing.T) {
-	resetFailureState(t, time.Hour)
+	t.Parallel()
+
+	notifier := newFailureTestNotifier(t, time.Hour)
 
 	now := time.Now()
 	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
 
-	shouldSendFailure(key, failureFingerprint("Deployment Failed", "pull access denied"), now)
+	notifier.shouldSendFailure(key, failureFingerprint("Deployment Failed", "pull access denied"), now)
 
-	if !shouldSendFailure(key, failureFingerprint("Deployment Failed", "hook exited with status 1"), now) {
+	if !notifier.shouldSendFailure(key, failureFingerprint("Deployment Failed", "hook exited with status 1"), now) {
 		t.Error("a different error on the same stack must be sent")
 	}
 
 	otherStack := failureKey(Metadata{Repository: "acme/deploy", Stack: "db"})
-	if !shouldSendFailure(otherStack, failureFingerprint("Deployment Failed", "pull access denied"), now) {
+	if !notifier.shouldSendFailure(otherStack, failureFingerprint("Deployment Failed", "pull access denied"), now) {
 		t.Error("the same error on another stack must be sent")
 	}
 }
 
 func TestClearFailure_LetsNextFailureThrough(t *testing.T) {
-	resetFailureState(t, time.Hour)
+	t.Parallel()
+
+	notifier := newFailureTestNotifier(t, time.Hour)
 
 	now := time.Now()
 	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
 	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
 
-	shouldSendFailure(key, fingerprint, now)
-	clearFailure(key)
+	notifier.shouldSendFailure(key, fingerprint, now)
+	notifier.clearFailure(key)
 
-	if !shouldSendFailure(key, fingerprint, now.Add(time.Second)) {
+	if !notifier.shouldSendFailure(key, fingerprint, now.Add(time.Second)) {
 		t.Error("after a success the next failure must be sent again")
 	}
 }
 
 func TestShouldSendFailure_PrunesStaleRecords(t *testing.T) {
-	resetFailureState(t, time.Hour)
+	t.Parallel()
+
+	notifier := newFailureTestNotifier(t, time.Hour)
 
 	now := time.Now()
 	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
 
 	gone := failureKey(Metadata{Repository: "acme/deploy", Stack: "removed"})
-	shouldSendFailure(gone, fingerprint, now)
+	notifier.shouldSendFailure(gone, fingerprint, now)
 
 	alive := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
-	shouldSendFailure(alive, fingerprint, now.Add(2*time.Hour))
+	notifier.shouldSendFailure(alive, fingerprint, now.Add(2*time.Hour))
 
-	failureMu.Lock()
-	_, found := lastFailures[gone]
-	size := len(lastFailures)
-	failureMu.Unlock()
+	notifier.failureMu.Lock()
+	_, found := notifier.lastFailures[gone]
+	size := len(notifier.lastFailures)
+	notifier.failureMu.Unlock()
 
 	if found {
 		t.Error("a record older than the repeat interval must be dropped")
@@ -122,32 +124,17 @@ func TestShouldSendFailure_PrunesStaleRecords(t *testing.T) {
 	}
 }
 
-func TestSetFailureRepeatInterval_ZeroDropsRecords(t *testing.T) {
-	resetFailureState(t, time.Hour)
-
-	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
-	shouldSendFailure(key, failureFingerprint("Deployment Failed", "pull access denied"), time.Now())
-
-	SetFailureRepeatInterval(0)
-
-	failureMu.Lock()
-	size := len(lastFailures)
-	failureMu.Unlock()
-
-	if size != 0 {
-		t.Errorf("turning suppression off must drop the records, got %d", size)
-	}
-}
-
 func TestShouldSendFailure_DisabledByZeroInterval(t *testing.T) {
-	resetFailureState(t, 0)
+	t.Parallel()
+
+	notifier := newFailureTestNotifier(t, 0)
 
 	now := time.Now()
 	key := failureKey(Metadata{Repository: "acme/deploy", Stack: "app"})
 	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
 
 	for i := range 3 {
-		if !shouldSendFailure(key, fingerprint, now.Add(time.Duration(i)*time.Second)) {
+		if !notifier.shouldSendFailure(key, fingerprint, now.Add(time.Duration(i)*time.Second)) {
 			t.Fatalf("suppression is off, send %d must go through", i+1)
 		}
 	}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -17,36 +17,28 @@ import (
 	"github.com/kimdre/doco-cd/internal/git"
 )
 
-type level int
+type Level int
 
 const (
-	Info    level = iota // Informational messages
+	Info    Level = iota // Informational messages
 	Success              // Successful operations
 	Warning              // Warning messages indicating potential issues
 	Failure              // Error messages indicating failure of operations
 )
 
-var logLevels = map[level]string{
+var logLevels = map[Level]string{
 	Info:    "info",
 	Success: "success",
 	Warning: "warning",
 	Failure: "failure",
 }
 
-var levelEmojis = map[level]string{
+var levelEmojis = map[Level]string{
 	Info:    "ℹ️",
 	Success: "✅",
 	Warning: "⚠️",
 	Failure: "❌",
 }
-
-var (
-	appriseConfigMu    sync.RWMutex
-	appriseApiURL      = ""
-	appriseNotifyUrls  = ""
-	appriseNotifyLevel = Info
-	appriseTemplate    *template.Template // template rendering the notification body; defaults to defaultTemplate
-)
 
 const (
 	maxAppriseErrorResponseBodyBytes = 4 * 1024
@@ -94,6 +86,53 @@ type Metadata struct {
 	DeploymentTargetObserver func(stack, context string)
 }
 
+// Config defines the immutable Apprise settings and failure-repeat behavior of a Notifier.
+type Config struct {
+	APIURL                string
+	NotifyURLs            string
+	NotifyLevel           string
+	BodyTemplate          string
+	FailureRepeatInterval time.Duration
+}
+
+// Sender is the notification capability consumed by application services.
+type Sender interface {
+	Send(level Level, title, message string, metadata Metadata, opts ...SendOption) error
+}
+
+// Notifier owns notification configuration and repeat-failure state.
+type Notifier struct {
+	apiURL       string
+	notifyURLs   string
+	notifyLevel  Level
+	bodyTemplate *template.Template
+
+	failureMu             sync.Mutex
+	lastFailures          map[string]failureRecord
+	failureRepeatInterval time.Duration
+}
+
+// New constructs an instance-owned notifier and validates its body template.
+func New(config Config) (*Notifier, error) {
+	bodyTemplate, err := validateTemplate(config.BodyTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	if bodyTemplate == nil {
+		bodyTemplate = defaultTemplate
+	}
+
+	return &Notifier{
+		apiURL:                config.APIURL,
+		notifyURLs:            config.NotifyURLs,
+		notifyLevel:           parseLevel(config.NotifyLevel),
+		bodyTemplate:          bodyTemplate,
+		lastFailures:          make(map[string]failureRecord),
+		failureRepeatInterval: config.FailureRepeatInterval,
+	}, nil
+}
+
 // TemplateData is the data exposed to a user-configured notification body template.
 // Metadata is embedded, so its fields (Repository, Stack, Revision, JobID, ...) are
 // referenced directly, e.g. {{.Stack}} or {{.Repository}}.
@@ -139,7 +178,7 @@ func validateTemplate(tmpl string) (*template.Template, error) {
 }
 
 // parseLevel converts a string representation of a log level to the level type.
-func parseLevel(level string) level {
+func parseLevel(level string) Level {
 	switch level {
 	case logLevels[Info]:
 		return Info
@@ -367,38 +406,6 @@ func redactSensitiveText(s string) string {
 	return strings.Join(strings.Fields(redacted), " ")
 }
 
-// SetAppriseConfig sets the configuration for the Apprise notification service.
-// bodyTemplate is an optional Go text/template rendering the notification body;
-// an empty string keeps the built-in format (defaultTemplate). An invalid
-// template is rejected.
-func SetAppriseConfig(apiURL, notifyUrls, notifyLevel, bodyTemplate string) error {
-	t, err := validateTemplate(bodyTemplate)
-	if err != nil {
-		return err
-	}
-
-	if t == nil {
-		t = defaultTemplate
-	}
-
-	appriseConfigMu.Lock()
-	defer appriseConfigMu.Unlock()
-
-	appriseApiURL = apiURL
-	appriseNotifyUrls = notifyUrls
-	appriseNotifyLevel = parseLevel(notifyLevel)
-	appriseTemplate = t
-
-	return nil
-}
-
-func getAppriseConfig() (string, string, level, *template.Template) {
-	appriseConfigMu.RLock()
-	defer appriseConfigMu.RUnlock()
-
-	return appriseApiURL, appriseNotifyUrls, appriseNotifyLevel, appriseTemplate
-}
-
 // SendOption customizes how a notification is rendered/sent.
 type SendOption func(*sendOptions)
 
@@ -416,11 +423,9 @@ func WithoutBodyTemplate() SendOption {
 	}
 }
 
-// Send sends a notification using the Apprise service based on the provided configuration and parameters.
-func Send(level level, title, message string, metadata Metadata, opts ...SendOption) error {
-	apiURL, notifyURLs, notifyLevel, bodyTemplate := getAppriseConfig()
-
-	if apiURL == "" || notifyURLs == "" {
+// Send sends a notification using this notifier's Apprise configuration.
+func (n *Notifier) Send(level Level, title, message string, metadata Metadata, opts ...SendOption) error {
+	if n.apiURL == "" || n.notifyURLs == "" {
 		return nil
 	}
 
@@ -428,15 +433,15 @@ func Send(level level, title, message string, metadata Metadata, opts ...SendOpt
 	// next failure of that stack is sent even if it repeats an older one. Done
 	// before the level check, so a configured level cannot leave stale state.
 	if level == Success {
-		clearFailure(failureKey(metadata))
+		n.clearFailure(failureKey(metadata))
 	}
 
-	if level < notifyLevel {
+	if level < n.notifyLevel {
 		return nil // Do not send notification if the level is lower than the configured level
 	}
 
 	// Suppress a failure that is already reported and unchanged, see failure_repeat.go.
-	if level == Failure && !shouldSendFailure(failureKey(metadata), failureFingerprint(title, message), time.Now()) {
+	if level == Failure && !n.shouldSendFailure(failureKey(metadata), failureFingerprint(title, message), time.Now()) {
 		return nil
 	}
 
@@ -445,6 +450,7 @@ func Send(level level, title, message string, metadata Metadata, opts ...SendOpt
 		opt(&o)
 	}
 
+	bodyTemplate := n.bodyTemplate
 	if o.skipBodyTemplate {
 		bodyTemplate = nil // renderTemplate falls back to the built-in default body
 	}
@@ -453,7 +459,7 @@ func Send(level level, title, message string, metadata Metadata, opts ...SendOpt
 
 	title = formatTitle(level, title, metadata)
 
-	err := send(apiURL, notifyURLs, title, message, logLevels[level])
+	err := send(n.apiURL, n.notifyURLs, title, message, logLevels[level])
 	if err != nil {
 		return fmt.Errorf("failed to send notification: %w", err)
 	}
@@ -461,7 +467,7 @@ func Send(level level, title, message string, metadata Metadata, opts ...SendOpt
 	return nil
 }
 
-func formatTitle(level level, title string, metadata Metadata) string {
+func formatTitle(level Level, title string, metadata Metadata) string {
 	formattedTitle := strings.TrimSpace(title)
 
 	if strings.TrimSpace(metadata.ReconciliationEvent) != "" {
@@ -592,7 +598,7 @@ func (d TemplateData) DefaultBody() string {
 // (defaultTemplate when t is nil). On execution failure it falls back to the
 // built-in body so an alert is never dropped because of a template mistake
 // (config-time validation catches most).
-func renderTemplate(t *template.Template, level level, title, message string, m Metadata) string {
+func renderTemplate(t *template.Template, level Level, title, message string, m Metadata) string {
 	if t == nil {
 		t = defaultTemplate
 	}

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -57,16 +57,23 @@ func TestSend(t *testing.T) {
 
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer server.Close()
+	t.Cleanup(server.Close)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Cannot run tests in parallel because SetAppriseConfig modifies global variables
-			if err := SetAppriseConfig(server.URL, tc.appriseURL, "info", ""); err != nil {
-				t.Fatalf("failed to set apprise config: %v", err)
+			t.Parallel()
+
+			notifier, err := New(Config{
+				APIURL:                server.URL,
+				NotifyURLs:            tc.appriseURL,
+				NotifyLevel:           "info",
+				FailureRepeatInterval: DefaultFailureRepeatInterval,
+			})
+			if err != nil {
+				t.Fatalf("failed to create notifier: %v", err)
 			}
 
-			err := Send(Info, "Test Notification", "This is a test message", metadata)
+			err = notifier.Send(Info, "Test Notification", "This is a test message", metadata)
 			if tc.expectedErr == nil {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)
@@ -79,6 +86,44 @@ func TestSend(t *testing.T) {
 				t.Fatalf("expected error wrapping %q, got: %v", tc.expectedErr, err)
 			}
 		})
+	}
+}
+
+func TestNewValidatesBodyTemplate(t *testing.T) {
+	t.Parallel()
+
+	if _, err := New(Config{BodyTemplate: "{{.Missing}}"}); !errors.Is(err, ErrInvalidTemplate) {
+		t.Fatalf("New() error = %v, want ErrInvalidTemplate", err)
+	}
+}
+
+func TestNotifierFailureStateIsIsolated(t *testing.T) {
+	t.Parallel()
+
+	first, err := New(Config{FailureRepeatInterval: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := New(Config{FailureRepeatInterval: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	key := failureKey(Metadata{Repository: "acme/repo", Stack: "app"})
+	fingerprint := failureFingerprint("Deployment Failed", "pull access denied")
+
+	if !first.shouldSendFailure(key, fingerprint, now) {
+		t.Fatal("first notifier should send its initial failure")
+	}
+
+	if first.shouldSendFailure(key, fingerprint, now.Add(time.Second)) {
+		t.Fatal("first notifier should suppress its unchanged failure")
+	}
+
+	if !second.shouldSendFailure(key, fingerprint, now.Add(time.Second)) {
+		t.Fatal("second notifier should have independent failure state")
 	}
 }
 

--- a/internal/reconciliation/clean.go
+++ b/internal/reconciliation/clean.go
@@ -26,6 +26,7 @@ import (
 func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.Logger,
 	dockerCli command.Cli, swarmMode bool, contextName string,
 	cloneUrl string, deployConfigs []*deployConfig.Config, metadata notification.Metadata,
+	notifier notification.Sender,
 ) error {
 	autoDiscoveredNames := make(map[string]bool)
 	runConfigTargets := make(map[string]struct{})
@@ -132,7 +133,7 @@ func cleanupObsoleteAutoDiscoveredContainers(ctx context.Context, jobLog *slog.L
 				return fmt.Errorf("failed to remove obsolete auto-discovered stack '%s': %w", stackName, err)
 			}
 
-			err = notification.Send(notification.Success, "Stack destroyed", "successfully destroyed stack "+removeConfig.Name, notifyMetadata)
+			err = notifier.Send(notification.Success, "Stack destroyed", "successfully destroyed stack "+removeConfig.Name, notifyMetadata)
 			if err != nil {
 				stackLog.Error("failed to send notification", logger.ErrAttr(err))
 			}

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/docker"
 
 	"github.com/kimdre/doco-cd/internal/logger"
-	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/stages"
 	"github.com/kimdre/doco-cd/internal/test"
 )
@@ -82,7 +81,7 @@ func (m *Manager) deploy(ctx context.Context, req DeployRequest) error {
 			if err := cleanupObsoleteAutoDiscoveredContainers(ctx, req.Logger,
 				entry.cli, swarmMode, contextName, req.Repository.SourceUrl,
 				modeConfigs,
-				req.Metadata); err != nil {
+				req.Metadata, m.notifier); err != nil {
 				req.Logger.Error("failed to clean up obsolete auto-discovered containers for context",
 					slog.String("context", docker.DisplayContextName(contextName)),
 					slog.Bool("swarm_mode", swarmMode),
@@ -243,9 +242,9 @@ func (m *Manager) handleOneDeploy(ctx context.Context, req DeployRequest, deploy
 
 	stageMgr, err := stages.NewStageManager(
 		stages.Dependencies{
-			AppConfig:         m.appConfig,
-			SecretProvider:    m.secretProvider,
-			NotifyFailureFunc: failNotifyFunc,
+			AppConfig:      m.appConfig,
+			SecretProvider: m.secretProvider,
+			Notifier:       m.notifier,
 		},
 		stages.RunInput{
 			Log:        deployLog,
@@ -295,18 +294,4 @@ func groupDeployConfigsByMode(dcs []*deployConfig.Config, swarmAvailable bool) m
 	}
 
 	return grouped
-}
-
-func failNotifyFunc(deployLog *slog.Logger, err error, metadata notification.Metadata) {
-	// Don't write to HTTP from goroutines. Just send notification and log
-	go func() {
-		notifyErr := notification.Send(notification.Failure, "Deployment Failed", err.Error(), metadata)
-		if notifyErr != nil {
-			deployLog.Error("failed to send notification", logger.ErrAttr(notifyErr))
-		}
-	}()
-
-	deployLog.Error("deployment failed",
-		slog.String("stack", metadata.Stack),
-		logger.ErrAttr(err))
 }

--- a/internal/reconciliation/manager.go
+++ b/internal/reconciliation/manager.go
@@ -45,6 +45,7 @@ type Dependencies struct {
 	Contexts       *docker.ContextRegistry `validate:"required"`
 	// A nil SecretProvider means no external secret provider is configured.
 	SecretProvider secretprovider.SecretProvider
+	Notifier       notification.Sender `validate:"required,nostructlevel"`
 	RuntimeQueries RuntimeQueries
 }
 
@@ -88,6 +89,7 @@ type Manager struct {
 	dockerCli      command.Cli
 	contexts       *docker.ContextRegistry
 	secretProvider secretprovider.SecretProvider
+	notifier       notification.Sender
 	runtimeQueries RuntimeQueries
 }
 
@@ -115,6 +117,7 @@ func NewManager(dependencies Dependencies) (*Manager, error) {
 		dockerCli:      dependencies.DockerCLI,
 		contexts:       dependencies.Contexts,
 		secretProvider: dependencies.SecretProvider,
+		notifier:       dependencies.Notifier,
 		runtimeQueries: dependencies.RuntimeQueries,
 	}, nil
 }

--- a/internal/reconciliation/reconciliation.go
+++ b/internal/reconciliation/reconciliation.go
@@ -548,7 +548,7 @@ func (j *job) deploy(ctx context.Context, jobLog *slog.Logger, dcs []*deployConf
 	if err := cleanupObsoleteAutoDiscoveredContainers(ctx, jobLog,
 		contextCLI, swarmMode, contextName, j.info.Repository.SourceUrl,
 		contextDCs,
-		j.info.Metadata); err != nil {
+		j.info.Metadata, j.manager.notifier); err != nil {
 		jobLog.Error("failed to clean up obsolete auto-discovered containers", logger.ErrAttr(err))
 	}
 

--- a/internal/reconciliation/reconciliation_integration_test.go
+++ b/internal/reconciliation/reconciliation_integration_test.go
@@ -245,6 +245,7 @@ func TestCleanupObsoleteAutoDiscoveredContainers_EmptyDiscoveredConfigs_RemovesS
 		repoURL,
 		[]*deployConfig.Config{},
 		notification.Metadata{Repository: "kimdre/doco-cd_tests", Stack: stackName, JobID: "cleanup-empty-discovered-configs"},
+		newTestNotifier(t),
 	)
 	if err != nil {
 		t.Fatalf("cleanupObsoleteAutoDiscoveredContainers returned error: %v", err)

--- a/internal/reconciliation/reconciliation_restart.go
+++ b/internal/reconciliation/reconciliation_restart.go
@@ -69,7 +69,7 @@ func (j *job) restartContainer(ctx context.Context, jobLog *slog.Logger, event e
 
 		restartLog.Error("failed to restart container", logger.ErrAttr(err))
 
-		if notifyErr := notification.Send(
+		if notifyErr := j.manager.notifier.Send(
 			notification.Failure,
 			actorKindTitle+" restart failed",
 			fmt.Sprintf("%s %s (%s) could not be restarted on %q event: %s", actorKindTitle, containerName, shortID(containerID), action, err.Error()),
@@ -83,7 +83,7 @@ func (j *job) restartContainer(ctx context.Context, jobLog *slog.Logger, event e
 
 	restartLog.Info(actorKind + " restarted successfully")
 
-	if notifyErr := notification.Send(
+	if notifyErr := j.manager.notifier.Send(
 		notification.Success,
 		actorKindTitle+" restarted",
 		fmt.Sprintf("%s %s (%s) was restarted successfully on %q event", actorKindTitle, containerName, shortID(containerID), action),
@@ -242,7 +242,7 @@ func (j *job) shouldSuppressUnhealthyRestart(jobLog *slog.Logger, event events.M
 	actorKind := restartNotificationActorKind(swarmMode)
 	metadata := restartNotificationMetadata(j.info.Metadata, dc, action, actorKind, containerID, event.Actor.Attributes["name"], reconciliationTraceIDFromEvent(event))
 
-	if notifyErr := notification.Send(
+	if notifyErr := j.manager.notifier.Send(
 		notification.Warning,
 		restartNotificationActorKindTitle(actorKind)+" restart suppressed",
 		msg,

--- a/internal/reconciliation/test_helpers_test.go
+++ b/internal/reconciliation/test_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/docker"
 	dockerSwarm "github.com/kimdre/doco-cd/internal/docker/swarm"
+	"github.com/kimdre/doco-cd/internal/notification"
 )
 
 // resolveTestSwarmMode checks if the Docker daemon is in Swarm mode.
@@ -23,6 +24,17 @@ func resolveTestSwarmMode(t *testing.T, apiClient client.APIClient) bool {
 	return enabled
 }
 
+func newTestNotifier(t *testing.T) notification.Sender {
+	t.Helper()
+
+	notifier, err := notification.New(notification.Config{})
+	if err != nil {
+		t.Fatalf("failed to create test notifier: %v", err)
+	}
+
+	return notifier
+}
+
 // newTestManagerWithDependencies creates a Manager for tests, filling in a zero-value AppConfig
 // and a fresh Docker CLI (closed via t.Cleanup) for any dependency left unset in deps, so tests
 // only need to override the fields they care about.
@@ -31,6 +43,10 @@ func newTestManagerWithDependencies(t *testing.T, deps Dependencies) *Manager {
 
 	if deps.AppConfig == nil {
 		deps.AppConfig = &app.Config{}
+	}
+
+	if deps.Notifier == nil {
+		deps.Notifier = newTestNotifier(t)
 	}
 
 	if deps.DataMountPoint.Source == "" || deps.DataMountPoint.Destination == "" {

--- a/internal/scheduler/scheduler_api.go
+++ b/internal/scheduler/scheduler_api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/common/id"
 	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/logger"
+	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/prometheus"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 )
@@ -184,11 +185,11 @@ func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (
 	return runID, nil
 }
 
-func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, secretProvider secretprovider.SecretProvider, runtime *runtimeStore, stackName string, composeOptions docker.ScheduledComposeOptions) ([]JobInfo, error) {
+func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, secretProvider secretprovider.SecretProvider, notifier notification.Sender, runtime *runtimeStore, stackName string, composeOptions docker.ScheduledComposeOptions) ([]JobInfo, error) {
 	var result []JobInfo
 
 	for _, mode := range modes {
-		jobs, err := newSchedulerForMode(cc, mode, log, nil, secretProvider, nil, runtime, composeOptions).listJobs(ctx, stackName)
+		jobs, err := newSchedulerForMode(cc, mode, log, nil, secretProvider, notifier, nil, runtime, composeOptions).listJobs(ctx, stackName)
 		if err != nil {
 			return nil, err
 		}
@@ -199,13 +200,13 @@ func listJobsForModes(ctx context.Context, modes []scheduledJobMode, cc docker.C
 	return result, nil
 }
 
-func triggerNowForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, jobName, stackName string, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker, runtime *runtimeStore, composeOptions docker.ScheduledComposeOptions) (string, error) {
+func triggerNowForModes(ctx context.Context, modes []scheduledJobMode, cc docker.ContextClient, log *slog.Logger, jobName, stackName string, secretProvider secretprovider.SecretProvider, notifier notification.Sender, stopHoldTracker ServiceStopHoldTracker, runtime *runtimeStore, composeOptions docker.ScheduledComposeOptions) (string, error) {
 	workers := make(map[scheduledJobMode]*scheduler, len(modes))
 
 	var jobs []scheduledJob
 
 	for _, mode := range modes {
-		worker := newSchedulerForMode(cc, mode, log, nil, secretProvider, stopHoldTracker, runtime, composeOptions)
+		worker := newSchedulerForMode(cc, mode, log, nil, secretProvider, notifier, stopHoldTracker, runtime, composeOptions)
 
 		discovered, err := worker.discoverJobs(ctx)
 		if err != nil {

--- a/internal/scheduler/scheduler_execution.go
+++ b/internal/scheduler/scheduler_execution.go
@@ -486,6 +486,10 @@ func (s *scheduler) sendRunNotification(job scheduledJob, cfg docker.JobSchedule
 		return
 	}
 
+	if s.notifier == nil {
+		return
+	}
+
 	actorKind := "container"
 	if job.mode == scheduledJobModeSwarm {
 		actorKind = "service"
@@ -502,7 +506,7 @@ func (s *scheduler) sendRunNotification(job scheduledJob, cfg docker.JobSchedule
 		AffectedActorName: job.name,
 	}
 
-	if err := notification.Send(lvl, title, msg, metadata); err != nil {
+	if err := s.notifier.Send(lvl, title, msg, metadata); err != nil {
 		s.log.Error("failed to send scheduled job notification", logger.ErrAttr(err), slog.String("job", job.name))
 	}
 }

--- a/internal/scheduler/scheduler_execution_test.go
+++ b/internal/scheduler/scheduler_execution_test.go
@@ -6,7 +6,53 @@ import (
 	"time"
 
 	"github.com/kimdre/doco-cd/internal/docker"
+	"github.com/kimdre/doco-cd/internal/notification"
 )
+
+type recordingSender struct {
+	levels   []notification.Level
+	metadata []notification.Metadata
+}
+
+func (s *recordingSender) Send(level notification.Level, _, _ string, metadata notification.Metadata, _ ...notification.SendOption) error {
+	s.levels = append(s.levels, level)
+	s.metadata = append(s.metadata, metadata)
+
+	return nil
+}
+
+func TestSendRunNotificationUsesInjectedSender(t *testing.T) {
+	t.Parallel()
+
+	sender := &recordingSender{}
+	s := &scheduler{notifier: sender}
+	job := scheduledJob{
+		name:    "backup",
+		mode:    scheduledJobModeSwarm,
+		context: "remote",
+		labels: map[string]string{
+			docker.DocoCDLabels.Source.Name:             "acme/repo",
+			docker.DocoCDLabels.Deployment.Name:         "app",
+			docker.DocoCDLabels.Deployment.ConfigTarget: "prod",
+			docker.DocoCDLabels.Deployment.CommitSHA:    "abc123",
+		},
+	}
+
+	s.sendRunNotification(job, docker.JobScheduleConfig{NotifyOn: docker.JobNotifyAll}, "run-1", true, "completed", "done")
+
+	if len(sender.levels) != 1 || sender.levels[0] != notification.Success {
+		t.Fatalf("notification levels = %v, want [success]", sender.levels)
+	}
+
+	if len(sender.metadata) != 1 {
+		t.Fatalf("notification count = %d, want 1", len(sender.metadata))
+	}
+
+	got := sender.metadata[0]
+	if got.Repository != "acme/repo" || got.Stack != "app" || got.Context != "remote" || got.JobID != "run-1" {
+		t.Fatalf("notification metadata = %#v", got)
+	}
+}
 
 func TestResolveStopServiceStacks(t *testing.T) {
 	t.Parallel()

--- a/internal/scheduler/scheduler_manager.go
+++ b/internal/scheduler/scheduler_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/graceful"
 	"github.com/kimdre/doco-cd/internal/logger"
+	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 )
 
@@ -30,6 +31,7 @@ type Manager struct {
 	log             *slog.Logger
 	wg              *sync.WaitGroup
 	secretProvider  secretprovider.SecretProvider
+	notifier        notification.Sender
 	stopHoldTracker ServiceStopHoldTracker
 	runtime         *runtimeStore
 	// composeOptions bundles the Docker-owned settings needed to reload scheduled Compose
@@ -53,7 +55,7 @@ type managedWorker struct {
 // NewManager creates a scheduler Manager bound to registry. log and wg are
 // required for Start (running background workers) but may be omitted if the
 // Manager is only used for on-demand ListJobs/TriggerNow calls.
-func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker, composeOptions docker.ScheduledComposeOptions) *Manager {
+func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, notifier notification.Sender, stopHoldTracker ServiceStopHoldTracker, composeOptions docker.ScheduledComposeOptions) *Manager {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -63,6 +65,7 @@ func NewManager(registry *docker.ContextRegistry, log *slog.Logger, wg *sync.Wai
 		log:             log.With(slog.String("component", "scheduler_manager")),
 		wg:              wg,
 		secretProvider:  secretProvider,
+		notifier:        notifier,
 		stopHoldTracker: stopHoldTracker,
 		runtime:         newRuntimeStore(),
 		composeOptions:  composeOptions,
@@ -138,7 +141,7 @@ func (m *Manager) refreshWorkers(ctx context.Context) {
 				continue
 			}
 
-			worker := newSchedulerForMode(result.ContextClient, mode, m.log, m.wg, m.secretProvider, m.stopHoldTracker, m.runtime, m.composeOptions)
+			worker := newSchedulerForMode(result.ContextClient, mode, m.log, m.wg, m.secretProvider, m.notifier, m.stopHoldTracker, m.runtime, m.composeOptions)
 			workerCtx, cancel := context.WithCancel(ctx)
 			m.nextID++
 			workerID := m.nextID
@@ -184,7 +187,7 @@ func (m *Manager) ListJobs(ctx context.Context, contextName, stackName string) (
 		return nil, fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
 	}
 
-	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, m.secretProvider, m.runtime, stackName, m.composeOptions)
+	return listJobsForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, m.secretProvider, m.notifier, m.runtime, stackName, m.composeOptions)
 }
 
 // TriggerNow executes one configured scheduled job immediately on the given
@@ -200,7 +203,7 @@ func (m *Manager) TriggerNow(ctx context.Context, contextName, jobName, stackNam
 		return "", fmt.Errorf("failed to resolve docker context %q: %w", docker.DisplayContextName(contextName), err)
 	}
 
-	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, jobName, stackName, secretProvider, m.stopHoldTracker, m.runtime, m.composeOptions)
+	return triggerNowForModes(ctx, schedulerModes(cc.SwarmMode), cc, m.log, jobName, stackName, secretProvider, m.notifier, m.stopHoldTracker, m.runtime, m.composeOptions)
 }
 
 // stopWorkers requests cancellation for every managed worker. Each worker

--- a/internal/scheduler/scheduler_runtime_test.go
+++ b/internal/scheduler/scheduler_runtime_test.go
@@ -241,8 +241,8 @@ func TestUpdateRuntimeRunStatus(t *testing.T) {
 func TestManagerRuntimeStateIsIsolated(t *testing.T) {
 	t.Parallel()
 
-	first := NewManager(nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
-	second := NewManager(nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
+	first := NewManager(nil, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
+	second := NewManager(nil, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	key := "container:project/service"
 
 	first.runtime.setLastRun(key, time.Now())
@@ -276,7 +276,7 @@ func TestRuntimeStoreClearContextModePreservesOtherPartitions(t *testing.T) {
 func TestManagerStopWorkersClearsRuntimeState(t *testing.T) {
 	t.Parallel()
 
-	manager := NewManager(nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
+	manager := NewManager(nil, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	key := schedulerWorkerKey("remote", scheduledJobModeContainer)
 	jobKey := "remote::container:shared/job"
 	cancelled := false
@@ -311,7 +311,7 @@ func TestManagerStopWorkersClearsRuntimeState(t *testing.T) {
 func TestManagerOldWorkerCannotClearReplacementState(t *testing.T) {
 	t.Parallel()
 
-	manager := NewManager(nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
+	manager := NewManager(nil, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	key := schedulerWorkerKey("remote", scheduledJobModeContainer)
 	jobKey := "remote::container:shared/job"
 	manager.workers[key] = managedWorker{

--- a/internal/scheduler/scheduler_types.go
+++ b/internal/scheduler/scheduler_types.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-co-op/gocron/v2"
 
 	"github.com/kimdre/doco-cd/internal/docker"
+	"github.com/kimdre/doco-cd/internal/notification"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 )
 
@@ -59,6 +60,7 @@ type scheduler struct {
 	// using the capability supplied by ContextRegistry.
 	mode            scheduledJobMode
 	secretProvider  secretprovider.SecretProvider
+	notifier        notification.Sender
 	stopHoldTracker ServiceStopHoldTracker
 	log             *slog.Logger
 	wg              *sync.WaitGroup
@@ -135,7 +137,7 @@ type JobInfo struct {
 // newSchedulerForMode builds a scheduler worker bound to a single Docker
 // context and runtime mode. log and wg may be nil for short-lived, one-shot
 // workers (e.g. a single ListJobs/TriggerNow call) that never call run().
-func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, stopHoldTracker ServiceStopHoldTracker, runtime *runtimeStore, composeOptions docker.ScheduledComposeOptions) *scheduler {
+func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *slog.Logger, wg *sync.WaitGroup, secretProvider secretprovider.SecretProvider, notifier notification.Sender, stopHoldTracker ServiceStopHoldTracker, runtime *runtimeStore, composeOptions docker.ScheduledComposeOptions) *scheduler {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -151,6 +153,7 @@ func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *sl
 		contextName:     contextName,
 		mode:            mode,
 		secretProvider:  secretProvider,
+		notifier:        notifier,
 		stopHoldTracker: stopHoldTracker,
 		log:             log.With(slog.String("component", "scheduler"), slog.String("context", docker.DisplayContextName(contextName))),
 		wg:              wg,

--- a/internal/scheduler/scheduler_types_test.go
+++ b/internal/scheduler/scheduler_types_test.go
@@ -21,7 +21,7 @@ func TestJobKeyPrefix(t *testing.T) {
 func TestNewSchedulerForMode_NormalizesContextAndCarriesMode(t *testing.T) {
 	t.Parallel()
 
-	s := newSchedulerForMode(docker.ContextClient{Name: "Default", SwarmMode: true}, scheduledJobModeSwarm, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
+	s := newSchedulerForMode(docker.ContextClient{Name: "Default", SwarmMode: true}, scheduledJobModeSwarm, nil, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	if s.contextName != "" {
 		t.Fatalf("newSchedulerForMode() contextName = %q, want empty string for the default context", s.contextName)
 	}
@@ -30,7 +30,7 @@ func TestNewSchedulerForMode_NormalizesContextAndCarriesMode(t *testing.T) {
 		t.Fatalf("newSchedulerForMode() mode = %q, want %q", s.mode, scheduledJobModeSwarm)
 	}
 
-	remote := newSchedulerForMode(docker.ContextClient{Name: "remote", SwarmMode: false}, scheduledJobModeContainer, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
+	remote := newSchedulerForMode(docker.ContextClient{Name: "remote", SwarmMode: false}, scheduledJobModeContainer, nil, nil, nil, nil, nil, nil, docker.ScheduledComposeOptions{})
 	if remote.contextName != "remote" {
 		t.Fatalf("newSchedulerForMode() contextName = %q, want %q", remote.contextName, "remote")
 	}

--- a/internal/stages/manager_test.go
+++ b/internal/stages/manager_test.go
@@ -6,18 +6,35 @@ import (
 	"log/slog"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/notification"
 )
 
+type recordingNotificationSender struct {
+	metadata chan notification.Metadata
+}
+
+func (s recordingNotificationSender) Send(_ notification.Level, _, _ string, metadata notification.Metadata, _ ...notification.SendOption) error {
+	s.metadata <- metadata
+
+	return nil
+}
+
 func newTestStageManager(t *testing.T) *StageManager {
 	t.Helper()
+
+	notifier, err := notification.New(notification.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	sm, err := NewStageManager(
 		Dependencies{
 			AppConfig: &app.Config{},
+			Notifier:  notifier,
 		},
 		RunInput{
 			Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -74,7 +91,12 @@ func TestNewStageManagerValidatesInputs(t *testing.T) {
 		t.Fatal("NewStageManager() error = nil, want dependency validation error")
 	}
 
-	if _, err := NewStageManager(Dependencies{AppConfig: &app.Config{}}, RunInput{}); err == nil {
+	notifier, err := notification.New(notification.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := NewStageManager(Dependencies{AppConfig: &app.Config{}, Notifier: notifier}, RunInput{}); err == nil {
 		t.Fatal("NewStageManager() error = nil, want run input validation error")
 	}
 }
@@ -115,15 +137,19 @@ func TestStageManagerNotifyFailureIncludesTarget(t *testing.T) {
 	sm.DeployConfig.Reference = "main"
 	sm.DeployConfig.Internal.ConfigTarget = "prod-vm"
 
-	var got notification.Metadata
-
-	sm.NotifyFailureFunc = func(_ *slog.Logger, _ error, metadata notification.Metadata) {
-		got = metadata
-	}
+	sent := make(chan notification.Metadata, 1)
+	sm.Notifier = recordingNotificationSender{metadata: sent}
 
 	boom := errors.New("boom")
 
 	returned := sm.NotifyFailure(boom)
+
+	var got notification.Metadata
+	select {
+	case got = <-sent:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for failure notification")
+	}
 
 	if got.Target != "prod-vm" {
 		t.Fatalf("expected target prod-vm, got %q", got.Target)

--- a/internal/stages/stage_4_post-deploy.go
+++ b/internal/stages/stage_4_post-deploy.go
@@ -65,7 +65,7 @@ func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logg
 		}
 	}
 
-	err = notification.Send(notification.Success, "Deployment completed", "Successfully deployed stack "+s.DeployConfig.Name, metadata)
+	err = s.Notifier.Send(notification.Success, "Deployment completed", "Successfully deployed stack "+s.DeployConfig.Name, metadata)
 	if err != nil {
 		stageLog.Error("failed to send notification", logger.ErrAttr(err))
 	}

--- a/internal/stages/stage_4_post-destroy.go
+++ b/internal/stages/stage_4_post-destroy.go
@@ -24,7 +24,7 @@ func (s *StageManager) RunPostDestroyStage(_ context.Context, stageLog *slog.Log
 	metadata.JobID = s.JobID
 	metadata.Duration = time.Since(s.Stages.Init.StartedAt).Truncate(time.Millisecond)
 
-	err := notification.Send(notification.Success, "Stack destroyed", "successfully destroyed stack "+s.DeployConfig.Name, metadata)
+	err := s.Notifier.Send(notification.Success, "Stack destroyed", "successfully destroyed stack "+s.DeployConfig.Name, metadata)
 	if err != nil {
 		stageLog.Error("failed to send notification", logger.ErrAttr(err))
 	}

--- a/internal/stages/types.go
+++ b/internal/stages/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker"
+	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
 
 	gitInternal "github.com/kimdre/doco-cd/internal/git"
@@ -172,30 +173,28 @@ func (d *DeploymentState) changedServiceNames() []string {
 
 // StageManager is the main structure that holds the logger and stage data.
 type StageManager struct {
-	Stages            *Stages
-	Log               *slog.Logger
-	JobID             string            // Unique identifier for the job
-	JobTrigger        JobTrigger        // Trigger type for the job (e.g., "webhook", "poll")
-	NotifyFailureFunc NotifyFailureFunc // Function to call on failure
-	AppConfig         *app.Config
-	DeployConfig      *deploy.Config
-	DeployState       *DeploymentState
-	Docker            *Docker
-	Payload           *webhook.ParsedPayload
-	Repository        *RepositoryData
-	SecretProvider    secretprovider.SecretProvider
-	Metadata          notification.Metadata // Notification metadata (may include reconciliation event info)
+	Stages         *Stages
+	Log            *slog.Logger
+	JobID          string     // Unique identifier for the job
+	JobTrigger     JobTrigger // Trigger type for the job (e.g., "webhook", "poll")
+	AppConfig      *app.Config
+	DeployConfig   *deploy.Config
+	DeployState    *DeploymentState
+	Docker         *Docker
+	Payload        *webhook.ParsedPayload
+	Repository     *RepositoryData
+	SecretProvider secretprovider.SecretProvider
+	Notifier       notification.Sender
+	Metadata       notification.Metadata // Notification metadata (may include reconciliation event info)
 }
-
-type NotifyFailureFunc func(log *slog.Logger, err error, metadata notification.Metadata)
 
 // Dependencies holds the stable services shared by every StageManager run in a process:
 // application configuration, the optional secret provider used to resolve external secret
-// references, and the callback invoked when a deployment fails.
+// references, and the notifier used for deployment lifecycle messages.
 type Dependencies struct {
-	AppConfig         *app.Config `validate:"required,nostructlevel"`
-	SecretProvider    secretprovider.SecretProvider
-	NotifyFailureFunc NotifyFailureFunc
+	AppConfig      *app.Config `validate:"required,nostructlevel"`
+	SecretProvider secretprovider.SecretProvider
+	Notifier       notification.Sender `validate:"required,nostructlevel"`
 }
 
 // RunInput holds the per-deployment input for a single StageManager run: the job identity and
@@ -224,18 +223,18 @@ func NewStageManager(dependencies Dependencies, run RunInput) (*StageManager, er
 	}
 
 	return &StageManager{
-		Log:               run.Log.With(),
-		JobID:             run.JobID,
-		JobTrigger:        run.JobTrigger,
-		NotifyFailureFunc: dependencies.NotifyFailureFunc,
-		AppConfig:         dependencies.AppConfig,
-		DeployConfig:      run.DeployConfig,
-		DeployState:       &DeploymentState{},
-		Docker:            run.Docker,
-		Payload:           run.Payload,
-		Repository:        run.Repository,
-		SecretProvider:    dependencies.SecretProvider,
-		Metadata:          run.Metadata,
+		Log:            run.Log.With(),
+		JobID:          run.JobID,
+		JobTrigger:     run.JobTrigger,
+		AppConfig:      dependencies.AppConfig,
+		DeployConfig:   run.DeployConfig,
+		DeployState:    &DeploymentState{},
+		Docker:         run.Docker,
+		Payload:        run.Payload,
+		Repository:     run.Repository,
+		SecretProvider: dependencies.SecretProvider,
+		Notifier:       dependencies.Notifier,
+		Metadata:       run.Metadata,
 		Stages: &Stages{
 			Init: &InitStageData{
 				MetaData: NewMetaData(StageInit),
@@ -284,10 +283,8 @@ func (s *StageManager) GetStageMetaData(stageName StageName) (*MetaData, error) 
 	}
 }
 
-// NotifyFailure sends a failure notification using the provided NotifyFailureFunc
-// and returns notifyErr marked as already reported, so the caller that receives
-// it does not notify about the same failure a second time. Without a
-// NotifyFailureFunc nothing is sent and the error is returned unchanged.
+// NotifyFailure sends a failure notification and returns notifyErr marked as already
+// reported, so the caller does not notify about the same failure a second time.
 func (s *StageManager) NotifyFailure(notifyErr error) error {
 	var (
 		latestCommit string
@@ -295,44 +292,48 @@ func (s *StageManager) NotifyFailure(notifyErr error) error {
 		commitSha    string
 	)
 
-	if s.NotifyFailureFunc != nil {
-		if s.Repository.Git != nil {
-			latestCommit, commitErr = gitInternal.GetLatestCommit(s.Repository.Git, s.DeployConfig.Reference)
-			if commitErr != nil {
-				latestCommit = ""
-			}
-
-			commitSha, commitErr = gitInternal.GetShortestUniqueCommitHash(s.Repository.Git, latestCommit, gitInternal.DefaultShortSHALength)
-			if commitErr != nil {
-				commitSha = latestCommit
-			}
+	if s.Repository.Git != nil {
+		latestCommit, commitErr = gitInternal.GetLatestCommit(s.Repository.Git, s.DeployConfig.Reference)
+		if commitErr != nil {
+			latestCommit = ""
 		}
 
-		if s.Repository.Git == nil {
-			commitSha = strings.TrimSpace(s.Repository.Revision)
+		commitSha, commitErr = gitInternal.GetShortestUniqueCommitHash(s.Repository.Git, latestCommit, gitInternal.DefaultShortSHALength)
+		if commitErr != nil {
+			commitSha = latestCommit
 		}
-
-		revision := notification.GetRevision(s.DeployConfig.Reference, commitSha)
-
-		metadata := s.Metadata
-		metadata.Repository = s.Repository.Name
-		metadata.Stack = s.DeployConfig.Name
-		metadata.Context = s.DeployConfig.Context
-		metadata.Target = s.DeployConfig.Internal.ConfigTarget
-		metadata.Revision = revision
-		metadata.JobID = s.JobID
-		metadata.ChangedServices = s.DeployState.changedServiceNames()
-
-		if !s.Stages.Init.StartedAt.IsZero() {
-			metadata.Duration = time.Since(s.Stages.Init.StartedAt).Truncate(time.Millisecond)
-		}
-
-		s.NotifyFailureFunc(s.Log, notifyErr, metadata)
-
-		return notification.MarkNotified(notifyErr)
 	}
 
-	return notifyErr
+	if s.Repository.Git == nil {
+		commitSha = strings.TrimSpace(s.Repository.Revision)
+	}
+
+	revision := notification.GetRevision(s.DeployConfig.Reference, commitSha)
+
+	metadata := s.Metadata
+	metadata.Repository = s.Repository.Name
+	metadata.Stack = s.DeployConfig.Name
+	metadata.Context = s.DeployConfig.Context
+	metadata.Target = s.DeployConfig.Internal.ConfigTarget
+	metadata.Revision = revision
+	metadata.JobID = s.JobID
+	metadata.ChangedServices = s.DeployState.changedServiceNames()
+
+	if !s.Stages.Init.StartedAt.IsZero() {
+		metadata.Duration = time.Since(s.Stages.Init.StartedAt).Truncate(time.Millisecond)
+	}
+
+	go func() {
+		if err := s.Notifier.Send(notification.Failure, "Deployment Failed", notifyErr.Error(), metadata); err != nil {
+			s.Log.Error("failed to send notification", logger.ErrAttr(err))
+		}
+	}()
+
+	s.Log.Error("deployment failed",
+		slog.String("stack", metadata.Stack),
+		logger.ErrAttr(notifyErr))
+
+	return notification.MarkNotified(notifyErr)
 }
 
 func (s *StageManager) NotifyDeploymentStarted() error {
@@ -367,7 +368,7 @@ func (s *StageManager) NotifyDeploymentStarted() error {
 	metadata.JobID = s.JobID
 	metadata.ChangedServices = s.DeployState.changedServiceNames()
 
-	return notification.Send(
+	return s.Notifier.Send(
 		notification.Info,
 		"Deployment started",
 		"Starting deployment of stack "+s.DeployConfig.Name,


### PR DESCRIPTION
## Summary

- construct an instance-owned notifier at application startup
- move Apprise configuration and failure-repeat suppression state out of package globals
- inject the narrow `notification.Sender` capability into handlers, reconciliation, stages, and scheduler workers
- remove notification side effects from `app.GetConfig()` and remove the stage failure callback seam

## Behavior preserved

- notification templates, levels, metadata, asynchronous failure delivery, repeat suppression, recovery clearing, and Apprise request format remain unchanged
- disabled notification configuration remains a no-op

## Validation

- `go test -race ./internal/notification/... ./internal/reconciliation/... ./internal/scheduler/...`
- `make test-nobitwarden` with local Swarm mode active
- `make build`
- `make fmt`

Closes part of #1764