### PR TITLE
Fix OCI deployment path reconstruction for scheduled runs and cert rotation

### DIFF
--- a/internal/docker/cert_rotation_redeploy.go
+++ b/internal/docker/cert_rotation_redeploy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/compose/v5/pkg/api"
 
+	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/lock"
@@ -89,7 +90,7 @@ func RotateProjectCertificates(
 		return fmt.Errorf("select certificate-consuming services for rotation of %s: %w", ref.Project, err)
 	}
 
-	payload := certRotationPayload(labels)
+	payload := certRotationPayload(labels, resolvedSourceType(ref, opts.Scheduled))
 
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 	latestCommit := strings.TrimSpace(labels[DocoCDLabels.Deployment.CommitSHA])
@@ -134,7 +135,7 @@ func rotateSwarmProjectCertificates(
 		return fmt.Errorf("reload deploy config for cert rotation of %s: %w", ref.Project, err)
 	}
 
-	payload := certRotationPayload(labels)
+	payload := certRotationPayload(labels, resolvedSourceType(ref, certOpts.Scheduled))
 
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 	latestCommit := strings.TrimSpace(labels[DocoCDLabels.Deployment.CommitSHA])
@@ -183,14 +184,31 @@ func pruneSwarmStackRevisions(ctx context.Context, dockerCli command.Cli, stackN
 	}
 }
 
+// resolvedSourceType reports the source type whose on-disk layout ref's repository actually
+// matches, falling back to the labeled one when neither directory is present.
+func resolvedSourceType(ref composeScheduledServiceRef, opts ScheduledComposeOptions) config.SourceType {
+	_, sourceType, err := resolveScheduledSourceRepo(ref, opts.ComposeLoad.DataMountPath)
+	if err != nil {
+		return config.NormalizeSourceType(config.SourceType(ref.SourceType))
+	}
+
+	return sourceType
+}
+
 // certRotationPayload builds a synthetic payload for relabeling purposes only. CommitSHA is
 // intentionally left as the zero value: ParsedPayload.TriggerString() falls back to
 // CommitSHAString(), which itself returns "" for a zero hash instead of panicking, but Trigger is
 // set explicitly anyway so the resulting label clearly identifies this as a rotation-driven
 // redeploy rather than an empty commit SHA.
