### PR TITLE
test(e2e): enhance deployment lifecycle tests with log assertions and image checks

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -64,10 +64,16 @@ by reading the stack name(s) straight from the fixture's `.doco-cd.yml`
 1. Create `scenarios/<name>/fixture/` with a `.doco-cd.yml` and compose
    files. Prefix stack names with `e2e-`.
 2. Write `<name>_test.go`: call `NewHarness(t, "<name>")`, `Start()`, then
-   combine `WaitForLog`, `WaitFor`, `ContainerID`, `WaitForContainerRecreate`,
-   `RepoPush` and `ReplaceInWorktree` into the flow you want to prove.
+   combine `WaitFor`, `ContainerID`, `ContainerImage`,
+   `WaitForContainerRecreate`, `RepoPush` and `ReplaceInWorktree` into the
+   flow you want to prove. Use `LogMark` with `WaitForLogAfter` for multi-phase
+   scenarios so old log entries cannot satisfy later assertions.
 3. `go test -tags e2e ./test/e2e/... -run Test<Name> -v`.
 
 Keep scenarios independent: every scenario gets a fresh daemon, a fresh data
 volume and a fresh repo. Harness containers remain running until the e2e suite
 finishes; deployed stacks are still cleaned up after each test.
+
+Prefer Docker state for the primary assertion. Logs are useful for proving that
+a specific path ran, but a success log alone does not prove that the expected
+container or image reached the Docker daemon.

--- a/test/e2e/deployment_lifecycle_test.go
+++ b/test/e2e/deployment_lifecycle_test.go
@@ -1,0 +1,64 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeploymentLifecycle(t *testing.T) {
+	t.Parallel()
+
+	const (
+		stack    = "e2e-deployment-lifecycle"
+		service  = "app"
+		oldImage = "alpine:3.22"
+		newImage = "alpine:3.21"
+	)
+
+	h := NewHarness(t, "deployment-lifecycle")
+	h.Start()
+
+	h.WaitFor(2*time.Minute, "initial app container", func() bool {
+		return h.ContainerID(stack, service) != ""
+	})
+
+	initialID := h.ContainerID(stack, service)
+	if got := h.ContainerImage(initialID); !imageReferenceMatches(got, oldImage) {
+		t.Fatalf("initial container image = %q, want %q", got, oldImage)
+	}
+
+	failureMark := h.LogMark()
+	h.ReplaceInWorktree("deploy/compose.yaml", "image: "+oldImage, "image: [")
+	h.RepoPush("break compose configuration")
+
+	h.WaitForLogAfter(`"msg":"job completed with errors"`, failureMark, 2*time.Minute)
+
+	if got := h.ContainerID(stack, service); got != initialID {
+		t.Fatalf("invalid configuration changed last-known-good container: got %q, want %q", got, initialID)
+	}
+
+	recoveryMark := h.LogMark()
+	h.ReplaceInWorktree("deploy/compose.yaml", "image: [", "image: "+newImage)
+	h.RepoPush("repair compose configuration")
+
+	h.WaitForContainerRecreate(stack, service, initialID, 2*time.Minute)
+	h.WaitForLogAfter(`"msg":"job completed successfully"`, recoveryMark, 2*time.Minute)
+
+	recoveredID := h.ContainerID(stack, service)
+	if got := h.ContainerImage(recoveredID); !imageReferenceMatches(got, newImage) {
+		t.Fatalf("recovered container image = %q, want %q", got, newImage)
+	}
+
+	destroyMark := h.LogMark()
+	h.ReplaceInWorktree(
+		".doco-cd.yml",
+		"working_dir: deploy",
+		"working_dir: deploy\ndestroy:\n  enabled: true\n  remove_images: false\n  remove_dir: false",
+	)
+	h.RepoPush("destroy deployment")
+
+	h.WaitForLogAfter(`"msg":"destroying stack"`, destroyMark, 2*time.Minute)
+	h.WaitForContainerRemoval(stack, service, 2*time.Minute)
+}

