### PR TITLE
fix(git): enhance corruption error detection for repository integrity

### DIFF
--- a/internal/git/repair.go
+++ b/internal/git/repair.go
@@ -78,29 +78,19 @@ func remoteRefExists(ctx context.Context, repo *git.Repository, url string, auth
 	return false, nil
 }
 
-// attemptLightweightRepair tries to fix a corrupted repository without re-cloning.
-// It attempts to validate repository metadata, which can recover from many corruption scenarios.
-// Returns true if repair succeeded, false if the repository requires re-clone.
-func attemptLightweightRepair(repo *git.Repository) bool {
-	// Attempt to validate that we can access HEAD and iterate references
-	// This is a lightweight operation compared to re-cloning
-
-	// First check if we can get HEAD
+// repositoryMetadataValid verifies that HEAD and all references can be read.
+func repositoryMetadataValid(repo *git.Repository) bool {
 	head, err := repo.Head()
 	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
-		// Head is corrupted beyond recovery
 		return false
 	}
 
-	// Try to list all references - this will fail if refs are corrupted
 	refs, err := repo.References()
 	if err != nil {
-		// References are corrupted
 		return false
 	}
 	defer refs.Close()
 
-	// Count accessible refs to validate repository structure
 	refCount := 0
 
 	err = refs.ForEach(func(_ *plumbing.Reference) error {
@@ -108,17 +98,10 @@ func attemptLightweightRepair(repo *git.Repository) bool {
 		return nil
 	})
 	if err != nil {
-		// Could not enumerate references properly
 		return false
 	}
 
-	// If we have no references and HEAD is also missing, repo is probably empty or very corrupted
-	if refCount == 0 && head == nil {
-		return false
-	}
-
-	// Lightweight repair succeeded - repository structure appears intact
-	return true
+	return refCount > 0 || head != nil
 }
 
 // RepairRepository attempts to fix a corrupted Git repository.
@@ -131,16 +114,23 @@ func RepairRepository(
 	cloneSubmodules bool, depth int,
 	logger *slog.Logger,
 ) (*git.Repository, error) {
-	if logger == nil {
-		logger = slog.Default()
-	}
+	depth = effectiveDepth(url, depth)
 
 	unlock := AcquirePathLock(path)
 	defer unlock()
 
-	repo, err := git.PlainOpen(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open repository for repair: %w", err)
+	return repairRepositoryLocked(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth, logger)
+}
+
+// repairRepositoryLocked repairs a repository while the caller holds its path lock.
+func repairRepositoryLocked(
+	path, url, ref string,
+	skipTLSVerify bool, proxyOpts transport.ProxyOptions, auth transport.AuthMethod,
+	cloneSubmodules bool, depth int,
+	logger *slog.Logger,
+) (*git.Repository, error) {
+	if logger == nil {
+		logger = slog.Default()
 	}
 
 	logger.Warn("repository corruption detected, attempting recovery",
@@ -148,30 +138,46 @@ func RepairRepository(
 		slog.String("url", url),
 		slog.String("ref", ref))
 
-	if attemptLightweightRepair(repo) {
-		logger.Info("lightweight repository repair succeeded",
-			slog.String("path", path))
+	recloneReason := "repository metadata is unreadable"
 
-		if _, err := repo.Reference(plumbing.ReferenceName(ref), true); err == nil {
-			logger.Info("repository references restored after lightweight repair",
-				slog.String("path", path))
+	repo, openErr := git.PlainOpen(path)
+	if openErr == nil && repositoryMetadataValid(repo) {
+		fetchErr := FetchRepository(repo, url, skipTLSVerify, proxyOpts, auth, depth)
+		switch {
+		case fetchErr != nil:
+			if !IsCorruptionError(fetchErr) {
+				return nil, fmt.Errorf("in-place repair fetch failed: %w", fetchErr)
+			}
 
-			return repo, nil
+			recloneReason = "in-place fetch failed: " + FormatGitErrorMessage(fetchErr)
+		default:
+			checkoutErr := CheckoutRepository(repo, ref, auth, cloneSubmodules)
+			if checkoutErr == nil {
+				logger.Info("repository successfully repaired in place",
+					slog.String("path", path))
+
+				return repo, nil
+			}
+
+			if !IsCorruptionError(checkoutErr) {
+				return nil, fmt.Errorf("in-place repair checkout failed: %w", checkoutErr)
+			}
+
+			recloneReason = "in-place checkout failed: " + FormatGitErrorMessage(checkoutErr)
 		}
+	} else if openErr != nil {
+		recloneReason = "repository could not be opened: " + FormatGitErrorMessage(openErr)
 	}
 
-	logger.Warn("lightweight repair failed, performing full repository re-clone",
+	logger.Warn("in-place repair failed, performing full repository re-clone",
 		slog.String("path", path),
-		slog.String("reason", "reference still not accessible after lightweight repair"))
-
-	// Release lock before re-cloning, because CloneRepository acquires the same path lock.
-	unlock()
+		slog.String("reason", recloneReason))
 
 	if err := os.RemoveAll(path); err != nil {
 		return nil, fmt.Errorf("failed to remove corrupted repository at %s: %w", path, err)
 	}
 
-	repairedRepo, err := CloneRepository(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
+	repairedRepo, err := cloneRepositoryLocked(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
 	if err != nil {
 		return nil, fmt.Errorf("failed to re-clone repository during repair: %w", err)
 	}

--- a/internal/git/repair_test.go
+++ b/internal/git/repair_test.go
@@ -234,6 +234,102 @@ func TestUpdateRepository_RepairsEmptyRefFileDuringFetch(t *testing.T) {
 	}
 }
 
+func TestRepairRepository_ChecksOutRequestedReference(t *testing.T) {
+	t.Parallel()
+
+	originPath, clonePath, originHash := setupLocalMainRepoAndClone(t)
+
+	repo, err := gogit.PlainOpen(clonePath)
+	if err != nil {
+		t.Fatalf("open clone: %v", err)
+	}
+
+	otherBranch := plumbing.NewBranchReferenceName("other")
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(otherBranch, originHash)); err != nil {
+		t.Fatalf("set other branch: %v", err)
+	}
+
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, otherBranch)); err != nil {
+		t.Fatalf("set HEAD to other branch: %v", err)
+	}
+
+	repairedRepo, err := RepairRepository(
+		clonePath,
+		originPath,
+		MainBranch,
+		false,
+		transport.ProxyOptions{},
+		nil,
+		false,
+		0,
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("repair failed: %v", err)
+	}
+
+	assertRepoOnMainHash(t, repairedRepo, originHash)
+}
+
+func TestRepairRepository_ReclonesUnreadableRepository(t *testing.T) {
+	t.Parallel()
+
+	originPath, clonePath, originHash := setupLocalMainRepoAndClone(t)
+
+	if err := os.RemoveAll(filepath.Join(clonePath, ".git")); err != nil {
+		t.Fatalf("remove repository metadata: %v", err)
+	}
+
+	repairedRepo, err := RepairRepository(
+		clonePath,
+		originPath,
+		MainBranch,
+		false,
+		transport.ProxyOptions{},
+		nil,
+		false,
+		0,
+		slog.Default(),
+	)
+	if err != nil {
+		t.Fatalf("repair failed: %v", err)
+	}
+
+	assertRepoOnMainHash(t, repairedRepo, originHash)
+}
+
+func TestRepairRepository_PreservesRepositoryOnNonCorruptionFailure(t *testing.T) {
+	t.Parallel()
+
+	_, clonePath, _ := setupLocalMainRepoAndClone(t)
+
+	sentinel := filepath.Join(clonePath, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("keep\n"), filesystem.PermOwner); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	missingOrigin := filepath.Join(t.TempDir(), "missing-origin")
+
+	_, err := RepairRepository(
+		clonePath,
+		missingOrigin,
+		MainBranch,
+		false,
+		transport.ProxyOptions{},
+		nil,
+		false,
+		0,
+		slog.Default(),
+	)
+	if err == nil {
+		t.Fatal("expected repair to fail for missing origin")
+	}
+
+	if _, statErr := os.Stat(sentinel); statErr != nil {
+		t.Fatalf("expected repository to remain intact after non-corruption failure: %v", statErr)
+	}
+}
+
 func TestRepairRepositoryWithMissingPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	missingPath := filepath.Join(tmpDir, "missing")
@@ -405,10 +501,6 @@ func commitFile(t *testing.T, repo *gogit.Repository, repoPath, relPath, content
 
 func assertRepoOnMainHash(t *testing.T, repo *gogit.Repository, expected plumbing.Hash) {
 	t.Helper()
-
-	if err := CheckoutRepository(repo, MainBranch, nil, false); err != nil {
-		t.Fatalf("checkout %s: %v", MainBranch, err)
-	}
 
 	mainRef, err := repo.Reference(plumbing.NewBranchReferenceName("main"), true)
 	if err != nil {

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -181,6 +181,11 @@ func UpdateRepository(path, url, ref string, skipTLSVerify bool, proxyOpts trans
 	unlock := AcquirePathLock(path)
 	defer unlock()
 
+	return updateRepositoryLocked(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
+}
+
+// updateRepositoryLocked updates a repository while the caller holds its path lock.
+func updateRepositoryLocked(path, url, ref string, skipTLSVerify bool, proxyOpts transport.ProxyOptions, auth transport.AuthMethod, cloneSubmodules bool, depth int) (*git.Repository, error) {
 	repo, err := git.PlainOpen(path)
 	if err != nil {
 		return nil, err
@@ -192,13 +197,11 @@ func UpdateRepository(path, url, ref string, skipTLSVerify bool, proxyOpts trans
 			slog.String("path", path),
 			slog.Int("requested_depth", depth))
 
-		unlock() // release lock before re-clone (CloneRepository acquires its own)
-
 		if err := os.RemoveAll(path); err != nil {
 			return nil, fmt.Errorf("failed to remove repository for re-clone: %w", err)
 		}
 
-		return CloneRepository(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
+		return cloneRepositoryLocked(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
 	}
 
 	err = updateRemoteURL(repo, url)
@@ -209,23 +212,12 @@ func UpdateRepository(path, url, ref string, skipTLSVerify bool, proxyOpts trans
 	err = FetchRepository(repo, url, skipTLSVerify, proxyOpts, auth, depth)
 	if err != nil {
 		if IsCorruptionError(err) {
-			slog.Warn("detected possible repository corruption during fetch",
-				slog.String("path", path),
-				slog.String("error", FormatGitErrorMessage(err)))
-
-			// Release the lock before calling RepairRepository because repair may re-clone.
-			unlock()
-
-			repairedRepo, repairErr := RepairRepository(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth, slog.Default())
+			repairedRepo, repairErr := repairAfterCorruptionLocked(path, url, ref, "fetch", err, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
 			if repairErr == nil {
 				return repairedRepo, nil
 			}
 
-			slog.Error("failed to repair corrupted repository",
-				slog.String("path", path),
-				slog.String("repair_error", FormatGitErrorMessage(repairErr)))
-
-			return nil, fmt.Errorf("%w: %w; repair failed: %v", ErrFetchFailed, err, repairErr)
+			return nil, fmt.Errorf("%w: %w", ErrFetchFailed, errors.Join(err, fmt.Errorf("repair failed: %w", repairErr)))
 		}
 
 		return nil, fmt.Errorf("%w: %w", ErrFetchFailed, err)
@@ -234,6 +226,8 @@ func UpdateRepository(path, url, ref string, skipTLSVerify bool, proxyOpts trans
 	// Pass auth and cloneSubmodules so CheckoutRepository can ensure submodules are updated when needed.
 	err = CheckoutRepository(repo, ref, auth, cloneSubmodules)
 	if err != nil {
+		var corruptionRepairErr error
+
 		// Check if this looks like repository corruption (ref not found despite successful fetch)
 		if IsCorruptionError(err) {
 			fetchedExists, fetchedCheckErr := fetchedReferenceExistsAfterFetch(repo, ref)
@@ -252,26 +246,34 @@ func UpdateRepository(path, url, ref string, skipTLSVerify bool, proxyOpts trans
 				return nil, fmt.Errorf("%w: %w", ErrCheckoutFailed, err)
 			}
 
-			slog.Warn("detected possible repository corruption during checkout",
-				slog.String("path", path),
-				slog.String("error", FormatGitErrorMessage(err)))
-
-			// Release the lock before calling RepairRepository because repair may re-clone.
-			unlock()
-
-			repairedRepo, repairErr := RepairRepository(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth, slog.Default())
+			repairedRepo, repairErr := repairAfterCorruptionLocked(path, url, ref, "checkout", err, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
 			if repairErr == nil {
 				return repairedRepo, nil
 			}
 
-			slog.Error("failed to repair corrupted repository",
-				slog.String("path", path),
-				slog.String("repair_error", FormatGitErrorMessage(repairErr)))
+			corruptionRepairErr = repairErr
+			if depth <= 0 || !IsRefUnreachableError(err) {
+				return nil, fmt.Errorf("%w: %w", ErrCheckoutFailed, errors.Join(err, fmt.Errorf("repair failed: %w", repairErr)))
+			}
+
+			reopenedRepo, reopenErr := git.PlainOpen(path)
+			if reopenErr != nil {
+				return nil, fmt.Errorf("%w: %w", ErrCheckoutFailed, errors.Join(
+					fmt.Errorf("repair failed: %w", repairErr),
+					fmt.Errorf("failed to reopen repository for deepening: %w", reopenErr),
+				))
+			}
+
+			repo = reopenedRepo
 		}
 		// Attempt to deepen if the ref is unreachable in a shallow clone
 		if depth > 0 && IsRefUnreachableError(err) {
 			repo, deepenErr := deepenAndCheckout(repo, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
 			if deepenErr != nil {
+				if corruptionRepairErr != nil {
+					deepenErr = errors.Join(deepenErr, fmt.Errorf("repair failed: %w", corruptionRepairErr))
+				}
+
 				return nil, fmt.Errorf("%w: %w", ErrCheckoutFailed, deepenErr)
 			}
 
@@ -284,6 +286,30 @@ func UpdateRepository(path, url, ref string, skipTLSVerify bool, proxyOpts trans
 	return repo, nil
 }
 
+// repairAfterCorruptionLocked attempts to repair a repository after detecting possible corruption during an operation.
+func repairAfterCorruptionLocked(
+	path, url, ref, operation string,
+	cause error,
+	skipTLSVerify bool,
+	proxyOpts transport.ProxyOptions,
+	auth transport.AuthMethod,
+	cloneSubmodules bool,
+	depth int,
+) (*git.Repository, error) {
+	slog.Warn("detected possible repository corruption during "+operation,
+		slog.String("path", path),
+		slog.String("error", FormatGitErrorMessage(cause)))
+
+	repairedRepo, repairErr := repairRepositoryLocked(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth, slog.Default())
+	if repairErr != nil {
+		slog.Error("failed to repair corrupted repository",
+			slog.String("path", path),
+			slog.String("repair_error", FormatGitErrorMessage(repairErr)))
+	}
+
+	return repairedRepo, repairErr
+}
+
 // CloneRepository clones a repository with HTTP or SSH auth.
 // If depth > 0, a shallow clone is performed with the specified number of commits.
 func CloneRepository(path, url, ref string, skipTLSVerify bool, proxyOpts transport.ProxyOptions, auth transport.AuthMethod, cloneSubmodules bool, depth int) (*git.Repository, error) {
@@ -293,6 +319,11 @@ func CloneRepository(path, url, ref string, skipTLSVerify bool, proxyOpts transp
 	unlock := AcquirePathLock(path)
 	defer unlock()
 
+	return cloneRepositoryLocked(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
+}
+
+// cloneRepositoryLocked clones a repository while the caller holds its path lock.
+func cloneRepositoryLocked(path, url, ref string, skipTLSVerify bool, proxyOpts transport.ProxyOptions, auth transport.AuthMethod, cloneSubmodules bool, depth int) (*git.Repository, error) {
 	err := os.MkdirAll(path, filesystem.PermDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create directory %s: %w", path, err)
@@ -343,7 +374,7 @@ func CloneRepository(path, url, ref string, skipTLSVerify bool, proxyOpts transp
 		if errors.Is(err, git.ErrRemoteExists) {
 			// If the directory contains a repository, try UpdateRepository
 			if _, openErr := git.PlainOpen(path); openErr == nil {
-				if upd, uErr := UpdateRepository(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth); uErr == nil {
+				if upd, uErr := updateRepositoryLocked(path, url, ref, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth); uErr == nil {
 					return upd, nil
 				}
 			}


### PR DESCRIPTION
Improved the repair process substantially:
- Repair only succeeds after fetch and checkout both work.
- Re-clones repositories that cannot be opened.
- Preserves caches on unrelated transport/auth failures.
- Holds the path lock through removal and re-cloning.
- Preserves original and repair errors.
- Strengthened tests to verify the repaired HEAD directly.