### PR TITLE
fix(git): handle repository corruption during fetch and repair empty ref files

### DIFF
--- a/internal/git/repair.go
+++ b/internal/git/repair.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
 )
 
 // IsCorruptionError checks if an error indicates repository corruption rather than transient failures.
@@ -23,6 +24,10 @@ func IsCorruptionError(err error) bool {
 
 	// Reference not found is a primary corruption indicator
 	if errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return true
+	}
+
+	if errors.Is(err, dotgit.ErrEmptyRefFile) {
 		return true
 	}
 

--- a/internal/git/repair.go
+++ b/internal/git/repair.go
@@ -15,19 +15,25 @@ import (
 	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
 )
 
-// IsCorruptionError checks if an error indicates repository corruption rather than transient failures.
-// Corruption is indicated by reference not found errors when fetches have completed successfully.
+// IsCorruptionError checks if an error indicates repository corruption rather than a transient failure.
 func IsCorruptionError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	// Reference not found is a primary corruption indicator
-	if errors.Is(err, plumbing.ErrReferenceNotFound) {
-		return true
+	corruptionErrors := []error{
+		plumbing.ErrReferenceNotFound,
+		plumbing.ErrObjectNotFound,
+		git.ErrInvalidReference,
+		dotgit.ErrEmptyRefFile,
+		dotgit.ErrPackedRefsBadFormat,
+		dotgit.ErrPackedRefsDuplicatedRef,
+		dotgit.ErrSymRefTargetNotFound,
 	}
 
-	if errors.Is(err, dotgit.ErrEmptyRefFile) {
+	if slices.ContainsFunc(corruptionErrors, func(target error) bool {
+		return errors.Is(err, target)
+	}) {
 		return true
 	}
 
@@ -81,7 +87,7 @@ func attemptLightweightRepair(repo *git.Repository) bool {
 
 	// First check if we can get HEAD
 	head, err := repo.Head()
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		// Head is corrupted beyond recovery
 		return false
 	}

--- a/internal/git/repair_test.go
+++ b/internal/git/repair_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
 
 	"github.com/kimdre/doco-cd/internal/filesystem"
 )
@@ -27,6 +29,7 @@ func TestIsCorruptionError(t *testing.T) {
 		{name: "nil error", err: nil, want: false},
 		{name: "reference not found", err: ErrInvalidReference, want: true},
 		{name: "error with reference not found message", err: gogit.ErrInvalidReference, want: true},
+		{name: "empty ref file", err: fmt.Errorf("fetch failed: %w", dotgit.ErrEmptyRefFile), want: true},
 		{name: "other error", err: ErrMissingAuthToken, want: false},
 	}
 
@@ -189,6 +192,41 @@ func TestUpdateRepository_RepairsCorruptionWithoutDeadlock(t *testing.T) {
 		assertRepoOnMainHash(t, res.repo, originHash)
 	case <-time.After(5 * time.Second):
 		t.Fatal("UpdateRepository timed out (possible path-lock deadlock during repair)")
+	}
+}
+
+func TestUpdateRepository_RepairsEmptyRefFileDuringFetch(t *testing.T) {
+	t.Parallel()
+
+	originPath, clonePath, originHash := setupLocalMainRepoAndClone(t)
+
+	refPath := filepath.Join(clonePath, ".git", "refs", "remotes", RemoteName, "main")
+	if err := os.WriteFile(refPath, nil, filesystem.PermOwner); err != nil {
+		t.Fatalf("empty remote ref file: %v", err)
+	}
+
+	done := make(chan struct {
+		repo *gogit.Repository
+		err  error
+	}, 1)
+
+	go func() {
+		r, e := UpdateRepository(clonePath, originPath, MainBranch, false, transport.ProxyOptions{}, nil, false, 0)
+		done <- struct {
+			repo *gogit.Repository
+			err  error
+		}{repo: r, err: e}
+	}()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("UpdateRepository failed: %v", res.err)
+		}
+
+		assertRepoOnMainHash(t, res.repo, originHash)
+	case <-time.After(5 * time.Second):
+		t.Fatal("UpdateRepository timed out (possible path-lock deadlock during fetch repair)")
 	}
 }
 

--- a/internal/git/repair_test.go
+++ b/internal/git/repair_test.go
@@ -28,8 +28,12 @@ func TestIsCorruptionError(t *testing.T) {
 	}{
 		{name: "nil error", err: nil, want: false},
 		{name: "reference not found", err: ErrInvalidReference, want: true},
-		{name: "error with reference not found message", err: gogit.ErrInvalidReference, want: true},
+		{name: "object not found", err: plumbing.ErrObjectNotFound, want: true},
 		{name: "empty ref file", err: fmt.Errorf("fetch failed: %w", dotgit.ErrEmptyRefFile), want: true},
+		{name: "malformed packed refs", err: dotgit.ErrPackedRefsBadFormat, want: true},
+		{name: "duplicated packed ref", err: dotgit.ErrPackedRefsDuplicatedRef, want: true},
+		{name: "symbolic ref target not found", err: dotgit.ErrSymRefTargetNotFound, want: true},
+		{name: "wrapped message fallback", err: errors.New("fetch failed: reference not found"), want: true},
 		{name: "other error", err: ErrMissingAuthToken, want: false},
 	}
 

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -208,6 +208,26 @@ func UpdateRepository(path, url, ref string, skipTLSVerify bool, proxyOpts trans
 
 	err = FetchRepository(repo, url, skipTLSVerify, proxyOpts, auth, depth)
 	if err != nil {
+		if IsCorruptionError(err) {
+			slog.Warn("detected possible repository corruption during fetch",
+				slog.String("path", path),
+				slog.String("error", FormatGitErrorMessage(err)))
+
+			// Release the lock before calling RepairRepository because repair may re-clone.
+			unlock()
+
+			repairedRepo, repairErr := RepairRepository(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth, slog.Default())
+			if repairErr == nil {
+				return repairedRepo, nil
+			}
+
+			slog.Error("failed to repair corrupted repository",
+				slog.String("path", path),
+				slog.String("repair_error", FormatGitErrorMessage(repairErr)))
+
+			return nil, fmt.Errorf("%w: %w; repair failed: %v", ErrFetchFailed, err, repairErr)
+		}
+
 		return nil, fmt.Errorf("%w: %w", ErrFetchFailed, err)
 	}
 


### PR DESCRIPTION
This PR improves the robustness of the repository update and repair logic by enhancing the detection and handling of repository corruption, specifically addressing cases where a Git reference file is empty. The changes ensure that such corruption is detected during fetch operations and automatically repaired.