--- a/test/e2e/failed_deploy_retry_test.go
+++ b/test/e2e/failed_deploy_retry_test.go
@@ -38,17 +38,19 @@ func TestFailedDeployRetry(t *testing.T) {
 	// fix the hook and push. Success must clear the record: the first "no
 	// changes" skip in the whole log proves both the successful deploy and
 	// the cleared record - with the record present the daemon never skips.
+	logMark := h.LogMark()
 	h.ReplaceInWorktree(".doco-cd.yml", `HOOK_EXIT: "1"`, `HOOK_EXIT: "0"`)
 	h.RepoPush("fix the hook")
 
-	h.WaitForLog("no changes detected, skipping deployment", 120*time.Second)
+	h.WaitForLogAfter("no changes detected, skipping deployment", logMark, 120*time.Second)
 
 	cidOK := h.ContainerID("e2e-retry", "app")
 	if cidOK == "" {
 		t.Fatal("app container must run after the successful deploy")
 	}
 
-	time.Sleep(25 * time.Second) // two poll cycles
+	stableMark := h.LogMark()
+	h.WaitForLogOccurrencesAfter("no changes detected, skipping deployment", stableMark, 2, 60*time.Second)
 
 	if got := h.ContainerID("e2e-retry", "app"); got != cidOK {
 		t.Fatalf("stack must stay untouched once the deploy succeeded: got %q, want %q", got, cidOK)

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -81,3 +81,50 @@ func TestDaemonBuildArgs(t *testing.T) {
 		t.Fatalf("daemonBuildArgs() = %v, want %v", got, want)
 	}
 }
+
+func TestLogsSince(t *testing.T) {
+	const logs = "first\nsecond\nthird\n"
+
+	tests := []struct {
+		name   string
+		offset int
+		want   string
+	}{
+		{name: "start", offset: 0, want: logs},
+		{name: "negative", offset: -1, want: logs},
+		{name: "middle", offset: len("first\n"), want: "second\nthird\n"},
+		{name: "end", offset: len(logs), want: ""},
+		{name: "past end", offset: len(logs) + 1, want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := logsSince(logs, tc.offset); got != tc.want {
+				t.Fatalf("logsSince() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestImageReferenceMatches(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+		ok   bool
+	}{
+		{name: "exact tag", got: "alpine:3.22", want: "alpine:3.22", ok: true},
+		{name: "swarm resolved tag", got: "alpine:3.22@sha256:abc", want: "alpine:3.22", ok: true},
+		{name: "different tag", got: "alpine:3.21@sha256:abc", want: "alpine:3.22"},
+		{name: "exact digest", got: "alpine:latest@sha256:abc", want: "alpine:latest@sha256:abc", ok: true},
+		{name: "different digest", got: "alpine:latest@sha256:def", want: "alpine:latest@sha256:abc"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := imageReferenceMatches(tc.got, tc.want); got != tc.ok {
+				t.Fatalf("imageReferenceMatches(%q, %q) = %t, want %t", tc.got, tc.want, got, tc.ok)
+			}
+		})
+	}
+}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -138,6 +138,40 @@ func (h *Harness) WaitForLog(substr string, timeout time.Duration) {
 	})
 }
 
+// LogMark returns a byte offset that can be used to restrict later log
+// assertions to events emitted after the current phase.
+func (h *Harness) LogMark() int {
+	h.t.Helper()
+
+	return len(h.daemonLogs())
+}
+
+func (h *Harness) WaitForLogAfter(substr string, offset int, timeout time.Duration) {
+	h.t.Helper()
+	h.WaitFor(timeout, "new daemon log contains \""+substr+"\"", func() bool {
+		return strings.Contains(logsSince(h.daemonLogs(), offset), substr)
+	})
+}
+
+func (h *Harness) WaitForLogOccurrencesAfter(substr string, offset, count int, timeout time.Duration) {
+	h.t.Helper()
+	h.WaitFor(timeout, fmt.Sprintf("new daemon logs contain %q %d times", substr, count), func() bool {
+		return strings.Count(logsSince(h.daemonLogs(), offset), substr) >= count
+	})
+}
+
+func logsSince(logs string, offset int) string {
+	if offset <= 0 {
+		return logs
+	}
+
+	if offset >= len(logs) {
+		return ""
+	}
+
+	return logs[offset:]
+}
+
 func (h *Harness) daemonHasLog(substr string) bool {
 	return strings.Contains(h.daemonLogs(), substr)
 }
@@ -219,19 +253,45 @@ func (h *Harness) RemoteContainerID(project, service string) string {
 	return h.containerID(h.remoteDocker, false, project, service)
 }
 
+func (h *Harness) ContainerImage(containerID string) string {
+	h.t.Helper()
+
+	return h.containerImage(h.docker, containerID)
+}
+
+func (h *Harness) RemoteContainerImage(containerID string) string {
+	h.t.Helper()
+
+	if h.remoteDocker == nil {
+		h.t.Fatal("remote Docker context is not enabled")
+	}
+
+	return h.containerImage(h.remoteDocker, containerID)
+}
+
+func (h *Harness) containerImage(dockerClient *client.Client, containerID string) string {
+	h.t.Helper()
+
+	inspect, err := dockerClient.ContainerInspect(h.ctx, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		h.t.Fatalf("inspect container %s: %v", shortContainerID(containerID), err)
+	}
+
+	if inspect.Container.Config == nil {
+		h.t.Fatalf("container %s has no configuration", shortContainerID(containerID))
+	}
+
+	return inspect.Container.Config.Image
+}
+
+func imageReferenceMatches(got, want string) bool {
+	return got == want || (!strings.Contains(want, "@") && strings.HasPrefix(got, want+"@sha256:"))
+}
+
 func (h *Harness) containerID(dockerClient *client.Client, swarmMode bool, project, service string) string {
 	h.t.Helper()
 
-	f := client.Filters{}
-	if swarmMode {
-		f = f.
-			Add("label", "com.docker.stack.namespace="+project).
-			Add("label", "com.docker.swarm.service.name="+project+"_"+service)
-	} else {
-		f = f.
-			Add("label", "com.docker.compose.project="+project).
-			Add("label", "com.docker.compose.service="+service)
-	}
+	f := h.containerFilters(swarmMode, project, service)
 
 	containers, err := dockerClient.ContainerList(h.ctx, client.ContainerListOptions{Filters: f})
 	if err != nil {
@@ -245,6 +305,23 @@ func (h *Harness) containerID(dockerClient *client.Client, swarmMode bool, proje
 	return containers.Items[0].ID
 }
 
+func (h *Harness) containerFilters(swarmMode bool, project, service string) client.Filters {
+	h.t.Helper()
+
+	f := client.Filters{}
+	if swarmMode {
+		f = f.
+			Add("label", "com.docker.stack.namespace="+project).
+			Add("label", "com.docker.swarm.service.name="+project+"_"+service)
+	} else {
+		f = f.
+			Add("label", "com.docker.compose.project="+project).
+			Add("label", "com.docker.compose.service="+service)
+	}
+
+	return f
+}
+
 // WaitForContainerRecreate waits until the container for project/service
 // exists and has an ID different from oldID.
 func (h *Harness) WaitForContainerRecreate(project, service, oldID string, timeout time.Duration) {
@@ -252,6 +329,20 @@ func (h *Harness) WaitForContainerRecreate(project, service, oldID string, timeo
 	h.WaitFor(timeout, project+"/"+service+" recreated", func() bool {
 		id := h.ContainerID(project, service)
 		return id != "" && id != oldID
+	})
+}
+
+func (h *Harness) WaitForContainerRemoval(project, service string, timeout time.Duration) {
+	h.t.Helper()
+	h.WaitFor(timeout, project+"/"+service+" removed", func() bool {
+		filters := h.containerFilters(h.isSwarmMode(), project, service)
+
+		containers, err := h.docker.ContainerList(h.ctx, client.ContainerListOptions{All: true, Filters: filters})
+		if err != nil {
+			h.t.Fatalf("list containers for %s/%s: %v", project, service, err)
+		}
+
+		return len(containers.Items) == 0
 	})
 }
 

--- a/test/e2e/image_bump_test.go
+++ b/test/e2e/image_bump_test.go
@@ -16,6 +16,7 @@ func TestImageBump(t *testing.T) {
 		stack      string
 		oldImage   string
 		newImage   string
+		wantImage  string
 		commitText string
 	}{
 		{
@@ -24,6 +25,7 @@ func TestImageBump(t *testing.T) {
 			stack:      "e2e-image-tag-bump",
 			oldImage:   "alpine:3.21",
 			newImage:   "alpine:3.22",
+			wantImage:  "alpine:3.22",
 			commitText: "bump app image tag",
 		},
 		{
@@ -32,6 +34,7 @@ func TestImageBump(t *testing.T) {
 			stack:      "e2e-image-digest-bump",
 			oldImage:   "sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d",
 			newImage:   "sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce",
+			wantImage:  "alpine:latest@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce",
 			commitText: "bump app image digest",
 		},
 	}
@@ -46,11 +49,20 @@ func TestImageBump(t *testing.T) {
 			h.WaitFor(120*time.Second, "initial app container", func() bool {
 				return h.ContainerID(tc.stack, "app") != ""
 			})
+			oldID := h.ContainerID(tc.stack, "app")
+			logMark := h.LogMark()
 
 			h.ReplaceInWorktree("deploy/compose.yaml", tc.oldImage, tc.newImage)
 			h.RepoPush(tc.commitText)
 
-			h.WaitForLog(`"msg":"service image reference changed"`, 120*time.Second)
+			h.WaitForLogAfter(`"msg":"service image reference changed"`, logMark, 120*time.Second)
+			h.WaitForContainerRecreate(tc.stack, "app", oldID, 120*time.Second)
+			h.WaitForLogAfter(`"msg":"job completed successfully"`, logMark, 120*time.Second)
+
+			newID := h.ContainerID(tc.stack, "app")
+			if got := h.ContainerImage(newID); !imageReferenceMatches(got, tc.wantImage) {
+				t.Fatalf("updated container image = %q, want %q", got, tc.wantImage)
+			}
 		})
 	}
 }

--- a/test/e2e/multi_context_test.go
+++ b/test/e2e/multi_context_test.go
@@ -20,4 +20,35 @@ func TestMultiContextSameNameDeployment(t *testing.T) {
 	h.WaitFor(2*time.Minute, "same-named stack deployed on remote context", func() bool {
 		return h.RemoteContainerID("e2e-multi-context", "app") != ""
 	})
+
+	const (
+		stack    = "e2e-multi-context"
+		oldImage = "alpine:3.22"
+		newImage = "alpine:3.21"
+	)
+
+	localID := h.ContainerID(stack, "app")
+	remoteID := h.RemoteContainerID(stack, "app")
+	logMark := h.LogMark()
+
+	h.ReplaceInWorktree("deploy/compose.yaml", oldImage, newImage)
+	h.RepoPush("update both contexts")
+
+	h.WaitFor(2*time.Minute, "default-context deployment updated", func() bool {
+		id := h.ContainerID(stack, "app")
+		return id != "" && id != localID
+	})
+	h.WaitFor(2*time.Minute, "remote-context deployment updated", func() bool {
+		id := h.RemoteContainerID(stack, "app")
+		return id != "" && id != remoteID
+	})
+	h.WaitForLogAfter(`"msg":"job completed successfully"`, logMark, 2*time.Minute)
+
+	if got := h.ContainerImage(h.ContainerID(stack, "app")); !imageReferenceMatches(got, newImage) {
+		t.Fatalf("default-context container image = %q, want %q", got, newImage)
+	}
+
+	if got := h.RemoteContainerImage(h.RemoteContainerID(stack, "app")); !imageReferenceMatches(got, newImage) {
+		t.Fatalf("remote-context container image = %q, want %q", got, newImage)
+	}
 }

--- a/test/e2e/scenarios/deployment-lifecycle/fixture/.doco-cd.yml
+++ b/test/e2e/scenarios/deployment-lifecycle/fixture/.doco-cd.yml
@@ -1,0 +1,2 @@
+name: e2e-deployment-lifecycle
+working_dir: deploy

--- a/test/e2e/scenarios/deployment-lifecycle/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/deployment-lifecycle/fixture/deploy/compose.yaml
@@ -1,0 +1,4 @@
+services:
+  app:
+    image: alpine:3.22
+    command: ["sleep", "600"]


### PR DESCRIPTION
## To do

Add a e2e test for deploying from an OCI artifact. if you need an OCI image for this, you can use ghcr.io/kimdre/doco-cd_tests:test