-func certRotationPayload(labels map[string]string) *webhook.ParsedPayload {
+//
+// sourceType is the source type that actually resolved for this deployment (see
+// resolvedSourceType), not necessarily the one its labels claim. A rotation redeploy only
+// recreates the certificate-consuming services, so writing the claimed value back would leave a
+// project whose services disagree about their own source - which is how a deployment ends up
+// resolving its repository directory under the wrong naming scheme in the first place.
+func certRotationPayload(labels map[string]string, sourceType config.SourceType) *webhook.ParsedPayload {
 	return &webhook.ParsedPayload{
-		Source:   webhook.PayloadSourceGit,
+		Source:   webhook.PayloadSource(SourceTypeLabelValue(string(sourceType), labels[DocoCDLabels.Source.Type])),
 		Trigger:  certRotationTrigger,
 		FullName: strings.TrimSpace(labels[DocoCDLabels.Source.Name]),
 		WebURL:   strings.TrimSpace(labels[DocoCDLabels.Source.URL]),

--- a/internal/docker/cert_rotation_redeploy.go
+++ b/internal/docker/cert_rotation_redeploy.go
@@ -195,17 +195,10 @@ func resolvedSourceType(ref composeScheduledServiceRef, opts ScheduledComposeOpt
 	return sourceType
 }
 
-// certRotationPayload builds a synthetic payload for relabeling purposes only. CommitSHA is
-// intentionally left as the zero value: ParsedPayload.TriggerString() falls back to
-// CommitSHAString(), which itself returns "" for a zero hash instead of panicking, but Trigger is
-// set explicitly anyway so the resulting label clearly identifies this as a rotation-driven
-// redeploy rather than an empty commit SHA.
-//
-// sourceType is the source type that actually resolved for this deployment (see
-// resolvedSourceType), not necessarily the one its labels claim. A rotation redeploy only
-// recreates the certificate-consuming services, so writing the claimed value back would leave a
-// project whose services disagree about their own source - which is how a deployment ends up
-// resolving its repository directory under the wrong naming scheme in the first place.
+// certRotationPayload builds a synthetic payload for relabeling rotated services.
+// Trigger identifies the rotation-driven redeploy, while CommitSHA remains unset.
+// sourceType reflects the source that actually resolved rather than a potentially stale label,
+// keeping recreated services consistent with the rest of the deployment.
 func certRotationPayload(labels map[string]string, sourceType config.SourceType) *webhook.ParsedPayload {
 	return &webhook.ParsedPayload{
 		Source:   webhook.PayloadSource(SourceTypeLabelValue(string(sourceType), labels[DocoCDLabels.Source.Type])),

--- a/internal/docker/cert_rotation_redeploy_test.go
+++ b/internal/docker/cert_rotation_redeploy_test.go
@@ -9,10 +9,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 	"github.com/kimdre/doco-cd/internal/filesystem"
+	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/lock"
+	"github.com/kimdre/doco-cd/internal/source/oci"
 	"github.com/kimdre/doco-cd/internal/test"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
@@ -554,5 +557,172 @@ external_secrets:
 
 	if gotCert != certPEM {
 		t.Errorf("expected service environment to carry the freshly issued certificate, got %q", gotCert)
+	}
+}
+
+// TestResolvedSourceType covers the source type a rotation writes back into the redeployed
+// services' labels. The labeled type is only a hint: it is wrong for every deployment created
+// before the source type label existed, so the on-disk layout decides and the label is used only
+// when neither directory is there to look at.
+func TestResolvedSourceType(t *testing.T) {
+	t.Parallel()
+
+	const (
+		artifactRef   = "ghcr.io/kimdre/doco-cd_tests:compose-oci"
+		repositoryURL = "https://example.com/owner/repo"
+	)
+
+	testCases := []struct {
+		name        string
+		sourceType  string
+		repoURL     string
+		existingDir func(dataMountPath string) string
+		want        config.SourceType
+	}{
+		{
+			name:       "oci label with the extracted artifact directory present",
+			sourceType: "oci",
+			repoURL:    artifactRef,
+			existingDir: func(dataMountPath string) string {
+				return filepath.Join(dataMountPath, oci.RepositoryNameFromArtifact(artifactRef))
+			},
+			want: config.SourceTypeOCI,
+		},
+		{
+			name:       "stale git label on an oci artifact resolves to oci",
+			sourceType: "git",
+			repoURL:    artifactRef,
+			existingDir: func(dataMountPath string) string {
+				return filepath.Join(dataMountPath, oci.RepositoryNameFromArtifact(artifactRef))
+			},
+			want: config.SourceTypeOCI,
+		},
+		{
+			name:       "git label with the checkout present stays git",
+			sourceType: "git",
+			repoURL:    repositoryURL,
+			existingDir: func(dataMountPath string) string {
+				return filepath.Join(dataMountPath, git.GetRepoName(repositoryURL))
+			},
+			want: config.SourceTypeGit,
+		},
+		{
+			name:       "no directory on disk keeps the labeled type",
+			sourceType: "oci",
+			repoURL:    artifactRef,
+			want:       config.SourceTypeOCI,
+		},
+		{
+			name:       "missing label defaults to git",
+			sourceType: "",
+			repoURL:    repositoryURL,
+			want:       config.SourceTypeGit,
+		},
+		{
+			// A repository URL that escapes the data mount makes both candidate paths
+			// unusable, so there is nothing on disk left to check and the labeled type
+			// (normalized) is all that remains.
+			name:       "unresolvable path falls back to the normalized label",
+			sourceType: "OCI",
+			repoURL:    "../../escape",
+			want:       config.SourceTypeOCI,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dataMountPath := t.TempDir()
+
+			if tc.existingDir != nil {
+				if err := os.MkdirAll(tc.existingDir(dataMountPath), 0o755); err != nil {
+					t.Fatalf("mkdir repo dir: %v", err)
+				}
+			}
+
+			ref := composeScheduledServiceRef{
+				Project:        "compose-oci",
+				RepositoryURL:  tc.repoURL,
+				SourceType:     tc.sourceType,
+				DeploymentName: "compose-oci",
+			}
+
+			opts := ScheduledComposeOptions{ComposeLoad: ComposeLoadOptions{DataMountPath: dataMountPath}}
+
+			if got := resolvedSourceType(ref, opts); got != tc.want {
+				t.Fatalf("expected source type %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// TestCertRotationPayload proves that a rotation stamps the resolved source type into the
+// payload instead of the hardcoded "git" it used to write. Rotation redeploys relabel the
+// certificate-consuming services, so a wrong value here is what leaves a project whose services
+// disagree about their own source in the first place.
+func TestCertRotationPayload(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		sourceType  config.SourceType
+		labeledType string
+		want        webhook.PayloadSource
+	}{
+		{
+			name:        "resolved oci type overrides a stale git label",
+			sourceType:  config.SourceTypeOCI,
+			labeledType: "git",
+			want:        webhook.PayloadSourceOCI,
+		},
+		{
+			name:        "resolved git type is preserved",
+			sourceType:  config.SourceTypeGit,
+			labeledType: "git",
+			want:        webhook.PayloadSourceGit,
+		},
+		{
+			name:        "empty resolved type falls back to the existing label",
+			sourceType:  "",
+			labeledType: "oci",
+			want:        webhook.PayloadSourceOCI,
+		},
+		{
+			name:        "neither known defaults to git",
+			sourceType:  "",
+			labeledType: "",
+			want:        webhook.PayloadSourceGit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			labels := map[string]string{
+				DocoCDLabels.Source.Type: tc.labeledType,
+				DocoCDLabels.Source.Name: "  owner/repo  ",
+				DocoCDLabels.Source.URL:  "  https://example.com/owner/repo  ",
+			}
+
+			payload := certRotationPayload(labels, tc.sourceType)
+
+			if payload.Source != tc.want {
+				t.Errorf("expected payload source %q, got %q", tc.want, payload.Source)
+			}
+
+			if payload.Trigger != certRotationTrigger {
+				t.Errorf("expected trigger %q, got %q", certRotationTrigger, payload.Trigger)
+			}
+
+			if payload.FullName != "owner/repo" {
+				t.Errorf("expected trimmed full name, got %q", payload.FullName)
+			}
+
+			if payload.WebURL != "https://example.com/owner/repo" {
+				t.Errorf("expected trimmed web url, got %q", payload.WebURL)
+			}
+		})
 	}
 }

--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -28,11 +28,9 @@ import (
 var (
 	ErrComposeScheduledMetadataUnavailable = errors.New("compose scheduled-job metadata unavailable")
 	ErrComposeScheduledServiceReplicated   = errors.New("standalone scheduled compose service must have exactly one replica")
-	// ErrComposeScheduledSourceUnavailable reports that a deployment's Git checkout or extracted
-	// OCI artifact is not (yet) present under the data mount, so its deploy config cannot be
-	// reloaded. It is transient right after startup, before the first poll has fetched the
-	// source, which is why callers that run on a timer treat it as "retry later" rather than as a
-	// deployment failure.
+	// ErrComposeScheduledSourceUnavailable reports that a deployment source is not yet on disk.
+	// This can occur before the first poll fetches it, so timer-based callers should retry rather
+	// than treat it as a deployment failure.
 	ErrComposeScheduledSourceUnavailable = errors.New("deployment source not available on disk")
 )
 
@@ -455,21 +453,10 @@ func loadComposeScheduledDeployConfig(
 	return deployConfig, repoPath, nil
 }
 
-// resolveScheduledSourceRepo returns the directory under dataMountPath that holds the
-// checked-out Git repository or the extracted OCI artifact for ref, mirroring how
-// source.Prepare names it at deploy time: git.GetRepoName for Git sources,
-// oci.RepositoryNameFromArtifact for OCI artifacts.
-//
-// The DocoCDLabels.Source.Type label picks the scheme, but it cannot be trusted on its own:
-// deployments created before that label existed, or relabeled by a redeploy path that never knew
-// the source type, carry "git" even though their source URL is an OCI artifact reference. The two
-// schemes only differ in the ":<tag>" suffix, which git.GetRepoName keeps and
-// VerifyAndSanitizePath then rewrites to "_<tag>", so a mislabeled OCI deployment always resolves
-// to a directory that was never created on disk. When the labeled scheme's directory is absent but
-// the other one exists, use that instead so such deployments still reload. The source type that
-// actually resolved is returned alongside the path so callers that relabel the redeployed
-// services (see certRotationPayload) write the corrected value back instead of persisting the
-// stale one.
+// resolveScheduledSourceRepo finds the prepared Git or OCI source directory.
+// It first uses the labeled source type to select the matching naming scheme.
+// If that directory is missing, it tries the other scheme to support legacy or
+// mislabeled deployments. The returned source type reflects the directory found.
 func resolveScheduledSourceRepo(ref composeScheduledServiceRef, dataMountPath string) (string, config.SourceType, error) {
 	labeled := config.NormalizeSourceType(config.SourceType(ref.SourceType))
 

--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -16,16 +16,24 @@ import (
 	containerTypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 
+	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
+	"github.com/kimdre/doco-cd/internal/source/oci"
 )
 
 var (
 	ErrComposeScheduledMetadataUnavailable = errors.New("compose scheduled-job metadata unavailable")
 	ErrComposeScheduledServiceReplicated   = errors.New("standalone scheduled compose service must have exactly one replica")
+	// ErrComposeScheduledSourceUnavailable reports that a deployment's Git checkout or extracted
+	// OCI artifact is not (yet) present under the data mount, so its deploy config cannot be
+	// reloaded. It is transient right after startup, before the first poll has fetched the
+	// source, which is why callers that run on a timer treat it as "retry later" rather than as a
+	// deployment failure.
+	ErrComposeScheduledSourceUnavailable = errors.New("deployment source not available on disk")
 )
 
 type composeScheduledServiceRef struct {
@@ -34,6 +42,7 @@ type composeScheduledServiceRef struct {
 	WorkingDir     string
 	ConfigFiles    []string
 	RepositoryURL  string
+	SourceType     string
 	DeploymentName string
 	ConfigTarget   string
 	Reference      string
@@ -342,6 +351,7 @@ func composeScheduledServiceRefFromLabels(labels map[string]string) (composeSche
 		WorkingDir:     strings.TrimSpace(labels[api.WorkingDirLabel]),
 		ConfigFiles:    splitCommaSeparatedLabelValues(labels[api.ConfigFilesLabel]),
 		RepositoryURL:  repositoryURL,
+		SourceType:     strings.TrimSpace(labels[DocoCDLabels.Source.Type]),
 		DeploymentName: strings.TrimSpace(labels[DocoCDLabels.Deployment.Name]),
 		ConfigTarget:   strings.TrimSpace(labels[DocoCDLabels.Deployment.ConfigTarget]),
 		Reference:      strings.TrimSpace(labels[DocoCDLabels.Deployment.TargetRef]),
@@ -379,6 +389,7 @@ func composeScheduledServiceRefFromSwarmLabels(labels map[string]string) (compos
 		Project:        project,
 		WorkingDir:     strings.TrimSpace(labels[DocoCDLabels.Deployment.WorkingDir]),
 		RepositoryURL:  repositoryURL,
+		SourceType:     strings.TrimSpace(labels[DocoCDLabels.Source.Type]),
 		DeploymentName: project,
 		ConfigTarget:   strings.TrimSpace(labels[DocoCDLabels.Deployment.ConfigTarget]),
 		Reference:      strings.TrimSpace(labels[DocoCDLabels.Deployment.TargetRef]),
@@ -401,12 +412,17 @@ func loadComposeScheduledDeployConfig(
 
 	dataMountPath := opts.ComposeLoad.DataMountPath
 
-	sourceRepoPath, err := filesystem.VerifyAndSanitizePath(
-		filepath.Join(dataMountPath, git.GetRepoName(ref.RepositoryURL)),
-		dataMountPath,
-	)
+	sourceRepoPath, _, err := resolveScheduledSourceRepo(ref, dataMountPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("resolve source repository path for scheduled service %s/%s: %w", ref.Project, ref.Service, err)
+	}
+
+	// deploy.GetConfigs would fail with a bare ENOENT here. Report the missing source as its own
+	// error instead so a deployment whose source has not been fetched yet is distinguishable from
+	// one whose config is genuinely broken.
+	if !filesystem.IsDir(sourceRepoPath) {
+		return nil, "", fmt.Errorf("%w: %s for scheduled service %s/%s",
+			ErrComposeScheduledSourceUnavailable, sourceRepoPath, ref.Project, ref.Service)
 	}
 
 	repoPath, err := resolveScheduledComposeRepoRoot(ref.WorkingDir, dataMountPath, sourceRepoPath)
@@ -437,6 +453,59 @@ func loadComposeScheduledDeployConfig(
 	}
 
 	return deployConfig, repoPath, nil
+}
+
+// resolveScheduledSourceRepo returns the directory under dataMountPath that holds the
+// checked-out Git repository or the extracted OCI artifact for ref, mirroring how
+// source.Prepare names it at deploy time: git.GetRepoName for Git sources,
+// oci.RepositoryNameFromArtifact for OCI artifacts.
+//
+// The DocoCDLabels.Source.Type label picks the scheme, but it cannot be trusted on its own:
+// deployments created before that label existed, or relabeled by a redeploy path that never knew
+// the source type, carry "git" even though their source URL is an OCI artifact reference. The two
+// schemes only differ in the ":<tag>" suffix, which git.GetRepoName keeps and
+// VerifyAndSanitizePath then rewrites to "_<tag>", so a mislabeled OCI deployment always resolves
+// to a directory that was never created on disk. When the labeled scheme's directory is absent but
+// the other one exists, use that instead so such deployments still reload. The source type that
+// actually resolved is returned alongside the path so callers that relabel the redeployed
+// services (see certRotationPayload) write the corrected value back instead of persisting the
+// stale one.
+func resolveScheduledSourceRepo(ref composeScheduledServiceRef, dataMountPath string) (string, config.SourceType, error) {
+	labeled := config.NormalizeSourceType(config.SourceType(ref.SourceType))
+
+	other := config.SourceTypeGit
+	if labeled == config.SourceTypeGit {
+		other = config.SourceTypeOCI
+	}
+
+	preferred := scheduledSourceRepoName(ref.RepositoryURL, labeled)
+	alternative := scheduledSourceRepoName(ref.RepositoryURL, other)
+
+	preferredPath, err := filesystem.VerifyAndSanitizePath(filepath.Join(dataMountPath, preferred), dataMountPath)
+	if err != nil {
+		return "", labeled, err
+	}
+
+	if preferred == alternative || filesystem.IsDir(preferredPath) {
+		return preferredPath, labeled, nil
+	}
+
+	alternativePath, err := filesystem.VerifyAndSanitizePath(filepath.Join(dataMountPath, alternative), dataMountPath)
+	if err == nil && filesystem.IsDir(alternativePath) {
+		return alternativePath, other, nil
+	}
+
+	return preferredPath, labeled, nil
+}
+
+// scheduledSourceRepoName names the data-mount-relative directory that sourceType's fetcher
+// extracts repositoryURL into, mirroring source.Prepare.
+func scheduledSourceRepoName(repositoryURL string, sourceType config.SourceType) string {
+	if sourceType == config.SourceTypeOCI {
+		return oci.RepositoryNameFromArtifact(repositoryURL)
+	}
+
+	return git.GetRepoName(repositoryURL)
 }
 
 // findComposeScheduledDeployConfig selects the deploy config matching the

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -283,7 +283,7 @@ func TestLoadComposeScheduledDeployConfigResolvesRepoPathBySourceType(t *testing
 		t.Helper()
 
 		content := fmt.Sprintf("name: %s\n", name)
-		if err := os.WriteFile(filepath.Join(repoDir, ".doco-cd.yaml"), []byte(content), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(repoDir, ".doco-cd.yaml"), []byte(content), 0o600); err != nil {
 			t.Fatalf("write deploy config: %v", err)
 		}
 	}

--- a/internal/docker/compose_scheduled_run_test.go
+++ b/internal/docker/compose_scheduled_run_test.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,8 +12,10 @@ import (
 	"github.com/docker/compose/v5/pkg/api"
 
 	"github.com/kimdre/doco-cd/internal/config/deploy"
+	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/secretprovider"
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
+	"github.com/kimdre/doco-cd/internal/source/oci"
 )
 
 // stubSecretProvider is a minimal SecretProvider whose ResolveSecretReferences
@@ -56,6 +59,7 @@ func TestComposeScheduledServiceRefFromLabels(t *testing.T) {
 			api.ConfigFilesLabel:                 "/repo/stack/compose.yaml, /repo/stack/compose.override.yaml",
 			DocoCDLabels.Source.Name:             "owner/repo",
 			DocoCDLabels.Source.URL:              "https://example.com/owner/repo",
+			DocoCDLabels.Source.Type:             "oci",
 			DocoCDLabels.Deployment.Name:         "stack-a",
 			DocoCDLabels.Deployment.ConfigTarget: "nas",
 			DocoCDLabels.Deployment.TargetRef:    "refs/heads/main",
@@ -81,6 +85,10 @@ func TestComposeScheduledServiceRefFromLabels(t *testing.T) {
 		// reconstruct a host-qualified repository path.
 		if ref.RepositoryURL != "https://example.com/owner/repo" {
 			t.Fatalf("unexpected repository url: %q", ref.RepositoryURL)
+		}
+
+		if ref.SourceType != "oci" {
+			t.Fatalf("unexpected source type: %q", ref.SourceType)
 		}
 
 		if ref.DeploymentName != "stack-a" {
@@ -184,6 +192,7 @@ func TestComposeScheduledServiceRefFromSwarmLabels(t *testing.T) {
 			DocoCDLabels.Deployment.WorkingDir:   "/repo/stack",
 			DocoCDLabels.Source.Name:             "owner/repo",
 			DocoCDLabels.Source.URL:              "https://example.com/owner/repo",
+			DocoCDLabels.Source.Type:             "oci",
 			DocoCDLabels.Deployment.ConfigTarget: "nas",
 			DocoCDLabels.Deployment.TargetRef:    "refs/heads/main",
 		})
@@ -209,6 +218,10 @@ func TestComposeScheduledServiceRefFromSwarmLabels(t *testing.T) {
 
 		if ref.RepositoryURL != "https://example.com/owner/repo" {
 			t.Fatalf("unexpected repository url: %q", ref.RepositoryURL)
+		}
+
+		if ref.SourceType != "oci" {
+			t.Fatalf("unexpected source type: %q", ref.SourceType)
 		}
 
 		if ref.ConfigTarget != "nas" {
@@ -255,6 +268,160 @@ func TestComposeScheduledServiceRefFromSwarmLabels(t *testing.T) {
 			t.Fatalf("expected ErrComposeScheduledMetadataUnavailable, got %v", err)
 		}
 	})
+}
+
+// TestLoadComposeScheduledDeployConfigResolvesRepoPathBySourceType reproduces the cert-rotation
+// bug where an OCI-sourced deployment's on-disk repository path was reconstructed with
+// git.GetRepoName() (which leaves the ":<tag>" suffix in place), pointing at a directory that
+// was never created on disk (the real directory, extracted at deploy time via
+// oci.RepositoryNameFromArtifact(), has no tag suffix). loadComposeScheduledDeployConfig must
+// branch on ref.SourceType the same way internal/source/prepare.go does for a fresh deploy.
+func TestLoadComposeScheduledDeployConfigResolvesRepoPathBySourceType(t *testing.T) {
+	t.Parallel()
+
+	writeDeployConfig := func(t *testing.T, repoDir, name string) {
+		t.Helper()
+
+		content := fmt.Sprintf("name: %s\n", name)
+		if err := os.WriteFile(filepath.Join(repoDir, ".doco-cd.yaml"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write deploy config: %v", err)
+		}
+	}
+
+	t.Run("oci source resolves repo path without the artifact tag", func(t *testing.T) {
+		t.Parallel()
+
+		dataMountPath := t.TempDir()
+		artifactRef := "ghcr.io/kimdre/doco-cd_tests:compose-oci"
+		repoDir := filepath.Join(dataMountPath, oci.RepositoryNameFromArtifact(artifactRef))
+
+		if err := os.MkdirAll(repoDir, 0o755); err != nil {
+			t.Fatalf("mkdir repo dir: %v", err)
+		}
+
+		writeDeployConfig(t, repoDir, "compose-oci")
+
+		ref := composeScheduledServiceRef{
+			Project:        "compose-oci",
+			RepositoryURL:  artifactRef,
+			SourceType:     "oci",
+			DeploymentName: "compose-oci",
+		}
+
+		opts := ScheduledComposeOptions{ComposeLoad: ComposeLoadOptions{DataMountPath: dataMountPath}}
+
+		cfg, repoPath, err := loadComposeScheduledDeployConfig(context.Background(), ref, newStubProvider(nil, nil), opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.Name != "compose-oci" {
+			t.Fatalf("unexpected config name: %q", cfg.Name)
+		}
+
+		if repoPath != repoDir {
+			t.Fatalf("expected repo path %q, got %q", repoDir, repoPath)
+		}
+	})
+
+	t.Run("stale git label on an oci artifact still finds the extracted directory", func(t *testing.T) {
+		t.Parallel()
+
+		dataMountPath := t.TempDir()
+		artifactRef := "ghcr.io/kimdre/doco-cd_tests:compose-oci"
+		repoDir := filepath.Join(dataMountPath, oci.RepositoryNameFromArtifact(artifactRef))
+
+		if err := os.MkdirAll(repoDir, 0o755); err != nil {
+			t.Fatalf("mkdir repo dir: %v", err)
+		}
+
+		writeDeployConfig(t, repoDir, "compose-oci")
+
+		// Deployments created before the source type label existed carry "git" even though the
+		// source URL is an OCI artifact reference, see resolveScheduledSourceRepoPath.
+		ref := composeScheduledServiceRef{
+			Project:        "compose-oci",
+			RepositoryURL:  artifactRef,
+			SourceType:     "git",
+			DeploymentName: "compose-oci",
+		}
+
+		opts := ScheduledComposeOptions{ComposeLoad: ComposeLoadOptions{DataMountPath: dataMountPath}}
+
+		cfg, repoPath, err := loadComposeScheduledDeployConfig(context.Background(), ref, newStubProvider(nil, nil), opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.Name != "compose-oci" {
+			t.Fatalf("unexpected config name: %q", cfg.Name)
+		}
+
+		if repoPath != repoDir {
+			t.Fatalf("expected repo path %q, got %q", repoDir, repoPath)
+		}
+	})
+
+	t.Run("git source still resolves repo path via git.GetRepoName", func(t *testing.T) {
+		t.Parallel()
+
+		dataMountPath := t.TempDir()
+		repositoryURL := "https://example.com/owner/repo"
+		repoDir := filepath.Join(dataMountPath, git.GetRepoName(repositoryURL))
+
+		if err := os.MkdirAll(repoDir, 0o755); err != nil {
+			t.Fatalf("mkdir repo dir: %v", err)
+		}
+
+		writeDeployConfig(t, repoDir, "stack-a")
+
+		ref := composeScheduledServiceRef{
+			Project:        "stack-a",
+			RepositoryURL:  repositoryURL,
+			SourceType:     "git",
+			DeploymentName: "stack-a",
+		}
+
+		opts := ScheduledComposeOptions{ComposeLoad: ComposeLoadOptions{DataMountPath: dataMountPath}}
+
+		cfg, repoPath, err := loadComposeScheduledDeployConfig(context.Background(), ref, newStubProvider(nil, nil), opts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if cfg.Name != "stack-a" {
+			t.Fatalf("unexpected config name: %q", cfg.Name)
+		}
+
+		if repoPath != repoDir {
+			t.Fatalf("expected repo path %q, got %q", repoDir, repoPath)
+		}
+	})
+}
+
+// TestLoadComposeScheduledDeployConfigReportsUnavailableSource covers the cold-start case the
+// certificate rotation watcher relies on: until the first poll has fetched a deployment's source
+// into the data mount, the reload must fail with ErrComposeScheduledSourceUnavailable so callers
+// can retry later instead of treating it as a broken deployment.
+func TestLoadComposeScheduledDeployConfigReportsUnavailableSource(t *testing.T) {
+	t.Parallel()
+
+	dataMountPath := t.TempDir()
+
+	ref := composeScheduledServiceRef{
+		Project:        "compose-oci",
+		Service:        "envoy",
+		RepositoryURL:  "ghcr.io/kimdre/doco-cd_tests:compose-oci",
+		SourceType:     "oci",
+		DeploymentName: "compose-oci",
+	}
+
+	opts := ScheduledComposeOptions{ComposeLoad: ComposeLoadOptions{DataMountPath: dataMountPath}}
+
+	_, _, err := loadComposeScheduledDeployConfig(context.Background(), ref, newStubProvider(nil, nil), opts)
+	if !errors.Is(err, ErrComposeScheduledSourceUnavailable) {
+		t.Fatalf("expected ErrComposeScheduledSourceUnavailable, got %v", err)
+	}
 }
 
 func TestSplitCommaSeparatedLabelValues(t *testing.T) {


### PR DESCRIPTION
Scheduled runs and cert-rotation redeploys no longer have the original deployment context
around, so they rebuild the path to the deployment's source directory from its container
labels. 
That rebuild always assumed a Git source. For an OCI reference this kept the
`:latest` part in the folder name, but OCI artifacts are extracted into a folder without
the tag. So the rebuilt path pointed at a directory that doesn't exist. The deploy config
couldn't be reloaded and the scheduled run or rotation failed.
