### PR TITLE
feat(commitstatus): add new status for queued webhook events

### DIFF
--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -476,6 +476,15 @@ func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 		return controlplane.SkippedRun(msg), nil
 	}
 
+	if errors.Is(deployErr, stages.ErrSkipDeployment) {
+		msg := "deployment skipped"
+		elapsedTime := time.Since(startTime)
+		jobLog.Info(msg, slog.String("elapsed_time", elapsedTime.Truncate(time.Millisecond).String()))
+		restAPI.JSONResponse(w, msg, metadata.JobID, http.StatusAccepted)
+
+		return controlplane.SkippedRun(msg), nil
+	}
+
 	if deployErr != nil {
 		if controlplane.IsLifecycleCancellation(deployErr) {
 			return controlplane.FailedRun(deployErr.Error()), deployErr

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/common/id"
 
+	"github.com/kimdre/doco-cd/internal/commitstatus"
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/poll"
@@ -240,6 +241,71 @@ func repositoryNameFromWebhookPayload(payload webhook.ParsedPayload) string {
 	}
 
 	return "unknown"
+}
+
+type webhookCommitStatusReporter struct {
+	appConfig *app.Config
+	log       *slog.Logger
+	payload   webhook.ParsedPayload
+}
+
+func (r webhookCommitStatusReporter) Post(ctx context.Context, state commitstatus.State, description string) {
+	if r.appConfig == nil {
+		return
+	}
+
+	sourceURL, _ := resolveWebhookGitCloneURL(r.payload, r.appConfig)
+	if sourceURL == "" {
+		sourceURL = r.payload.WebURL
+	}
+
+	req, ok := commitstatus.ResolveRequest(r.log, commitstatus.RequestParams{
+		Enabled:          r.appConfig.GitCommitStatus,
+		SourceIsGit:      r.payload.Source == webhook.PayloadSourceGit,
+		SourceURL:        sourceURL,
+		CommitSHA:        r.payload.CommitSHAString(),
+		PayloadWebURL:    r.payload.WebURL,
+		PayloadFullName:  r.payload.FullName,
+		ProviderOverride: r.appConfig.GitScmProvider,
+		APIBaseURL:       string(r.appConfig.GitScmApiUrl),
+		AccessToken:      r.appConfig.GitAccessToken,
+		ContextName:      commitstatus.DeployContext,
+	})
+	if !ok {
+		return
+	}
+
+	r.log.Debug("posting aggregate webhook commit status",
+		slog.String("provider", string(req.Provider)),
+		slog.String("repository", req.RepoFullName),
+		slog.String("commit_sha", req.CommitSHA),
+		slog.String("context", req.Context),
+		slog.String("state", string(state)),
+		slog.String("description", description),
+	)
+
+	if err := req.Post(ctx, commitstatus.Status{State: state, Description: description}); err != nil {
+		r.log.Warn("failed to post aggregate webhook commit status", slog.String("error", err.Error()))
+	}
+}
+
+func aggregateWebhookCommitStatus(result controlplane.RunResult, err error) (commitstatus.State, string) {
+	if err != nil {
+		return commitstatus.StateError, commitstatus.FailureDescription(err)
+	}
+
+	switch result.Status {
+	case controlplane.RunStatusFailed:
+		if strings.TrimSpace(result.Message) == "" {
+			return commitstatus.StateFailure, "Failed"
+		}
+
+		return commitstatus.StateFailure, commitstatus.FailureDescription(errors.New(result.Message))
+	case controlplane.RunStatusSkipped:
+		return commitstatus.StateSuccess, "Skipped"
+	default:
+		return commitstatus.StateSuccess, "Successful"
+	}
 }
 
 type orchestrationHandler struct {
@@ -556,6 +622,12 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 		Revision:   metadata.Revision,
 	})
 
+	statusReporter := webhookCommitStatusReporter{
+		appConfig: h.appConfig,
+		log:       jobLog,
+		payload:   payload,
+	}
+
 	lockEntity := "repository"
 	lockLogValue := metadata.Repository
 
@@ -567,7 +639,17 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 	// Prevent concurrent deployments for the same repository using a lock
 	repoLock := lock.GetRepoLock(metadata.Repository)
 
-	handleFn := func(ctx context.Context, w http.ResponseWriter) (controlplane.RunResult, error) {
+	handleFn := func(ctx context.Context, w http.ResponseWriter) (result controlplane.RunResult, handleErr error) {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				statusReporter.Post(ctx, commitstatus.StateError, "Deployment panicked")
+				panic(recovered)
+			}
+
+			state, description := aggregateWebhookCommitStatus(result, handleErr)
+			statusReporter.Post(ctx, state, description)
+		}()
+
 		if !acquireWebhookRepoLock(ctx, repoLock, jobID, func() {
 			jobLog.Info("waiting for webhook "+lockEntity+" lock", slog.String(lockEntity, lockLogValue))
 		}) {
@@ -575,6 +657,8 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 		}
 
 		defer repoLock.Unlock()
+
+		statusReporter.Post(ctx, commitstatus.StatePending, "In Progress")
 
 		return handleEvent(ctx, jobLog, w, h.appConfig, payload, customTarget, metadata, h.testName, h.deployment, h.notifier)
 	}
@@ -584,11 +668,18 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 		mode = controlplane.RunSynchronousDetached
 	}
 
-	err = h.controlPlaneRuns.Execute(r.Context(), jobID, controlplane.RunExecution{
+	execution := controlplane.RunExecution{
 		Mode:         mode,
 		PanicContext: "webhook deployment",
 		PanicError:   errWebhookDeploymentPanicked,
-	}, func(ctx context.Context) (controlplane.RunResult, error) {
+	}
+	if !wait {
+		execution.OnQueued = func(ctx context.Context) {
+			statusReporter.Post(ctx, commitstatus.StatePending, "Queued")
+		}
+	}
+
+	err = h.controlPlaneRuns.Execute(r.Context(), jobID, execution, func(ctx context.Context) (controlplane.RunResult, error) {
 		if wait {
 			return handleFn(ctx, w)
 		}

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/common/id"
 
-	"github.com/kimdre/doco-cd/internal/commitstatus"
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/poll"
@@ -241,71 +240,6 @@ func repositoryNameFromWebhookPayload(payload webhook.ParsedPayload) string {
 	}
 
 	return "unknown"
-}
-
-type webhookCommitStatusReporter struct {
-	appConfig *app.Config
-	log       *slog.Logger
-	payload   webhook.ParsedPayload
-}
-
-func (r webhookCommitStatusReporter) Post(ctx context.Context, state commitstatus.State, description string) {
-	if r.appConfig == nil {
-		return
-	}
-
-	sourceURL, _ := resolveWebhookGitCloneURL(r.payload, r.appConfig)
-	if sourceURL == "" {
-		sourceURL = r.payload.WebURL
-	}
-
-	req, ok := commitstatus.ResolveRequest(r.log, commitstatus.RequestParams{
-		Enabled:          r.appConfig.GitCommitStatus,
-		SourceIsGit:      r.payload.Source == webhook.PayloadSourceGit,
-		SourceURL:        sourceURL,
-		CommitSHA:        r.payload.CommitSHAString(),
-		PayloadWebURL:    r.payload.WebURL,
-		PayloadFullName:  r.payload.FullName,
-		ProviderOverride: r.appConfig.GitScmProvider,
-		APIBaseURL:       string(r.appConfig.GitScmApiUrl),
-		AccessToken:      r.appConfig.GitAccessToken,
-		ContextName:      commitstatus.DeployContext,
-	})
-	if !ok {
-		return
-	}
-
-	r.log.Debug("posting aggregate webhook commit status",
-		slog.String("provider", string(req.Provider)),
-		slog.String("repository", req.RepoFullName),
-		slog.String("commit_sha", req.CommitSHA),
-		slog.String("context", req.Context),
-		slog.String("state", string(state)),
-		slog.String("description", description),
-	)
-
-	if err := req.Post(ctx, commitstatus.Status{State: state, Description: description}); err != nil {
-		r.log.Warn("failed to post aggregate webhook commit status", slog.String("error", err.Error()))
-	}
-}
-
-func aggregateWebhookCommitStatus(result controlplane.RunResult, err error) (commitstatus.State, string) {
-	if err != nil {
-		return commitstatus.StateError, commitstatus.FailureDescription(err)
-	}
-
-	switch result.Status {
-	case controlplane.RunStatusFailed:
-		if strings.TrimSpace(result.Message) == "" {
-			return commitstatus.StateFailure, "Failed"
-		}
-
-		return commitstatus.StateFailure, commitstatus.FailureDescription(errors.New(result.Message))
-	case controlplane.RunStatusSkipped:
-		return commitstatus.StateSuccess, "Skipped"
-	default:
-		return commitstatus.StateSuccess, "Successful"
-	}
 }
 
 type orchestrationHandler struct {
@@ -631,12 +565,6 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 		Revision:   metadata.Revision,
 	})
 
-	statusReporter := webhookCommitStatusReporter{
-		appConfig: h.appConfig,
-		log:       jobLog,
-		payload:   payload,
-	}
-
 	lockEntity := "repository"
 	lockLogValue := metadata.Repository
 
@@ -648,17 +576,7 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 	// Prevent concurrent deployments for the same repository using a lock
 	repoLock := lock.GetRepoLock(metadata.Repository)
 
-	handleFn := func(ctx context.Context, w http.ResponseWriter) (result controlplane.RunResult, handleErr error) {
-		defer func() {
-			if recovered := recover(); recovered != nil {
-				statusReporter.Post(ctx, commitstatus.StateError, "Deployment panicked")
-				panic(recovered)
-			}
-
-			state, description := aggregateWebhookCommitStatus(result, handleErr)
-			statusReporter.Post(ctx, state, description)
-		}()
-
+	handleFn := func(ctx context.Context, w http.ResponseWriter) (controlplane.RunResult, error) {
 		if !acquireWebhookRepoLock(ctx, repoLock, jobID, func() {
 			jobLog.Info("waiting for webhook "+lockEntity+" lock", slog.String(lockEntity, lockLogValue))
 		}) {
@@ -666,8 +584,6 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 		}
 
 		defer repoLock.Unlock()
-
-		statusReporter.Post(ctx, commitstatus.StatePending, "In Progress")
 
 		return handleEvent(ctx, jobLog, w, h.appConfig, payload, customTarget, metadata, h.testName, h.deployment, h.notifier)
 	}
@@ -677,18 +593,11 @@ func (h *orchestrationHandler) WebhookHandler(w http.ResponseWriter, r *http.Req
 		mode = controlplane.RunSynchronousDetached
 	}
 
-	execution := controlplane.RunExecution{
+	err = h.controlPlaneRuns.Execute(r.Context(), jobID, controlplane.RunExecution{
 		Mode:         mode,
 		PanicContext: "webhook deployment",
 		PanicError:   errWebhookDeploymentPanicked,
-	}
-	if !wait {
-		execution.OnQueued = func(ctx context.Context) {
-			statusReporter.Post(ctx, commitstatus.StatePending, "Queued")
-		}
-	}
-
-	err = h.controlPlaneRuns.Execute(r.Context(), jobID, execution, func(ctx context.Context) (controlplane.RunResult, error) {
+	}, func(ctx context.Context) (controlplane.RunResult, error) {
 		if wait {
 			return handleFn(ctx, w)
 		}

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/common/id"
 
+	"github.com/kimdre/doco-cd/internal/commitstatus"
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/poll"
@@ -242,6 +243,40 @@ func repositoryNameFromWebhookPayload(payload webhook.ParsedPayload) string {
 	return "unknown"
 }
 
+func postSkippedWebhookCommitStatus(ctx context.Context, appConfig *app.Config, log *slog.Logger, payload webhook.ParsedPayload) {
+	if appConfig == nil {
+		return
+	}
+
+	sourceURL, _ := resolveWebhookGitCloneURL(payload, appConfig)
+	if sourceURL == "" {
+		sourceURL = payload.WebURL
+	}
+
+	req, ok := commitstatus.ResolveRequest(log, commitstatus.RequestParams{
+		Enabled:          appConfig.GitCommitStatus,
+		SourceIsGit:      payload.Source == webhook.PayloadSourceGit,
+		SourceURL:        sourceURL,
+		CommitSHA:        payload.CommitSHAString(),
+		PayloadWebURL:    payload.WebURL,
+		PayloadFullName:  payload.FullName,
+		ProviderOverride: appConfig.GitScmProvider,
+		APIBaseURL:       string(appConfig.GitScmApiUrl),
+		AccessToken:      appConfig.GitAccessToken,
+		ContextName:      commitstatus.DeployContext,
+	})
+	if !ok {
+		return
+	}
+
+	if err := req.Post(ctx, commitstatus.Status{
+		State:       commitstatus.StateSuccess,
+		Description: "Skipped",
+	}); err != nil {
+		log.Warn("failed to post skipped webhook commit status", slog.String("error", err.Error()))
+	}
+}
+
 type orchestrationHandler struct {
 	appConfig        *app.Config // Application configuration
 	controlPlaneRuns *controlplane.Runs
@@ -401,6 +436,10 @@ func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 		PollConfig:   poll.Config{},
 		Payload:      payload,
 	})
+	if errors.Is(deployErr, stages.ErrSkipDeployment) {
+		postSkippedWebhookCommitStatus(ctx, appConfig, jobLog, payload)
+	}
+
 	if errors.Is(deployErr, stages.ErrWebhookFilterMismatch) {
 		msg := "deployment skipped, webhook filter did not match"
 		elapsedTime := time.Since(startTime)

--- a/cmd/doco-cd/handler_webhook_test.go
+++ b/cmd/doco-cd/handler_webhook_test.go
@@ -14,21 +14,17 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 
 	restserver "github.com/kimdre/doco-cd/internal/api"
-	"github.com/kimdre/doco-cd/internal/commitstatus"
-	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/controlplane"
 
@@ -43,248 +39,6 @@ import (
 	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
-
-func TestWebhookCommitStatusReporterPostsAggregateContext(t *testing.T) {
-	t.Parallel()
-
-	type postedStatus struct {
-		State       string `json:"state"`
-		Description string `json:"description"`
-		Context     string `json:"context"`
-	}
-
-	var received []postedStatus
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("method = %s, want POST", r.Method)
-		}
-
-		if !strings.HasSuffix(r.URL.Path, "/api/v1/repos/owner/repo/statuses/0123456789012345678901234567890123456789") {
-			t.Errorf("unexpected status path %q", r.URL.Path)
-		}
-
-		var status postedStatus
-		if err := json.NewDecoder(r.Body).Decode(&status); err != nil {
-			t.Errorf("decode status: %v", err)
-		}
-
-		received = append(received, status)
-
-		w.WriteHeader(http.StatusCreated)
-	}))
-	defer server.Close()
-
-	reporter := webhookCommitStatusReporter{
-		appConfig: &app.Config{
-			GitCommitStatus: true,
-			GitAccessToken:  "token",
-			GitScmProvider:  string(commitstatus.ProviderGitea),
-			GitScmApiUrl:    config.HttpUrl(server.URL),
-		},
-		log: logger.New(logger.LevelCritical).Logger,
-		payload: webhook.ParsedPayload{
-			Source:    webhook.PayloadSourceGit,
-			CommitSHA: plumbing.NewHash("0123456789012345678901234567890123456789"),
-			FullName:  "owner/repo",
-			CloneURL:  "https://git.example.com/owner/repo.git",
-			WebURL:    "https://git.example.com/owner/repo",
-		},
-	}
-
-	reporter.Post(t.Context(), commitstatus.StatePending, "Queued")
-	reporter.Post(t.Context(), commitstatus.StatePending, "In Progress")
-	reporter.Post(t.Context(), commitstatus.StateSuccess, "Successful")
-
-	wantDescriptions := []string{"Queued", "In Progress", "Successful"}
-	if len(received) != len(wantDescriptions) {
-		t.Fatalf("received %d statuses, want %d", len(received), len(wantDescriptions))
-	}
-
-	for i, status := range received {
-		if status.Description != wantDescriptions[i] {
-			t.Errorf("status %d description = %q, want %q", i, status.Description, wantDescriptions[i])
-		}
-
-		if status.Context != commitstatus.DeployContext {
-			t.Errorf("status %d context = %q, want %q", i, status.Context, commitstatus.DeployContext)
-		}
-	}
-}
-
-func TestWebhookCommitStatusReporterSkipsUnsupportedEvents(t *testing.T) {
-	t.Parallel()
-
-	requests := 0
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests++
-
-		w.WriteHeader(http.StatusCreated)
-	}))
-	defer server.Close()
-
-	baseConfig := app.Config{
-		GitCommitStatus: true,
-		GitAccessToken:  "token",
-		GitScmProvider:  string(commitstatus.ProviderGitea),
-		GitScmApiUrl:    config.HttpUrl(server.URL),
-	}
-	basePayload := webhook.ParsedPayload{
-		Source:    webhook.PayloadSourceGit,
-		CommitSHA: plumbing.NewHash("0123456789012345678901234567890123456789"),
-		FullName:  "owner/repo",
-		WebURL:    "https://git.example.com/owner/repo",
-	}
-
-	disabledConfig := baseConfig
-	disabledConfig.GitCommitStatus = false
-	webhookCommitStatusReporter{
-		appConfig: &disabledConfig,
-		log:       logger.New(logger.LevelCritical).Logger,
-		payload:   basePayload,
-	}.Post(t.Context(), commitstatus.StatePending, "Queued")
-
-	ociPayload := basePayload
-	ociPayload.Source = webhook.PayloadSourceOCI
-	webhookCommitStatusReporter{
-		appConfig: &baseConfig,
-		log:       logger.New(logger.LevelCritical).Logger,
-		payload:   ociPayload,
-	}.Post(t.Context(), commitstatus.StatePending, "Queued")
-
-	if requests != 0 {
-		t.Fatalf("received %d commit status requests, want none", requests)
-	}
-}
-
-func TestWebhookHandlerPostsAggregateStatusLifecycle(t *testing.T) {
-	testCases := []struct {
-		name             string
-		url              string
-		wantDescriptions []string
-	}{
-		{
-			name:             "asynchronous",
-			url:              restserver.WebhookPath,
-			wantDescriptions: []string{"Queued", "In Progress", "Skipped"},
-		},
-		{
-			name:             "synchronous",
-			url:              restserver.WebhookPath + "?wait=true",
-			wantDescriptions: []string{"In Progress", "Skipped"},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			type postedStatus struct {
-				State       string `json:"state"`
-				Description string `json:"description"`
-				Context     string `json:"context"`
-			}
-
-			statuses := make(chan postedStatus, len(testCase.wantDescriptions))
-
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				var status postedStatus
-				if err := json.NewDecoder(r.Body).Decode(&status); err != nil {
-					t.Errorf("decode status: %v", err)
-				}
-
-				statuses <- status
-
-				w.WriteHeader(http.StatusCreated)
-			}))
-			defer server.Close()
-
-			appConfig, err := app.GetConfig()
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			appConfig.GitCommitStatus = true
-			appConfig.GitAccessToken = "token"
-			appConfig.GitScmProvider = string(commitstatus.ProviderGitea)
-			appConfig.GitScmApiUrl = config.HttpUrl(server.URL)
-
-			log := logger.New(logger.LevelCritical)
-			mountPoint := container.MountPoint{
-				Type:        "bind",
-				Source:      t.TempDir(),
-				Destination: t.TempDir(),
-				Mode:        "rw",
-			}
-			handler := orchestrationHandler{
-				appConfig: appConfig,
-				log:       log,
-				controlPlaneRuns: newTestControlPlaneRuns(t, testControlPlaneRunsOptions{
-					appConfig:      appConfig,
-					dataMountPoint: mountPoint,
-					log:            log,
-				}),
-			}
-
-			payload := []byte(`{
-				"ref": "",
-				"before": "0000000000000000000000000000000000000000",
-				"after": "0123456789012345678901234567890123456789",
-				"repository": {
-					"name": "repo",
-					"full_name": "owner/repo",
-					"clone_url": "https://git.example.com/owner/repo.git",
-					"html_url": "https://git.example.com/owner/repo",
-					"private": false
-				}
-			}`)
-			recorder := httptest.NewRecorder()
-			handler.WebhookHandler(recorder, newWebhookRequest(t, testCase.url, payload, appConfig))
-
-			for i, wantDescription := range testCase.wantDescriptions {
-				select {
-				case status := <-statuses:
-					if status.Description != wantDescription {
-						t.Errorf("status %d description = %q, want %q", i, status.Description, wantDescription)
-					}
-
-					if status.Context != commitstatus.DeployContext {
-						t.Errorf("status %d context = %q, want %q", i, status.Context, commitstatus.DeployContext)
-					}
-				case <-time.After(5 * time.Second):
-					t.Fatalf("timed out waiting for status %d (%s)", i, wantDescription)
-				}
-			}
-		})
-	}
-}
-
-func TestAggregateWebhookCommitStatus(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name            string
-		result          controlplane.RunResult
-		err             error
-		wantState       commitstatus.State
-		wantDescription string
-	}{
-		{name: "success", result: controlplane.SucceededRun("done"), wantState: commitstatus.StateSuccess, wantDescription: "Successful"},
-		{name: "skipped", result: controlplane.SkippedRun("not applicable"), wantState: commitstatus.StateSuccess, wantDescription: "Skipped"},
-		{name: "failure", result: controlplane.FailedRun("deploy failed"), wantState: commitstatus.StateFailure, wantDescription: "deploy failed"},
-		{name: "error", err: errors.New("run cancelled"), wantState: commitstatus.StateError, wantDescription: "run cancelled"},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-
-			state, description := aggregateWebhookCommitStatus(testCase.result, testCase.err)
-			if state != testCase.wantState || description != testCase.wantDescription {
-				t.Fatalf("status = (%q, %q), want (%q, %q)", state, description, testCase.wantState, testCase.wantDescription)
-			}
-		})
-	}
-}
 
 func TestAcquireWebhookRepoLockHonorsCancellation(t *testing.T) {
 	t.Parallel()
@@ -391,12 +145,6 @@ const (
 	githubPayloadFile          = "testdata/github_payload.json"
 	githubPayloadFileSwarmMode = "testdata/github_payload_swarm_mode.json"
 	webhookTestPollInterval    = 100 * time.Millisecond
-	composeContent             = `services:
-  nginx:
-    image: nginx:latest
-    ports:
-      - "80"
-`
 )
 
 // webhookFixtureFiles backs the local, network-independent fixture repo used

--- a/cmd/doco-cd/handler_webhook_test.go
+++ b/cmd/doco-cd/handler_webhook_test.go
@@ -14,17 +14,21 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 
 	restserver "github.com/kimdre/doco-cd/internal/api"
+	"github.com/kimdre/doco-cd/internal/commitstatus"
+	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/controlplane"
 
@@ -39,6 +43,248 @@ import (
 	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
+
+func TestWebhookCommitStatusReporterPostsAggregateContext(t *testing.T) {
+	t.Parallel()
+
+	type postedStatus struct {
+		State       string `json:"state"`
+		Description string `json:"description"`
+		Context     string `json:"context"`
+	}
+
+	var received []postedStatus
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+
+		if !strings.HasSuffix(r.URL.Path, "/api/v1/repos/owner/repo/statuses/0123456789012345678901234567890123456789") {
+			t.Errorf("unexpected status path %q", r.URL.Path)
+		}
+
+		var status postedStatus
+		if err := json.NewDecoder(r.Body).Decode(&status); err != nil {
+			t.Errorf("decode status: %v", err)
+		}
+
+		received = append(received, status)
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	reporter := webhookCommitStatusReporter{
+		appConfig: &app.Config{
+			GitCommitStatus: true,
+			GitAccessToken:  "token",
+			GitScmProvider:  string(commitstatus.ProviderGitea),
+			GitScmApiUrl:    config.HttpUrl(server.URL),
+		},
+		log: logger.New(logger.LevelCritical).Logger,
+		payload: webhook.ParsedPayload{
+			Source:    webhook.PayloadSourceGit,
+			CommitSHA: plumbing.NewHash("0123456789012345678901234567890123456789"),
+			FullName:  "owner/repo",
+			CloneURL:  "https://git.example.com/owner/repo.git",
+			WebURL:    "https://git.example.com/owner/repo",
+		},
+	}
+
+	reporter.Post(t.Context(), commitstatus.StatePending, "Queued")
+	reporter.Post(t.Context(), commitstatus.StatePending, "In Progress")
+	reporter.Post(t.Context(), commitstatus.StateSuccess, "Successful")
+
+	wantDescriptions := []string{"Queued", "In Progress", "Successful"}
+	if len(received) != len(wantDescriptions) {
+		t.Fatalf("received %d statuses, want %d", len(received), len(wantDescriptions))
+	}
+
+	for i, status := range received {
+		if status.Description != wantDescriptions[i] {
+			t.Errorf("status %d description = %q, want %q", i, status.Description, wantDescriptions[i])
+		}
+
+		if status.Context != commitstatus.DeployContext {
+			t.Errorf("status %d context = %q, want %q", i, status.Context, commitstatus.DeployContext)
+		}
+	}
+}
+
+func TestWebhookCommitStatusReporterSkipsUnsupportedEvents(t *testing.T) {
+	t.Parallel()
+
+	requests := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	baseConfig := app.Config{
+		GitCommitStatus: true,
+		GitAccessToken:  "token",
+		GitScmProvider:  string(commitstatus.ProviderGitea),
+		GitScmApiUrl:    config.HttpUrl(server.URL),
+	}
+	basePayload := webhook.ParsedPayload{
+		Source:    webhook.PayloadSourceGit,
+		CommitSHA: plumbing.NewHash("0123456789012345678901234567890123456789"),
+		FullName:  "owner/repo",
+		WebURL:    "https://git.example.com/owner/repo",
+	}
+
+	disabledConfig := baseConfig
+	disabledConfig.GitCommitStatus = false
+	webhookCommitStatusReporter{
+		appConfig: &disabledConfig,
+		log:       logger.New(logger.LevelCritical).Logger,
+		payload:   basePayload,
+	}.Post(t.Context(), commitstatus.StatePending, "Queued")
+
+	ociPayload := basePayload
+	ociPayload.Source = webhook.PayloadSourceOCI
+	webhookCommitStatusReporter{
+		appConfig: &baseConfig,
+		log:       logger.New(logger.LevelCritical).Logger,
+		payload:   ociPayload,
+	}.Post(t.Context(), commitstatus.StatePending, "Queued")
+
+	if requests != 0 {
+		t.Fatalf("received %d commit status requests, want none", requests)
+	}
+}
+
+func TestWebhookHandlerPostsAggregateStatusLifecycle(t *testing.T) {
+	testCases := []struct {
+		name             string
+		url              string
+		wantDescriptions []string
+	}{
+		{
+			name:             "asynchronous",
+			url:              restserver.WebhookPath,
+			wantDescriptions: []string{"Queued", "In Progress", "Skipped"},
+		},
+		{
+			name:             "synchronous",
+			url:              restserver.WebhookPath + "?wait=true",
+			wantDescriptions: []string{"In Progress", "Skipped"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			type postedStatus struct {
+				State       string `json:"state"`
+				Description string `json:"description"`
+				Context     string `json:"context"`
+			}
+
+			statuses := make(chan postedStatus, len(testCase.wantDescriptions))
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var status postedStatus
+				if err := json.NewDecoder(r.Body).Decode(&status); err != nil {
+					t.Errorf("decode status: %v", err)
+				}
+
+				statuses <- status
+
+				w.WriteHeader(http.StatusCreated)
+			}))
+			defer server.Close()
+
+			appConfig, err := app.GetConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			appConfig.GitCommitStatus = true
+			appConfig.GitAccessToken = "token"
+			appConfig.GitScmProvider = string(commitstatus.ProviderGitea)
+			appConfig.GitScmApiUrl = config.HttpUrl(server.URL)
+
+			log := logger.New(logger.LevelCritical)
+			mountPoint := container.MountPoint{
+				Type:        "bind",
+				Source:      t.TempDir(),
+				Destination: t.TempDir(),
+				Mode:        "rw",
+			}
+			handler := orchestrationHandler{
+				appConfig: appConfig,
+				log:       log,
+				controlPlaneRuns: newTestControlPlaneRuns(t, testControlPlaneRunsOptions{
+					appConfig:      appConfig,
+					dataMountPoint: mountPoint,
+					log:            log,
+				}),
+			}
+
+			payload := []byte(`{
+				"ref": "",
+				"before": "0000000000000000000000000000000000000000",
+				"after": "0123456789012345678901234567890123456789",
+				"repository": {
+					"name": "repo",
+					"full_name": "owner/repo",
+					"clone_url": "https://git.example.com/owner/repo.git",
+					"html_url": "https://git.example.com/owner/repo",
+					"private": false
+				}
+			}`)
+			recorder := httptest.NewRecorder()
+			handler.WebhookHandler(recorder, newWebhookRequest(t, testCase.url, payload, appConfig))
+
+			for i, wantDescription := range testCase.wantDescriptions {
+				select {
+				case status := <-statuses:
+					if status.Description != wantDescription {
+						t.Errorf("status %d description = %q, want %q", i, status.Description, wantDescription)
+					}
+
+					if status.Context != commitstatus.DeployContext {
+						t.Errorf("status %d context = %q, want %q", i, status.Context, commitstatus.DeployContext)
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatalf("timed out waiting for status %d (%s)", i, wantDescription)
+				}
+			}
+		})
+	}
+}
+
+func TestAggregateWebhookCommitStatus(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		result          controlplane.RunResult
+		err             error
+		wantState       commitstatus.State
+		wantDescription string
+	}{
+		{name: "success", result: controlplane.SucceededRun("done"), wantState: commitstatus.StateSuccess, wantDescription: "Successful"},
+		{name: "skipped", result: controlplane.SkippedRun("not applicable"), wantState: commitstatus.StateSuccess, wantDescription: "Skipped"},
+		{name: "failure", result: controlplane.FailedRun("deploy failed"), wantState: commitstatus.StateFailure, wantDescription: "deploy failed"},
+		{name: "error", err: errors.New("run cancelled"), wantState: commitstatus.StateError, wantDescription: "run cancelled"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			state, description := aggregateWebhookCommitStatus(testCase.result, testCase.err)
+			if state != testCase.wantState || description != testCase.wantDescription {
+				t.Fatalf("status = (%q, %q), want (%q, %q)", state, description, testCase.wantState, testCase.wantDescription)
+			}
+		})
+	}
+}
 
 func TestAcquireWebhookRepoLockHonorsCancellation(t *testing.T) {
 	t.Parallel()

--- a/cmd/doco-cd/handler_webhook_test.go
+++ b/cmd/doco-cd/handler_webhook_test.go
@@ -19,12 +19,15 @@ import (
 
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/docker/compose/v5/pkg/compose"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 
 	restserver "github.com/kimdre/doco-cd/internal/api"
+	"github.com/kimdre/doco-cd/internal/commitstatus"
+	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/controlplane"
 
@@ -39,6 +42,46 @@ import (
 	"github.com/kimdre/doco-cd/internal/reconciliation"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
+
+func TestPostSkippedWebhookCommitStatusUsesRunContext(t *testing.T) {
+	type postedStatus struct {
+		State       string `json:"state"`
+		Description string `json:"description"`
+		Context     string `json:"context"`
+	}
+
+	var received postedStatus
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode status: %v", err)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	postSkippedWebhookCommitStatus(t.Context(), &app.Config{
+		GitCommitStatus: true,
+		GitAccessToken:  "token",
+		GitScmProvider:  string(commitstatus.ProviderGitea),
+		GitScmApiUrl:    config.HttpUrl(server.URL),
+	}, logger.New(logger.LevelCritical).Logger, webhook.ParsedPayload{
+		Source:    webhook.PayloadSourceGit,
+		CommitSHA: plumbing.NewHash("0123456789012345678901234567890123456789"),
+		FullName:  "owner/repo",
+		CloneURL:  "https://git.example.com/owner/repo.git",
+		WebURL:    "https://git.example.com/owner/repo",
+	})
+
+	if received.State != string(commitstatus.StateSuccess) || received.Description != "Skipped" {
+		t.Fatalf("unexpected skipped status: %+v", received)
+	}
+
+	if received.Context != commitstatus.DeployContext {
+		t.Fatalf("context = %q, want %q", received.Context, commitstatus.DeployContext)
+	}
+}
 
 func TestAcquireWebhookRepoLockHonorsCancellation(t *testing.T) {
 	t.Parallel()

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,8 +2,8 @@
 
 Full working setups for common doco-cd scenarios. Each example replicates every repo it needs:
 
-- `app-repo/` or `deployments-repo/` — what you commit to Git.
-- `server/` — what you put on the Docker host (doco-cd itself).
+- `app-repo/` or `deployments-repo/`: what you commit to Git.
+- `server/`: what you put on the Docker host (doco-cd itself).
 
 | Example | Pattern | Pick it when |
 |---|---|---|
@@ -13,6 +13,6 @@ Full working setups for common doco-cd scenarios. Each example replicates every 
 
 Notes that apply to all examples:
 
-- All examples poll. Polling needs no inbound port, so the host firewall stays closed. Webhooks work the same way — set `WEBHOOK_SECRET` and publish the port.
+- All examples poll. Polling needs no inbound port, so the host firewall stays closed. Webhooks work the same way: set `WEBHOOK_SECRET` and publish the port.
 - Examples use the `latest` image tag to stay copy-pasteable. In real use pin the doco-cd image by tag + digest.
-- The `server/` compose is the one thing doco-cd cannot GitOps — it deploys stacks, not itself. Copy it to the host by hand (or see [Self-Updating](https://doco.cd/latest/Advanced/Self-Updating/)).
+- The `server/` compose is the one thing doco-cd cannot GitOps because it deploys stacks, not itself. Copy it to the host by hand (or see [Self-Updating](https://doco.cd/latest/Advanced/Self-Updating/)).

--- a/examples/deployments-repo/README.md
+++ b/examples/deployments-repo/README.md
@@ -6,10 +6,10 @@ Needs doco-cd >= 0.108.0 (remote compose `include:`).
 
 ## The model
 
-- **One target file per host.** It lists the host's stacks and pins **every** version the host runs: your images by git sha, third-party by exact tag. Nothing floats. A version change is a commit — reviewable, revertable, and the diff is the changelog.
-- **Compose lives with the app code, not here.** Each per-env compose is a small stub that `include:`s the app repo's `deploy/compose.yaml`, pinned at a sha. The compose travels through envs together with the images it describes — a compose change cannot hit prod before its code does.
+- **One target file per host.** It lists the host's stacks and pins **every** version the host runs: your images by git sha, third-party by exact tag. Nothing floats. A version change is a reviewable, revertable commit, and the diff is the changelog.
+- **Compose lives with the app code, not here.** Each per-env compose is a small stub that `include:`s the app repo's `deploy/compose.yaml`, pinned at a sha. The compose travels through envs together with the images it describes, so a compose change cannot hit prod before its code does.
 - **Non-secret config** is a cleartext env file per environment, committed here.
-- **Secrets** are SOPS-encrypted env files, committed here. The daemon decrypts them at deploy time with an age key (KMS works the same). Secrets land as container env — verify on the host with `docker exec <c> printenv`, never by reading files.
+- **Secrets** are SOPS-encrypted env files, committed here. The daemon decrypts them at deploy time with an age key (KMS works the same). Secrets land as container env. Verify on the host with `docker exec <c> printenv`, never by reading files.
 - **App CI closes the loop:** after building an image, a bump job rewrites the sha pins in the target files of the envs that should follow, and commits. doco-cd does the rest.
 
 ## Layout
@@ -26,14 +26,14 @@ deployments-repo/            # the fleet's Git repository
     env/shop-prod.env
     secrets/shop-dev.sops.env         # SOPS-encrypted (example is a template)
 app-repo/                    # the app's own repo (e.g. github.com/example/shop-be)
-  deploy/compose.yaml        # THE family compose — single source for every env
+  deploy/compose.yaml        # THE family compose, single source for every env
 server/                      # per host, e.g. /opt/doco-cd/
   compose.yaml
   poll.yaml                  # target: shop-dev on the dev host, shop-prod on prod
   secrets.env.example
 ```
 
-Add more apps as more families (`blog/`, `api/`, …) and more target files. One host can also run several stacks — add more YAML documents to its target file.
+Add more apps as more families (`blog/`, `api/`, …) and more target files. One host can also run several stacks. Add more YAML documents to its target file.
 
 ## Try it
 
@@ -45,4 +45,4 @@ Add more apps as more families (`blog/`, `api/`, …) and more target files. One
 
 ## Why a stub and not a plain compose here?
 
-You can start with full compose files in this repo — that also works and is simpler. The stub + pinned `include:` pays off when app developers own their compose: they change it in the app repo, CI bumps `SHOP_COMPOSE_SHA` here per env, and dev/test/prod each run exactly the compose revision they were promoted to. `project_directory: .` makes the included file's relative paths (`../env/*`, `../secrets/*`) resolve against the per-env stub directory, so one compose serves every env.
+You can start with full compose files in this repo. That also works and is simpler. The stub + pinned `include:` pays off when app developers own their compose: they change it in the app repo, CI bumps `SHOP_COMPOSE_SHA` here per env, and dev/test/prod each run exactly the compose revision they were promoted to. `project_directory: .` makes the included file's relative paths (`../env/*`, `../secrets/*`) resolve against the per-env stub directory, so one compose serves every env.

--- a/examples/deployments-repo/deployments-repo/.doco-cd.shop-dev.yml
+++ b/examples/deployments-repo/deployments-repo/.doco-cd.shop-dev.yml
@@ -20,4 +20,4 @@ environment:
 # the drift-redeploy loop alive.
 remove_orphans: true
 reconciliation:
-  events: [unhealthy] # never `die` — one-shot/post_start exits would loop it
+  events: [unhealthy] # never `die`, one-shot/post_start exits would loop it

--- a/examples/single-repo-single-env/README.md
+++ b/examples/single-repo-single-env/README.md
@@ -36,6 +36,6 @@ Within one poll interval the stack is up. From now on, a push to `main` is a dep
 
 ## How a release works
 
-CI builds the image and tags it with the commit SHA. Then a CI job rewrites `APP_TAG` in `.doco-cd.yml` and commits with `[skip ci]`. doco-cd sees the deploy config changed and redeploys. The repo always states what runs — that is the whole point.
+CI builds the image and tags it with the commit SHA. Then a CI job rewrites `APP_TAG` in `.doco-cd.yml` and commits with `[skip ci]`. doco-cd sees the deploy config changed and redeploys. The repo always states what runs. That is the whole point.
 
 A commit that touches nothing the stack references (docs, other dirs) is skipped: cloned, compared, no `compose up`.

--- a/examples/single-repo-two-envs/README.md
+++ b/examples/single-repo-two-envs/README.md
@@ -7,8 +7,8 @@ One app repo, two Docker hosts (staging + prod). The repo carries **two deploy c
 - **`target:` is real isolation.** The staging daemon (no `target:`) reads only the bare `.doco-cd.yml`. The prod daemon (`target: prod`) reads only `.doco-cd.prod.yml`. Staging values cannot leak into prod.
 - The prod config repeats only what differs: image tags, domain, log level. Behavior blocks are copied on purpose, so the two files cannot argue.
 - **Separate tags per stack.** The db stack pins its own tag. A web-only release must not recreate the stateful side.
-- Why `reconciliation.events` stays `[unhealthy]` and never gets `die`: the one-shot `migrate` container exits 0 on every deploy by design, and `die` reads that as a failure — an unbounded reconcile loop.
-- Cross-stack networking via an **external network** — each stack is its own compose project.
+- Why `reconciliation.events` stays `[unhealthy]` and never gets `die`: the one-shot `migrate` container exits 0 on every deploy by design, and `die` reads that as a failure, causing an unbounded reconcile loop.
+- Cross-stack networking via an **external network**, since each stack is its own compose project.
 - **Deploy notifications** to Telegram (or anything else) via an Apprise sidecar, with a compact body template.
 
 ## Layout
@@ -16,7 +16,7 @@ One app repo, two Docker hosts (staging + prod). The repo carries **two deploy c
 ```
 app-repo/                  # your Git repository
   .doco-cd.yml             # staging config (both stacks)
-  .doco-cd.prod.yml        # prod config — only the values that differ
+  .doco-cd.prod.yml        # prod config with only the values that differ
   deploy/
     app/compose.yaml       # web stack
     db/compose.yaml        # postgres + one-shot migrate

--- a/examples/single-repo-two-envs/server/compose.yaml
+++ b/examples/single-repo-two-envs/server/compose.yaml
@@ -26,7 +26,7 @@ services:
       #     so the body degrades back to the one-liner.
       #   - the repo prefix is a literal: each daemon polls one repo anyway.
       APPRISE_NOTIFY_BODY_TEMPLATE: |-
-        myapp -> {{.Stack}} @ {{.Revision}}{{if .IsReconciliation}} · {{.ReconciliationEvent}}{{else}} in {{.Duration}}{{end}}{{if ne .Level "success"}} — {{.Message}}{{end}}
+        myapp -> {{.Stack}} @ {{.Revision}}{{if .IsReconciliation}} · {{.ReconciliationEvent}}{{else}} in {{.Duration}}{{end}}{{if ne .Level "success"}} - {{.Message}}{{end}}
         {{- range .Commits }}
         - {{ . }}
         {{- end }}

--- a/internal/controlplane/deploy.go
+++ b/internal/controlplane/deploy.go
@@ -173,8 +173,8 @@ func classifySourceFailure(err error) (int, error) {
 //
 // Errors are returned as DeploymentError so callers can preserve the exact
 // HTTP status/message mapping the pre-refactor handler used. A
-// stages.ErrWebhookFilterMismatch from the reconciler is returned unwrapped so
-// callers can keep reporting it as a skipped (not failed) deployment.
+// For webhook requests, stages.ErrSkipDeployment from the reconciler is
+// returned unwrapped so callers can report a skipped (not failed) deployment.
 func (d *Deployment) Deploy(ctx context.Context, req DeploymentRequest) error {
 	if err := validation.Validate(req); err != nil {
 		return newDeploymentError(source.ErrInvalidRequest, err, http.StatusInternalServerError)
@@ -227,7 +227,11 @@ func (d *Deployment) Deploy(ctx context.Context, req DeploymentRequest) error {
 		Payload:       &result.Payload,
 		TestName:      req.TestName,
 	}); err != nil {
-		if errors.Is(err, stages.ErrWebhookFilterMismatch) {
+		if errors.Is(err, stages.ErrSkipDeployment) {
+			if req.JobTrigger == stages.JobTriggerPoll {
+				return nil
+			}
+
 			return err
 		}
 

--- a/internal/controlplane/deploy_test.go
+++ b/internal/controlplane/deploy_test.go
@@ -423,6 +423,37 @@ func TestDeploy_PreservesErrWebhookFilterMismatchIdentity(t *testing.T) {
 	}
 }
 
+func TestDeploy_PreservesWebhookSkipIdentity(t *testing.T) {
+	t.Parallel()
+
+	preparer := &fakeSourcePreparer{result: source.Result{DeployConfigs: []*deploy.Config{{Name: "stack"}}}}
+	reconciler := &fakeReconciler{err: stages.ErrSkipDeployment}
+	d := newTestDeployment(t, preparer, reconciler)
+
+	err := d.Deploy(t.Context(), validDeploymentRequest())
+	if !errors.Is(err, stages.ErrSkipDeployment) {
+		t.Fatalf("expected ErrSkipDeployment identity to be preserved, got %v", err)
+	}
+
+	if de, ok := errors.AsType[controlplane.DeploymentError](err); ok {
+		t.Fatalf("expected ErrSkipDeployment not to be wrapped in a DeploymentError, got %+v", de)
+	}
+}
+
+func TestDeploy_KeepsPollSkipAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	preparer := &fakeSourcePreparer{result: source.Result{DeployConfigs: []*deploy.Config{{Name: "stack"}}}}
+	reconciler := &fakeReconciler{err: stages.ErrSkipDeployment}
+	d := newTestDeployment(t, preparer, reconciler)
+	req := validDeploymentRequest()
+	req.JobTrigger = stages.JobTriggerPoll
+
+	if err := d.Deploy(t.Context(), req); err != nil {
+		t.Fatalf("expected poll skip to remain successful, got %v", err)
+	}
+}
+
 // TestCommitStatusEarlyFailure_SkipsWithoutBlockingDeployment is a sanity check that
 // commitstatus.ResolveRequest (used by internal/source to report early Git
 // clone/config-resolution failures before controlplane ever runs

--- a/internal/controlplane/runs.go
+++ b/internal/controlplane/runs.go
@@ -42,6 +42,8 @@ type RunExecution struct {
 	Mode         RunMode
 	PanicContext string
 	PanicError   error
+	// OnQueued runs after asynchronous admission and before the run starts.
+	OnQueued func(context.Context)
 }
 
 // RunFunc performs the work associated with an accepted control-plane run.
@@ -196,19 +198,25 @@ func (c *Runs) Execute(
 	execution RunExecution,
 	run RunFunc,
 ) error {
-	runRegistered := func(runCtx context.Context) error {
-		return c.executeRegistered(runCtx, jobID, execution, run)
+	runRegistered := func(runCtx context.Context, queued bool) error {
+		return c.executeRegistered(runCtx, jobID, execution, run, queued)
 	}
 
 	if execution.Mode == RunAsynchronous {
-		err := c.background.Go(func() {
-			_ = runRegistered(c.applicationCtx)
-		})
+		release, err := c.background.Register()
 		if err != nil {
 			c.MarkFailed(jobID, err.Error())
+
+			return err
 		}
 
-		return err
+		go func() {
+			defer release()
+
+			_ = runRegistered(c.applicationCtx, true)
+		}()
+
+		return nil
 	}
 
 	release, err := c.background.Register()
@@ -229,7 +237,7 @@ func (c *Runs) Execute(
 	stopApplicationCancel := context.AfterFunc(c.applicationCtx, cancel) //nolint:contextcheck // A synchronous run is intentionally cancelled by either its request or the application lifecycle.
 	defer stopApplicationCancel()
 
-	return runRegistered(runCtx)
+	return runRegistered(runCtx, false)
 }
 
 // executeRegistered transitions an accepted run through execution, recovery, and finalization.
@@ -238,9 +246,8 @@ func (c *Runs) executeRegistered(
 	jobID string,
 	execution RunExecution,
 	run RunFunc,
+	queued bool,
 ) (err error) {
-	c.MarkRunning(jobID)
-
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			logger.LogRecoveredPanic(c.log.With(slog.String("job_id", jobID)), execution.PanicContext, recovered)
@@ -248,6 +255,12 @@ func (c *Runs) executeRegistered(
 			err = execution.PanicError
 		}
 	}()
+
+	if queued && execution.OnQueued != nil {
+		execution.OnQueued(ctx)
+	}
+
+	c.MarkRunning(jobID)
 
 	result, err := run(ctx)
 	c.finish(jobID, result, err)

--- a/internal/controlplane/runs.go
+++ b/internal/controlplane/runs.go
@@ -42,8 +42,6 @@ type RunExecution struct {
 	Mode         RunMode
 	PanicContext string
 	PanicError   error
-	// OnQueued runs after asynchronous admission and before the run starts.
-	OnQueued func(context.Context)
 }
 
 // RunFunc performs the work associated with an accepted control-plane run.
@@ -198,25 +196,19 @@ func (c *Runs) Execute(
 	execution RunExecution,
 	run RunFunc,
 ) error {
-	runRegistered := func(runCtx context.Context, queued bool) error {
-		return c.executeRegistered(runCtx, jobID, execution, run, queued)
+	runRegistered := func(runCtx context.Context) error {
+		return c.executeRegistered(runCtx, jobID, execution, run)
 	}
 
 	if execution.Mode == RunAsynchronous {
-		release, err := c.background.Register()
+		err := c.background.Go(func() {
+			_ = runRegistered(c.applicationCtx)
+		})
 		if err != nil {
 			c.MarkFailed(jobID, err.Error())
-
-			return err
 		}
 
-		go func() {
-			defer release()
-
-			_ = runRegistered(c.applicationCtx, true)
-		}()
-
-		return nil
+		return err
 	}
 
 	release, err := c.background.Register()
@@ -237,7 +229,7 @@ func (c *Runs) Execute(
 	stopApplicationCancel := context.AfterFunc(c.applicationCtx, cancel) //nolint:contextcheck // A synchronous run is intentionally cancelled by either its request or the application lifecycle.
 	defer stopApplicationCancel()
 
-	return runRegistered(runCtx, false)
+	return runRegistered(runCtx)
 }
 
 // executeRegistered transitions an accepted run through execution, recovery, and finalization.
@@ -246,8 +238,9 @@ func (c *Runs) executeRegistered(
 	jobID string,
 	execution RunExecution,
 	run RunFunc,
-	queued bool,
 ) (err error) {
+	c.MarkRunning(jobID)
+
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			logger.LogRecoveredPanic(c.log.With(slog.String("job_id", jobID)), execution.PanicContext, recovered)
@@ -255,12 +248,6 @@ func (c *Runs) executeRegistered(
 			err = execution.PanicError
 		}
 	}()
-
-	if queued && execution.OnQueued != nil {
-		execution.OnQueued(ctx)
-	}
-
-	c.MarkRunning(jobID)
 
 	result, err := run(ctx)
 	c.finish(jobID, result, err)

--- a/internal/controlplane/runs_test.go
+++ b/internal/controlplane/runs_test.go
@@ -280,6 +280,87 @@ func TestControlPlaneRunsConcurrentAsynchronousRuns(t *testing.T) {
 	}
 }
 
+func TestControlPlaneRunsCallsOnQueuedBeforeAsynchronousRun(t *testing.T) {
+	t.Parallel()
+
+	runs := newTestControlPlaneRuns(t, testControlPlaneRunsOptions{})
+	jobID := runs.Accept("queued-hook", deploymentRunTriggerWebhook, RunMetadata{})
+	queuedStarted := make(chan struct{})
+	releaseQueued := make(chan struct{})
+	queued := make(chan struct{})
+	started := make(chan struct{})
+
+	if err := runs.Execute(t.Context(), jobID, RunExecution{
+		Mode:         RunAsynchronous,
+		PanicContext: "test run",
+		PanicError:   errors.New("test run panicked"),
+		OnQueued: func(context.Context) {
+			close(queuedStarted)
+			<-releaseQueued
+			close(queued)
+		},
+	}, func(context.Context) (RunResult, error) {
+		select {
+		case <-queued:
+		default:
+			t.Error("asynchronous run started before OnQueued completed")
+		}
+
+		close(started)
+
+		return SucceededRun("done"), nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-queuedStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for OnQueued")
+	}
+
+	select {
+	case <-started:
+		t.Fatal("asynchronous run started before OnQueued completed")
+	default:
+	}
+
+	close(releaseQueued)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for asynchronous run")
+	}
+
+	runs.CloseAndWait()
+}
+
+func TestControlPlaneRunsDoesNotCallOnQueuedForSynchronousRun(t *testing.T) {
+	t.Parallel()
+
+	runs := newTestControlPlaneRuns(t, testControlPlaneRunsOptions{})
+	jobID := runs.Accept("sync-hook", deploymentRunTriggerWebhook, RunMetadata{})
+	queued := false
+
+	if err := runs.Execute(t.Context(), jobID, RunExecution{
+		Mode:         RunSynchronous,
+		PanicContext: "test run",
+		PanicError:   errors.New("test run panicked"),
+		OnQueued: func(context.Context) {
+			queued = true
+		},
+	}, func(context.Context) (RunResult, error) {
+		return SucceededRun("done"), nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if queued {
+		t.Fatal("OnQueued called for synchronous run")
+	}
+}
+
 func TestControlPlaneRunsConvertsPanic(t *testing.T) {
 	t.Parallel()
 
@@ -491,11 +572,15 @@ func TestControlPlaneRunsRejectsAfterShutdownBegins(t *testing.T) {
 	runs.CloseAndWait()
 
 	jobID := runs.Accept("rejected", deploymentRunTriggerPoll, RunMetadata{})
+	queued := false
 
 	err := runs.Execute(t.Context(), jobID, RunExecution{
 		Mode:         RunAsynchronous,
 		PanicContext: "test run",
 		PanicError:   errors.New("test run panicked"),
+		OnQueued: func(context.Context) {
+			queued = true
+		},
 	}, func(context.Context) (RunResult, error) {
 		t.Fatal("run started during shutdown")
 
@@ -503,6 +588,10 @@ func TestControlPlaneRunsRejectsAfterShutdownBegins(t *testing.T) {
 	})
 	if !errors.Is(err, ErrBackgroundWorkClosed) {
 		t.Fatalf("error = %v, want %v", err, ErrBackgroundWorkClosed)
+	}
+
+	if queued {
+		t.Fatal("OnQueued called after admission was rejected")
 	}
 
 	run, ok := runs.Get(jobID)

--- a/internal/controlplane/runs_test.go
+++ b/internal/controlplane/runs_test.go
@@ -280,87 +280,6 @@ func TestControlPlaneRunsConcurrentAsynchronousRuns(t *testing.T) {
 	}
 }
 
-func TestControlPlaneRunsCallsOnQueuedBeforeAsynchronousRun(t *testing.T) {
-	t.Parallel()
-
-	runs := newTestControlPlaneRuns(t, testControlPlaneRunsOptions{})
-	jobID := runs.Accept("queued-hook", deploymentRunTriggerWebhook, RunMetadata{})
-	queuedStarted := make(chan struct{})
-	releaseQueued := make(chan struct{})
-	queued := make(chan struct{})
-	started := make(chan struct{})
-
-	if err := runs.Execute(t.Context(), jobID, RunExecution{
-		Mode:         RunAsynchronous,
-		PanicContext: "test run",
-		PanicError:   errors.New("test run panicked"),
-		OnQueued: func(context.Context) {
-			close(queuedStarted)
-			<-releaseQueued
-			close(queued)
-		},
-	}, func(context.Context) (RunResult, error) {
-		select {
-		case <-queued:
-		default:
-			t.Error("asynchronous run started before OnQueued completed")
-		}
-
-		close(started)
-
-		return SucceededRun("done"), nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	select {
-	case <-queuedStarted:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for OnQueued")
-	}
-
-	select {
-	case <-started:
-		t.Fatal("asynchronous run started before OnQueued completed")
-	default:
-	}
-
-	close(releaseQueued)
-
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for asynchronous run")
-	}
-
-	runs.CloseAndWait()
-}
-
-func TestControlPlaneRunsDoesNotCallOnQueuedForSynchronousRun(t *testing.T) {
-	t.Parallel()
-
-	runs := newTestControlPlaneRuns(t, testControlPlaneRunsOptions{})
-	jobID := runs.Accept("sync-hook", deploymentRunTriggerWebhook, RunMetadata{})
-	queued := false
-
-	if err := runs.Execute(t.Context(), jobID, RunExecution{
-		Mode:         RunSynchronous,
-		PanicContext: "test run",
-		PanicError:   errors.New("test run panicked"),
-		OnQueued: func(context.Context) {
-			queued = true
-		},
-	}, func(context.Context) (RunResult, error) {
-		return SucceededRun("done"), nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	if queued {
-		t.Fatal("OnQueued called for synchronous run")
-	}
-}
-
 func TestControlPlaneRunsConvertsPanic(t *testing.T) {
 	t.Parallel()
 
@@ -572,15 +491,11 @@ func TestControlPlaneRunsRejectsAfterShutdownBegins(t *testing.T) {
 	runs.CloseAndWait()
 
 	jobID := runs.Accept("rejected", deploymentRunTriggerPoll, RunMetadata{})
-	queued := false
 
 	err := runs.Execute(t.Context(), jobID, RunExecution{
 		Mode:         RunAsynchronous,
 		PanicContext: "test run",
 		PanicError:   errors.New("test run panicked"),
-		OnQueued: func(context.Context) {
-			queued = true
-		},
 	}, func(context.Context) (RunResult, error) {
 		t.Fatal("run started during shutdown")
 
@@ -588,10 +503,6 @@ func TestControlPlaneRunsRejectsAfterShutdownBegins(t *testing.T) {
 	})
 	if !errors.Is(err, ErrBackgroundWorkClosed) {
 		t.Fatalf("error = %v, want %v", err, ErrBackgroundWorkClosed)
-	}
-
-	if queued {
-		t.Fatal("OnQueued called after admission was rejected")
 	}
 
 	run, ok := runs.Get(jobID)

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -499,7 +499,7 @@ func TestRenderTemplate(t *testing.T) {
 	t.Run("renders metadata fields and trims trailing newlines", func(t *testing.T) {
 		t.Parallel()
 
-		tmpl, err := validateTemplate("{{.Emoji}} {{.Title}} — {{.Target}}/{{.Stack}} @ {{.Revision}}\n")
+		tmpl, err := validateTemplate("{{.Emoji}} {{.Title}} - {{.Target}}/{{.Stack}} @ {{.Revision}}\n")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -510,7 +510,7 @@ func TestRenderTemplate(t *testing.T) {
 			Revision: "main (abc123)",
 			JobID:    "job-1",
 		})
-		expected := "✅ Deployment completed — prod-vm/app @ main (abc123)"
+		expected := "✅ Deployment completed - prod-vm/app @ main (abc123)"
 
 		if got != expected {
 			t.Errorf("expected %q, got %q", expected, got)

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -273,8 +273,6 @@ func (m *Manager) handleOneDeploy(ctx context.Context, req DeployRequest, deploy
 		return stages.ErrWebhookFilterMismatch
 	}
 
-	stageMgr.PostQueuedCommitStatus(ctx)
-
 	if m.limiter != nil {
 		deployLog.Debug("queuing deployment")
 

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -269,6 +269,10 @@ func (m *Manager) handleOneDeploy(ctx context.Context, req DeployRequest, deploy
 		return err
 	}
 
+	if !stageMgr.MatchesWebhookEventFilter() {
+		return stages.ErrWebhookFilterMismatch
+	}
+
 	stageMgr.PostQueuedCommitStatus(ctx)
 
 	if m.limiter != nil {

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -243,16 +243,6 @@ func (m *Manager) handleOneDeploy(ctx context.Context, req DeployRequest, deploy
 			dc.Name, docker.DisplayContextName(dc.Context), err)
 	}
 
-	if m.limiter != nil {
-		deployLog.Debug("queuing deployment")
-
-		unlock, lErr := m.limiter.acquire(ctx, req.Repository.Name, NormalizeReference(dc.Reference))
-		if lErr != nil {
-			return lErr
-		}
-		defer unlock()
-	}
-
 	stageMgr, err := stages.NewStageManager(
 		stages.Dependencies{
 			AppConfig:      m.appConfig,
@@ -277,6 +267,18 @@ func (m *Manager) handleOneDeploy(ctx context.Context, req DeployRequest, deploy
 	)
 	if err != nil {
 		return err
+	}
+
+	stageMgr.PostQueuedCommitStatus(ctx)
+
+	if m.limiter != nil {
+		deployLog.Debug("queuing deployment")
+
+		unlock, lErr := m.limiter.acquire(ctx, req.Repository.Name, NormalizeReference(dc.Reference))
+		if lErr != nil {
+			return lErr
+		}
+		defer unlock()
 	}
 
 	err = stageMgr.RunStages(ctx)

--- a/internal/reconciliation/deploy.go
+++ b/internal/reconciliation/deploy.go
@@ -155,8 +155,10 @@ func (m *Manager) handleDeploy(ctx context.Context, req DeployRequest) error {
 	close(resultCh)
 
 	var (
-		errs         []error
-		successCount int
+		errs            []error
+		successCount    int
+		skipCount       int
+		filterSkipCount int
 	)
 
 	for e := range resultCh {
@@ -166,7 +168,13 @@ func (m *Manager) handleDeploy(ctx context.Context, req DeployRequest) error {
 		}
 
 		if errors.Is(e, stages.ErrWebhookFilterMismatch) {
-			continue // counted implicitly via successCount staying 0
+			filterSkipCount++
+			continue
+		}
+
+		if errors.Is(e, stages.ErrSkipDeployment) {
+			skipCount++
+			continue
 		}
 
 		errs = append(errs, e)
@@ -177,8 +185,13 @@ func (m *Manager) handleDeploy(ctx context.Context, req DeployRequest) error {
 	}
 
 	if successCount == 0 && len(req.DeployConfigs) > 0 {
-		// All deployments were skipped by the webhook filter
-		return stages.ErrWebhookFilterMismatch
+		if filterSkipCount == len(req.DeployConfigs) {
+			return stages.ErrWebhookFilterMismatch
+		}
+
+		if skipCount+filterSkipCount == len(req.DeployConfigs) {
+			return stages.ErrSkipDeployment
+		}
 	}
 
 	return nil

--- a/internal/source/oci/service_test.go
+++ b/internal/source/oci/service_test.go
@@ -176,7 +176,7 @@ func TestSyncDirectoryContents_PreservesDestinationInode(t *testing.T) {
 	// The destination directory inode must be unchanged.
 	inodeAfter := dirInode(t, dst)
 	if inodeBefore != inodeAfter {
-		t.Fatalf("destination inode changed: before=%d after=%d — bind mounts would be broken", inodeBefore, inodeAfter)
+		t.Fatalf("destination inode changed: before=%d after=%d; bind mounts would be broken", inodeBefore, inodeAfter)
 	}
 
 	// The new file must be present.

--- a/internal/stages/run.go
+++ b/internal/stages/run.go
@@ -118,15 +118,10 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 			stageLog.Debug(string("end stage early: "+stageName),
 				slog.String("reason", err.Error()),
 				slog.String("duration", metadata.FinishedAt.Sub(metadata.StartedAt).Truncate(time.Millisecond).String()))
-			// If the error is ErrSkipDeployment, we don't treat it as a failure.
-			// ErrWebhookFilterMismatch wraps ErrSkipDeployment but must propagate so
-			// the HTTP handler can return a "skipped" response rather than "success".
+			// Skip outcomes propagate without failure reporting so callers can
+			// distinguish an intentional no-op from a successful deployment.
 			if errors.Is(err, ErrSkipDeployment) {
-				if errors.Is(err, ErrWebhookFilterMismatch) {
-					return err
-				}
-
-				return nil
+				return err
 			}
 
 			s.recordDeploymentFailure(stageName, err)

--- a/internal/stages/run.go
+++ b/internal/stages/run.go
@@ -38,6 +38,10 @@ func shouldPostFailureCommitStatus(destroyEnabled bool) bool {
 	return !destroyEnabled
 }
 
+func shouldPostWebhookCommitStatus(jobTrigger JobTrigger, destroyEnabled bool) bool {
+	return jobTrigger == JobTriggerWebhook && !destroyEnabled
+}
+
 func failureCommitStatusState(stageName StageName) commitstatus.State {
 	switch stageName {
 	case StageInit, StagePreDeploy:
@@ -121,6 +125,10 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 			// Skip outcomes propagate without failure reporting so callers can
 			// distinguish an intentional no-op from a successful deployment.
 			if errors.Is(err, ErrSkipDeployment) {
+				if shouldPostWebhookCommitStatus(s.JobTrigger, s.DeployConfig.Destroy.Enabled) {
+					s.PostCommitStatus(ctx, commitstatus.StateSuccess, "Skipped")
+				}
+
 				return err
 			}
 
@@ -163,6 +171,14 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 	s.clearDeploymentFailure()
 
 	return nil
+}
+
+// PostQueuedCommitStatus reports that a resolved webhook deployment is waiting
+// to run. Poll and destroy operations do not publish queued statuses.
+func (s *StageManager) PostQueuedCommitStatus(ctx context.Context) {
+	if shouldPostWebhookCommitStatus(s.JobTrigger, s.DeployConfig.Destroy.Enabled) {
+		s.PostCommitStatus(ctx, commitstatus.StatePending, "Queued")
+	}
 }
 
 // stageRecordsDeploymentFailure reports whether a failure of the stage must be

--- a/internal/stages/run.go
+++ b/internal/stages/run.go
@@ -125,11 +125,6 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 			// Skip outcomes propagate without failure reporting so callers can
 			// distinguish an intentional no-op from a successful deployment.
 			if errors.Is(err, ErrSkipDeployment) {
-				if !errors.Is(err, ErrWebhookFilterMismatch) &&
-					shouldPostWebhookCommitStatus(s.JobTrigger, s.DeployConfig.Destroy.Enabled) {
-					s.PostCommitStatus(ctx, commitstatus.StateSuccess, "No changes")
-				}
-
 				return err
 			}
 
@@ -156,8 +151,9 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 			startedNotified = true
 		}
 
-		// Post "pending" once the repository/commit has been resolved.
+		// Post pending statuses only after pre-deploy confirms work is required.
 		if shouldPostPendingCommitStatus(stageName, s.DeployConfig.Destroy.Enabled, pendingPosted) {
+			s.PostQueuedCommitStatus(ctx)
 			s.PostCommitStatus(ctx, commitstatus.StatePending, "In Progress")
 
 			pendingPosted = true
@@ -174,8 +170,8 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 	return nil
 }
 
-// PostQueuedCommitStatus reports that a resolved webhook deployment is waiting
-// to run. Poll and destroy operations do not publish queued statuses.
+// PostQueuedCommitStatus reports a resolved webhook deployment that requires
+// work. Poll and destroy operations do not publish queued statuses.
 func (s *StageManager) PostQueuedCommitStatus(ctx context.Context) {
 	if shouldPostWebhookCommitStatus(s.JobTrigger, s.DeployConfig.Destroy.Enabled) {
 		s.PostCommitStatus(ctx, commitstatus.StatePending, "Queued")

--- a/internal/stages/run.go
+++ b/internal/stages/run.go
@@ -125,8 +125,9 @@ func (s *StageManager) RunStages(ctx context.Context) error {
 			// Skip outcomes propagate without failure reporting so callers can
 			// distinguish an intentional no-op from a successful deployment.
 			if errors.Is(err, ErrSkipDeployment) {
-				if shouldPostWebhookCommitStatus(s.JobTrigger, s.DeployConfig.Destroy.Enabled) {
-					s.PostCommitStatus(ctx, commitstatus.StateSuccess, "Skipped")
+				if !errors.Is(err, ErrWebhookFilterMismatch) &&
+					shouldPostWebhookCommitStatus(s.JobTrigger, s.DeployConfig.Destroy.Enabled) {
+					s.PostCommitStatus(ctx, commitstatus.StateSuccess, "No changes")
 				}
 
 				return err

--- a/internal/stages/run_test.go
+++ b/internal/stages/run_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/kimdre/doco-cd/internal/commitstatus"
+	"github.com/kimdre/doco-cd/internal/config/deploy"
+	"github.com/kimdre/doco-cd/internal/webhook"
 )
 
 func TestSuccessfulCommitStatusDescription(t *testing.T) {
@@ -188,6 +190,39 @@ func TestShouldPostWebhookCommitStatus(t *testing.T) {
 			got := shouldPostWebhookCommitStatus(tt.jobTrigger, tt.destroyEnabled)
 			if got != tt.want {
 				t.Fatalf("shouldPostWebhookCommitStatus() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchesWebhookEventFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		trigger JobTrigger
+		filter  string
+		ref     string
+		want    bool
+	}{
+		{name: "matching webhook", trigger: JobTriggerWebhook, filter: `^refs/heads/main$`, ref: "refs/heads/main", want: true},
+		{name: "non-matching webhook", trigger: JobTriggerWebhook, filter: `^refs/heads/main$`, ref: "refs/heads/feature", want: false},
+		{name: "webhook without filter", trigger: JobTriggerWebhook, ref: "refs/heads/feature", want: true},
+		{name: "poll ignores filter", trigger: JobTriggerPoll, filter: `^refs/heads/main$`, ref: "refs/heads/feature", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sm := &StageManager{
+				JobTrigger:   tt.trigger,
+				DeployConfig: &deploy.Config{WebhookEventFilter: tt.filter},
+				Payload:      &webhook.ParsedPayload{Ref: tt.ref},
+			}
+
+			if got := sm.MatchesWebhookEventFilter(); got != tt.want {
+				t.Fatalf("MatchesWebhookEventFilter() = %t, want %t", got, tt.want)
 			}
 		})
 	}

--- a/internal/stages/run_test.go
+++ b/internal/stages/run_test.go
@@ -171,6 +171,28 @@ func TestShouldPostFailureCommitStatus(t *testing.T) {
 	}
 }
 
+func TestShouldPostWebhookCommitStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		jobTrigger     JobTrigger
+		destroyEnabled bool
+		want           bool
+	}{
+		{name: "webhook deployment", jobTrigger: JobTriggerWebhook, want: true},
+		{name: "poll deployment", jobTrigger: JobTriggerPoll, want: false},
+		{name: "webhook destroy", jobTrigger: JobTriggerWebhook, destroyEnabled: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldPostWebhookCommitStatus(tt.jobTrigger, tt.destroyEnabled)
+			if got != tt.want {
+				t.Fatalf("shouldPostWebhookCommitStatus() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFailureCommitStatusState(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/stages/stage_1_init.go
+++ b/internal/stages/stage_1_init.go
@@ -47,8 +47,7 @@ func (s *StageManager) RunInitStage(ctx context.Context, stageLog *slog.Logger) 
 	if s.JobTrigger == JobTriggerWebhook {
 		// Skip deployment if the webhook event does not match the filter
 		if s.DeployConfig.WebhookEventFilter != "" {
-			filter := regexp.MustCompile(s.DeployConfig.WebhookEventFilter)
-			if !filter.MatchString(s.Payload.Ref) {
+			if !s.MatchesWebhookEventFilter() {
 				stageLog.Debug("reference does not match the webhook event filter, skipping deployment",
 					slog.String("webhook_filter", s.DeployConfig.WebhookEventFilter), slog.String("ref", s.Payload.Ref))
 
@@ -271,4 +270,14 @@ func (s *StageManager) RunInitStage(ctx context.Context, stageLog *slog.Logger) 
 	}
 
 	return nil
+}
+
+// MatchesWebhookEventFilter reports whether this run should proceed based on
+// its trigger, configured webhook filter, and payload reference.
+func (s *StageManager) MatchesWebhookEventFilter() bool {
+	if s.JobTrigger != JobTriggerWebhook || s.DeployConfig.WebhookEventFilter == "" {
+		return true
+	}
+
+	return s.Payload != nil && regexp.MustCompile(s.DeployConfig.WebhookEventFilter).MatchString(s.Payload.Ref)
 }

--- a/internal/stages/types_commitstatus_test.go
+++ b/internal/stages/types_commitstatus_test.go
@@ -1,9 +1,13 @@
 package stages
 
 import (
+	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	gitInternal "github.com/kimdre/doco-cd/internal/git"
@@ -50,6 +54,42 @@ func TestResolveCommitStatusRequest_DelegatesToCommitStatusPackage(t *testing.T)
 
 	if req.Context != "doco-cd/stack" {
 		t.Fatalf("expected context derived from deploy config, got %q", req.Context)
+	}
+}
+
+func TestPostQueuedCommitStatusUsesDeploymentContext(t *testing.T) {
+	gitInternal.ConfigureAuthResolver(nil, "", "", "pat-token", "", gitInternal.GitHubAppConfig{})
+	t.Cleanup(func() {
+		gitInternal.ConfigureAuthResolver(nil, "", "", "", "", gitInternal.GitHubAppConfig{})
+	})
+
+	var received map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode status request: %v", err)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	sm := newTestStageManagerForCommitStatus(&app.Config{
+		GitCommitStatus: true,
+		GitScmProvider:  "gitea",
+		GitScmApiUrl:    config.HttpUrl(server.URL),
+		GitAccessToken:  "pat-token",
+	}, server.URL+"/org/repo.git")
+	sm.JobTrigger = JobTriggerWebhook
+
+	sm.PostQueuedCommitStatus(t.Context())
+
+	if received["state"] != "pending" || received["description"] != "Queued" {
+		t.Fatalf("unexpected queued status: %v", received)
+	}
+
+	if received["context"] != "doco-cd/stack" {
+		t.Fatalf("expected deployment-specific context, got %q", received["context"])
 	}
 }
 

--- a/wiki/docs/Advanced/Docker-API-Permissions.md
+++ b/wiki/docs/Advanced/Docker-API-Permissions.md
@@ -134,7 +134,7 @@ which maps Docker API resources to environment variables.
 
 !!! info "Other proxies use different variable names"
     Environment variable names differ between socket proxy implementations.
-    The **Docker API endpoint tables above are the source of truth** — map them to whatever
+    The **Docker API endpoint tables above are the source of truth**. Map them to whatever
     your proxy of choice expects.
 
 ```yaml title="docker-compose.yml"
@@ -197,7 +197,7 @@ volumes:
 1. Needed to wait for Swarm services to converge. Without it every Swarm deployment fails with `403 Forbidden`.
 2. Required for recreating containers, rotating configs/secrets and `remove_orphans`. Set to `0` only if you accept that redeployments will fail.
 3. Point doco-cd at the proxy instead of mounting the socket. See [Docker Settings](../Docker-Settings.md).
-4. The Docker socket is no longer mounted here — only the data volume remains.
+4. The Docker socket is no longer mounted here; only the data volume remains.
 
 ### Minimal standalone (Compose only) configuration
 

--- a/wiki/docs/Advanced/Docker-Contexts.md
+++ b/wiki/docs/Advanced/Docker-Contexts.md
@@ -52,7 +52,7 @@ services:
 
 The SSH key used must:
 
-- Be **passphrase-free** — Docker's SSH transport runs `ssh` non-interactively inside the container; a passphrase prompt will cause the connection to fail with `Permission denied`
+- Be **passphrase-free** because Docker's SSH transport runs `ssh` non-interactively inside the container; a passphrase prompt will cause the connection to fail with `Permission denied`
 - Have the corresponding **public key in `~/.ssh/authorized_keys`** on the remote host for the connecting user
 - Be a supported key type (Ed25519 recommended: `ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_doco-cd -N ""`)
 
@@ -114,8 +114,8 @@ services:
       - ~/.ssh:/root/.ssh:ro       # (2)!
 ```
 
-1. Docker context metadata and credentials — required for all non-default contexts
-2. SSH keys and `known_hosts` — required for SSH contexts only
+1. Docker context metadata and credentials, required for all non-default contexts
+2. SSH keys and `known_hosts`, required for SSH contexts only
 
 !!! warning "File permissions"
     The mounted `~/.docker` and `~/.ssh` directories (and all files within them) must be **readable by the user running inside the container** (root by default).
@@ -188,7 +188,7 @@ volumes:
   - /data/myapp:/app/data  # ← this path must exist on the remote host
 ```
 
-Named volumes work fine — they are created on the remote host automatically:
+Named volumes work fine because they are created on the remote host automatically:
 
 ```yaml
 volumes:
@@ -202,7 +202,7 @@ services:
 
 ### Configs and secrets with `file:` sources
 
-Docker Compose resolves `file:` references to absolute paths on the doco-cd host, then sends those paths to the remote daemon. The remote daemon tries to bind-mount them locally — and fails because the files don't exist there.
+Docker Compose resolves `file:` references to absolute paths on the doco-cd host, then sends those paths to the remote daemon. The remote daemon tries to bind-mount them locally and fails because the files don't exist there.
 
 ```yaml
 # ✗ Will fail on remote contexts because the remote daemon can't access this path
@@ -237,5 +237,5 @@ secrets:
 
 === "Docker Swarm"
 
-    Swarm secrets and configs are uploaded to the cluster and distributed automatically — they work correctly with remote contexts.
+    Swarm secrets and configs are uploaded to the cluster and distributed automatically, so they work correctly with remote contexts.
     See [Swarm Mode](Swarm-Mode.md) for details.

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -234,7 +234,7 @@ Behavior:
 ??? note "Concurrency and shared targets"
     While services are held stopped, doco-cd locks the job's own stack **and** every stack referenced by `cd.doco.job.stop_services`, so a concurrent deployment or another scheduled run cannot race with the reconciliation of those stacks.
 
-    If two scheduled jobs happen to list the same target service (e.g. two backup jobs sharing a cache), the target is only actually restarted once every job that stopped it has finished — it will not be brought back up prematurely while another job still needs it stopped.
+    If two scheduled jobs happen to list the same target service (e.g. two backup jobs sharing a cache), the target is only actually restarted once every job that stopped it has finished. It will not be brought back up prematurely while another job still needs it stopped.
 
 ## Examples
 

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -95,16 +95,16 @@ When a notification is sent, the following metadata fields are included in the n
 
 ## Custom notification body
 
-By default the notification body is the message followed by the [metadata fields](#metadata-fields) as `key: value` lines. Set `APPRISE_NOTIFY_BODY_TEMPLATE` (or `APPRISE_NOTIFY_BODY_TEMPLATE_FILE`) to a [Go `text/template`](https://pkg.go.dev/text/template) to render the body yourself — useful to drop noisy fields, add a host label, or produce a one-liner when several stacks report into one channel.
+By default the notification body is the message followed by the [metadata fields](#metadata-fields) as `key: value` lines. Set `APPRISE_NOTIFY_BODY_TEMPLATE` (or `APPRISE_NOTIFY_BODY_TEMPLATE_FILE`) to a [Go `text/template`](https://pkg.go.dev/text/template) to render the body yourself. This is useful to drop noisy fields, add a host label, or produce a one-liner when several stacks report into one channel.
 
 The template is validated at startup: a syntax error or a reference to an unknown field stops doco-cd from starting. The title (emoji + optional `[R]` marker + title text) is not affected by the template.
 
 !!! warning "Don't swallow failure reasons"
 
-    The template replaces the default body for **every** notification level, and on `failure` the error text is only carried by `{{ .Message }}` — a template that never references it produces failure notifications with no failure reason at all (the title only says `Deployment failed`; the details then live only in the logs). On `success`, `.Message` is largely redundant with the title, so compact templates should include it guarded by level:
+    The template replaces the default body for **every** notification level, and on `failure` the error text is only carried by `{{ .Message }}`. A template that never references it produces failure notifications with no failure reason at all (the title only says `Deployment failed`; the details then live only in the logs). On `success`, `.Message` is largely redundant with the title, so compact templates should include it guarded by level:
 
     ```
-    {{ if ne .Level "success" }} — {{ .Message }}{{ end }}
+    {{ if ne .Level "success" }} - {{ .Message }}{{ end }}
     ```
 
 The following fields are available:
@@ -128,7 +128,7 @@ The following fields are available:
 | `.AffectedActorID`    | Affected container/service ID                                            |
 | `.AffectedActorName`  | Affected container/service name                                          |
 | `.Commits`            | Commits deployed since the last deploy (see [Commit changelog](#commit-changelog)) |
-| `.Duration`           | Time the deployment (or destroy) took, from job start to the notification, e.g. `12.483s`. Zero where no deployment ran (reconciliation restarts, scheduled jobs) — hide it with `{{if .Duration}}...{{end}}` |
+| `.Duration`           | Time the deployment (or destroy) took, from job start to the notification, e.g. `12.483s`. Zero where no deployment ran (reconciliation restarts, scheduled jobs); hide it with `{{if .Duration}}...{{end}}` |
 | `.ChangedServices`    | Sorted names of the services changed by this deploy: force-recreated ones (changed mounted/referenced files or a changed auto-discovery label) plus services whose image digest changed in the registry (detected with [`force_image_pull`](../Deploy-Settings.md)). Empty when the whole stack is (re)deployed for other reasons, e.g. a compose config change (including image tag changes in the compose file), state drift or `force_recreate` |
 
 `{{ .DefaultBody }}` renders the built-in body (message + metadata), so you can extend the default format instead of replacing it, e.g. `{{ .DefaultBody }}\nhost: my-vm`.
@@ -137,10 +137,10 @@ The following fields are available:
 
     ```yaml
     environment:
-      APPRISE_NOTIFY_BODY_TEMPLATE: "{{.Emoji}} {{if .Target}}{{.Target}}/{{end}}{{.Stack}} — {{.Message}} ({{.Revision}})"
+      APPRISE_NOTIFY_BODY_TEMPLATE: "{{.Emoji}} {{if .Target}}{{.Target}}/{{end}}{{.Stack}} - {{.Message}} ({{.Revision}})"
     ```
 
-    renders e.g. `✅ prod-vm/app — Successfully deployed stack app (main (abc123))` for target `prod-vm`, or `✅ app — Successfully deployed stack app (main (abc123))` without a custom target.
+    renders e.g. `✅ prod-vm/app - Successfully deployed stack app (main (abc123))` for target `prod-vm`, or `✅ app - Successfully deployed stack app (main (abc123))` without a custom target.
 
 ### Commit changelog
 

--- a/wiki/docs/Advanced/Tips-and-Tricks.md
+++ b/wiki/docs/Advanced/Tips-and-Tricks.md
@@ -23,7 +23,7 @@ include:
 
 ### Resolving `.env` and other relative paths
 
-When a remote compose file references relative paths — most commonly `env_file: .env` in a service definition — Docker Compose resolves those paths against the remote include's own directory inside doco-cd's internal cache, **not** against your deployment repository.
+When a remote compose file references relative paths, most commonly `env_file: .env` in a service definition, Docker Compose resolves those paths against the remote include's own directory inside doco-cd's internal cache, **not** against your deployment repository.
 
 This means a deployment like the following will fail with *"env file … not found"* even if `.env` exists in your repository:
 

--- a/wiki/docs/App-Settings.md
+++ b/wiki/docs/App-Settings.md
@@ -229,16 +229,16 @@ If you want to pull images from a private registry, see [Container Registry Auth
 
 `SOURCE_URL_REWRITES` (and `SOURCE_URL_REWRITES_FILE`) let you rewrite git source URLs before doco-cd clones them. Rules apply to both webhook- and poll-triggered deployments.
 
-This is useful when your Git provider advertises a public URL (in webhook payloads or poll configs) but doco-cd should clone through an internal network path instead — for example when your Forgejo instance is behind a reverse proxy with a public domain, but is reachable directly over a Docker network.
+This is useful when your Git provider advertises a public URL (in webhook payloads or poll configs) but doco-cd should clone through an internal network path instead, for example when your Forgejo instance is behind a reverse proxy with a public domain, but is reachable directly over a Docker network.
 
 Two match strategies are supported:
 
-- **URL/URI prefix** — e.g. `https://forgejo.example.com/` or `git@forgejo.example.com:`.
+- **URL/URI prefix**, e.g. `https://forgejo.example.com/` or `git@forgejo.example.com:`.
   The matched prefix in the source URL is replaced with the configured target, and the repository path is appended as-is.
     - HTTPS URLs should end with `/` to avoid partial host matches.
-    - SCP-style SSH URLs (e.g. `git@host:`) **must** end with `:` — it is the mandatory separator between host and repository path in SCP syntax (`user@host:path/repo.git`).
+    - SCP-style SSH URLs (e.g. `git@host:`) **must** end with `:` because it is the mandatory separator between host and repository path in SCP syntax (`user@host:path/repo.git`).
     - SCP syntax cannot express a port number. Use `ssh://` syntax when targeting a non-standard port (e.g. `"ssh://git@forgejo.internal:2222/"`).
-- **Host/domain** — e.g. `forgejo.example.com`. Only the host (and optional port) is replaced; scheme, credentials, and path are preserved.
+- **Host/domain**, e.g. `forgejo.example.com`. Only the host (and optional port) is replaced; scheme, credentials, and path are preserved.
 
 Rules are matched in order of specificity (longest key first).
 

--- a/wiki/docs/Core-Concepts.md
+++ b/wiki/docs/Core-Concepts.md
@@ -32,7 +32,7 @@ Doco-CD automatically detects whether the Docker daemon is running in Swarm mode
 
 ### Webhook
 An event-based HTTP notification sent by your Git provider (GitHub, GitLab, Gitea, etc.) to Doco-CD whenever a commit is pushed.
-Webhooks are the recommended trigger method — they are fast and efficient, but require Doco-CD to be reachable from the internet or local network.
+Webhooks are the recommended trigger method. They are fast and efficient, but require Doco-CD to be reachable from the internet or local network.
 
 Enabled by setting the `WEBHOOK_SECRET` environment variable. See [Setup Webhook](Setup-Webhook.md) and [Webhook Listener](Endpoints/Webhook-Listener.md) for details.
 

--- a/wiki/docs/Endpoints/MCP-Server.md
+++ b/wiki/docs/Endpoints/MCP-Server.md
@@ -108,7 +108,7 @@ x-api-key: your-api-key
 
 | Tool                    | Key Parameters                                                                                 | Description                                                                                                          |
 |-------------------------|------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `get_health`            | —                                                                                              | Verify access to the Docker API.                                                                                     |
+| `get_health`            | None                                                                                           | Verify access to the Docker API.                                                                                     |
 | `list_deployment_runs`  | `limit` (default 50, max 200), `status` (accepted/running/succeeded/failed/skipped), `trigger` | List recent deployment runs, optionally filtered by status and trigger.                                              |
 | `get_deployment_run`    | `job_id`                                                                                       | Get a deployment run by job ID.                                                                                      |
 | `list_scheduled_jobs`   | `stack` (filter), `context`                                                                    | List scheduler-managed jobs, optionally filtered by stack or Compose project.                                        |

--- a/wiki/docs/External-Secrets/Openbao.md
+++ b/wiki/docs/External-Secrets/Openbao.md
@@ -183,7 +183,7 @@ services:
 ```
 
 Enable `CERT_ROTATION_ENABLED=true` on the doco-cd instance, and the client certificate will be
-reissued and redeployed automatically before it expires — mTLS handshakes never fail due to an
+reissued and redeployed automatically before it expires, so mTLS handshakes never fail due to an
 expired client certificate.
 
 #### Private PKI

--- a/wiki/docs/Git-Settings.md
+++ b/wiki/docs/Git-Settings.md
@@ -32,12 +32,12 @@ Supported authentication methods:
 
 | Key                               | Type   | Description                                                                                                                                                                                                                                                                             | Default                                          |
 |-----------------------------------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
-| `GIT_ACCESS_TOKEN`                | string | Access token for cloning repositories (required for private repositories) via **HTTP**. See [Setup Access Token](Setup-Access-Token.md), [Required Token Permissions](#required-token-permissions), and [Domain-scoped Authentication](#domain-scoped-authentication). | Optional for public repositories but recommended |
+| `GIT_ACCESS_TOKEN`                | string | Access token for cloning repositories (required for private repositories) via **HTTP**. See [Setup Access Token](Setup-Access-Token.md), [Required Token Permissions](#required-token-permissions), and [Domain-scoped Authentication](#domain-scoped-authentication).                  | Optional for public repositories but recommended |
 | `GIT_ACCESS_TOKEN_USER`           | string | Username paired with `GIT_ACCESS_TOKEN` for **HTTP(S)** clone/fetch. Most providers accept any non-empty value, but some require a specific username for their token (e.g. a GitLab **deploy token** uses `gitlab+deploy-token-1234567`). Set it when your provider needs one.          | `oauth2`                                         |
 | `GIT_ACCESS_TOKEN_FILE`           | string | Path to the file containing the Git Access Token (mutually exclusive with `GIT_ACCESS_TOKEN`).                                                                                                                                                                                          |                                                  |
 | `GIT_AUTH_DOMAINS`                | list   | YAML list of domain-scoped Git credentials (HTTP token, SSH key, and GitHub App credentials). Supports exact domains and wildcard subdomains like `*.example.com` (see [Domain-scoped authentication](#domain-scoped-authentication)). Mutually exclusive with `GIT_AUTH_DOMAINS_FILE`. |                                                  |
 | `GIT_AUTH_DOMAINS_FILE`           | string | Path to a file containing the YAML configuration for `GIT_AUTH_DOMAINS` (mutually exclusive with `GIT_AUTH_DOMAINS`).                                                                                                                                                                   |                                                  |
-| `SSH_PRIVATE_KEY`                 | string | The private key used for cloning repositories via SSH. See [Setup SSH Key](Setup-SSH-Key.md) and [Domain-scoped Authentication](#domain-scoped-authentication).                                                                                                                    |                                                  |
+| `SSH_PRIVATE_KEY`                 | string | The private key used for cloning repositories via SSH. See [Setup SSH Key](Setup-SSH-Key.md) and [Domain-scoped Authentication](#domain-scoped-authentication).                                                                                                                         |                                                  |
 | `SSH_PRIVATE_KEY_FILE`            | string | Path to the file containing the SSH private key.                                                                                                                                                                                                                                        |                                                  |
 | `SSH_PRIVATE_KEY_PASSPHRASE`      | string | Passphrase for the SSH private key (if the key was generated with a passphrase).                                                                                                                                                                                                        |                                                  |
 | `SSH_PRIVATE_KEY_PASSPHRASE_FILE` | string | Path to the file containing the SSH private key passphrase.                                                                                                                                                                                                                             |                                                  |
@@ -156,17 +156,15 @@ Doco-CD can post a commit status back to the source Git provider after each depl
 
 This closes the GitOps feedback loop: instead of only seeing success or failure in container logs or Apprise notifications, the commit itself is marked with the deployment outcome.
 
-For asynchronous webhooks, Doco-CD immediately creates an aggregate `doco-cd/deploy` status after the event is admitted to the queue. Its lifecycle is:
+Once a webhook's deployment configuration is resolved, Doco-CD reports each deployment under its own context, such as `doco-cd/<target>/<project>`:
 
-- **pending / Queued** — the webhook event was accepted and is waiting to run.
-- **pending / In Progress** — processing started after the repository deployment lock was acquired.
-- **success**, **failure**, or **error** — processing reached its final outcome. Intentionally skipped events complete the aggregate status successfully with the description `Skipped`.
+- **pending / Queued**: the deployment is waiting to run.
+- **pending / In Progress**: the deployment has started.
+- **success**: set when all deployment stages complete successfully.
+- **success / Skipped**: set when the deployment intentionally performs no work.
+- **failure**: set when any stage fails after initialization.
 
-Synchronous webhooks (`wait=true`) start with `In Progress` because they are not queued. Doco-CD also keeps reporting stack-specific statuses once repository configuration is available:
-
-- **pending** — set once after the repository is cloned and the stack deployment begins.
-- **success** — set when all deployment stages complete successfully.
-- **failure** — set when any stage fails after initialisation.
+The generic `doco-cd/deploy` context is reserved for failures that happen before deployment configuration can be resolved.
 
 | Key                 | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                           | Default |
 |---------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
@@ -218,7 +216,7 @@ Doco-CD derives the SCM API base URL from the clone URL by converting its scheme
 
 **SSH clone URL with a non-standard SSH port**
 
-When the clone URL is an SSH URL with a custom port (e.g. `ssh://git@gitea.example.com:2222/org/repo.git`), doco-cd strips the port before building the API URL — so the API call targets `https://gitea.example.com/...` correctly. If for any reason this stripping doesn't produce the right host or port (e.g. the HTTPS endpoint is on a non-standard port), set the API base URL explicitly:
+When the clone URL is an SSH URL with a custom port (e.g. `ssh://git@gitea.example.com:2222/org/repo.git`), doco-cd strips the port before building the API URL so the API call targets `https://gitea.example.com/...` correctly. If for any reason this stripping doesn't produce the right host or port (e.g. the HTTPS endpoint is on a non-standard port), set the API base URL explicitly:
 
 ```yaml
 GIT_SCM_API_URL: "https://gitea.example.com:8443"

--- a/wiki/docs/Git-Settings.md
+++ b/wiki/docs/Git-Settings.md
@@ -156,9 +156,15 @@ Doco-CD can post a commit status back to the source Git provider after each depl
 
 This closes the GitOps feedback loop: instead of only seeing success or failure in container logs or Apprise notifications, the commit itself is marked with the deployment outcome.
 
-Three states are reported:
+For asynchronous webhooks, Doco-CD immediately creates an aggregate `doco-cd/deploy` status after the event is admitted to the queue. Its lifecycle is:
 
-- **pending** — set once after the repository is cloned and the deployment begins.
+- **pending / Queued** — the webhook event was accepted and is waiting to run.
+- **pending / In Progress** — processing started after the repository deployment lock was acquired.
+- **success**, **failure**, or **error** — processing reached its final outcome. Intentionally skipped events complete the aggregate status successfully with the description `Skipped`.
+
+Synchronous webhooks (`wait=true`) start with `In Progress` because they are not queued. Doco-CD also keeps reporting stack-specific statuses once repository configuration is available:
+
+- **pending** — set once after the repository is cloned and the stack deployment begins.
 - **success** — set when all deployment stages complete successfully.
 - **failure** — set when any stage fails after initialisation.
 

--- a/wiki/docs/Git-Settings.md
+++ b/wiki/docs/Git-Settings.md
@@ -161,10 +161,9 @@ Once a webhook's deployment configuration is resolved, Doco-CD reports each depl
 - **pending / Queued**: the deployment is waiting to run.
 - **pending / In Progress**: the deployment has started.
 - **success**: set when all deployment stages complete successfully.
-- **success / No changes**: set when a queued deployment does not require changes.
 - **failure**: set when any stage fails after initialization.
 
-Deployments excluded by a webhook reference filter do not receive deployment-specific statuses. When the entire webhook run is skipped, Doco-CD posts one **success / Skipped** status under the generic `doco-cd/deploy` context. This context is also used for failures that happen before deployment configuration can be resolved.
+Deployments excluded by a webhook reference filter or requiring no changes do not receive deployment-specific statuses. When the entire webhook run is skipped, Doco-CD posts one **success / Skipped** status under the generic `doco-cd/deploy` context. This context is also used for failures that happen before deployment configuration can be resolved.
 
 | Key                 | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                           | Default |
 |---------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|

--- a/wiki/docs/Git-Settings.md
+++ b/wiki/docs/Git-Settings.md
@@ -161,10 +161,10 @@ Once a webhook's deployment configuration is resolved, Doco-CD reports each depl
 - **pending / Queued**: the deployment is waiting to run.
 - **pending / In Progress**: the deployment has started.
 - **success**: set when all deployment stages complete successfully.
-- **success / Skipped**: set when the deployment intentionally performs no work.
+- **success / No changes**: set when a queued deployment does not require changes.
 - **failure**: set when any stage fails after initialization.
 
-The generic `doco-cd/deploy` context is reserved for failures that happen before deployment configuration can be resolved.
+Deployments excluded by a webhook reference filter do not receive deployment-specific statuses. When the entire webhook run is skipped, Doco-CD posts one **success / Skipped** status under the generic `doco-cd/deploy` context. This context is also used for failures that happen before deployment configuration can be resolved.
 
 | Key                 | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                           | Default |
 |---------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|


### PR DESCRIPTION
When a async webhook event gets queued before processing, a new commit status gets reported to the repo:

`doco-cd/deploy - Pending: Queued`