### PR TITLE
fix(git): improvements to git package

### DIFF
--- a/internal/git/local_watcher.go
+++ b/internal/git/local_watcher.go
@@ -53,7 +53,7 @@ func WatchLocalGitRef(ctx context.Context, repoURL string, log *slog.Logger) (<-
 	// Best-effort: also watch refs/heads/ for loose-ref updates.
 	refsHeadsDir := filepath.Join(gitDir, "refs", "heads")
 	if _, statErr := os.Stat(refsHeadsDir); statErr == nil {
-		_ = watcher.Add(refsHeadsDir)
+		addRefDirectoryWatches(watcher, refsHeadsDir, log)
 	}
 
 	packedRefs := filepath.Join(gitDir, "packed-refs")
@@ -130,6 +130,12 @@ func WatchLocalGitRef(ctx context.Context, repoURL string, log *slog.Logger) (<-
 					continue
 				}
 
+				if event.Has(fsnotify.Create) {
+					if info, statErr := os.Stat(cleanName); statErr == nil && info.IsDir() {
+						addRefDirectoryWatches(watcher, cleanName, log)
+					}
+				}
+
 				if debounce != nil {
 					debounce.Stop()
 				}
@@ -151,6 +157,33 @@ func WatchLocalGitRef(ctx context.Context, repoURL string, log *slog.Logger) (<-
 	}()
 
 	return ch, nil
+}
+
+// addRefDirectoryWatches watches all existing ref directories on a best-effort basis.
+func addRefDirectoryWatches(watcher *fsnotify.Watcher, root string, log *slog.Logger) {
+	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			if log != nil && !os.IsNotExist(err) {
+				log.Warn("failed to inspect ref directory",
+					slog.String("path", path),
+					slog.Any("error", err))
+			}
+
+			return nil
+		}
+
+		if !entry.IsDir() {
+			return nil
+		}
+
+		if err := watcher.Add(path); err != nil && log != nil && !os.IsNotExist(err) {
+			log.Warn("failed to watch ref directory",
+				slog.String("path", path),
+				slog.Any("error", err))
+		}
+
+		return nil
+	})
 }
 
 // localPathFromURL extracts the filesystem path from a file:// URL.

--- a/internal/git/local_watcher_test.go
+++ b/internal/git/local_watcher_test.go
@@ -83,6 +83,32 @@ func TestWatchLocalGitRef_BareRepo(t *testing.T) {
 	}
 }
 
+func TestWatchLocalGitRef_NestedBranch(t *testing.T) {
+	t.Parallel()
+
+	srcPath := filepath.Join(t.TempDir(), "repo")
+	initLocalTestRepo(t, srcPath)
+
+	nestedRefsDir := filepath.Join(srcPath, ".git", "refs", "heads", "feature")
+	if err := os.MkdirAll(nestedRefsDir, 0o755); err != nil {
+		t.Fatalf("create nested refs directory: %v", err)
+	}
+
+	watchCh, err := git.WatchLocalGitRef(t.Context(), "file://"+srcPath, nil)
+	if err != nil {
+		t.Fatalf("WatchLocalGitRef: %v", err)
+	}
+
+	fakeHash := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	if err := os.WriteFile(filepath.Join(nestedRefsDir, "foo"), []byte(fakeHash+"\n"), 0o600); err != nil {
+		t.Fatalf("write nested ref: %v", err)
+	}
+
+	if !waitForSignal(t, watchCh, watchSignalTimeout) {
+		t.Fatal("expected watcher signal after nested branch update, got none within timeout")
+	}
+}
+
 func TestWatchLocalGitRef_CancelStopsWatcher(t *testing.T) {
 	t.Parallel()
 

--- a/internal/git/lock.go
+++ b/internal/git/lock.go
@@ -1,6 +1,10 @@
 package git
 
-import "sync"
+import (
+	"path/filepath"
+	"slices"
+	"sync"
+)
 
 // cloneLocks serializes clone/update operations per repository path to avoid
 // race conditions where concurrent clones produce partial repo state.
@@ -13,6 +17,8 @@ var cloneLocks = struct {
 
 // lockForKey returns the mutex for a given key, creating it if necessary.
 func lockForKey(k string) *sync.Mutex {
+	k = canonicalLockKey(k)
+
 	cloneLocks.mu.Lock()
 	defer cloneLocks.mu.Unlock()
 
@@ -24,6 +30,37 @@ func lockForKey(k string) *sync.Mutex {
 	cloneLocks.m[k] = m
 
 	return m
+}
+
+// canonicalLockKey resolves equivalent paths to a shared lock key.
+func canonicalLockKey(path string) string {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		absolutePath = filepath.Clean(path)
+	}
+
+	current := absolutePath
+
+	var suffix []string
+
+	for {
+		resolved, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for _, s := range slices.Backward(suffix) {
+				resolved = filepath.Join(resolved, s)
+			}
+
+			return filepath.Clean(resolved)
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			return filepath.Clean(absolutePath)
+		}
+
+		suffix = append(suffix, filepath.Base(current))
+		current = parent
+	}
 }
 
 // AcquirePathLock locks the mutex for the given key and returns a function to unlock it.

--- a/internal/git/lock_test.go
+++ b/internal/git/lock_test.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -15,6 +17,21 @@ func TestLockForPath(t *testing.T) {
 
 	if lock1 != lock2 {
 		t.Fatalf("expected same mutex for the same path, got different instances")
+	}
+}
+
+func TestLockForPath_CanonicalizesSymlinks(t *testing.T) {
+	t.Parallel()
+
+	realDir := t.TempDir()
+
+	symlinkPath := filepath.Join(t.TempDir(), "repo")
+	if err := os.Symlink(realDir, symlinkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	if lockForKey(realDir) != lockForKey(symlinkPath) {
+		t.Fatal("expected real and symlinked paths to use the same mutex")
 	}
 }
 

--- a/internal/git/references.go
+++ b/internal/git/references.go
@@ -98,6 +98,12 @@ func fetchedReferenceExistsAfterFetch(repo *git.Repository, ref string) (bool, e
 		return true, nil
 	}
 
+	refName := plumbing.ReferenceName(ref)
+	if !strings.HasPrefix(ref, "refs/") && refName.IsSafe() {
+		// Uppercase pseudo-refs such as HEAD are resolved locally rather than fetched.
+		return true, nil
+	}
+
 	candidates := make([]plumbing.ReferenceName, 0, 3)
 
 	switch {

--- a/internal/git/repair.go
+++ b/internal/git/repair.go
@@ -142,7 +142,7 @@ func repairRepositoryLocked(
 
 	repo, openErr := git.PlainOpen(path)
 	if openErr == nil && repositoryMetadataValid(repo) {
-		fetchErr := FetchRepository(repo, url, skipTLSVerify, proxyOpts, auth, depth)
+		fetchErr := fetchRepositoryLocked(repo, url, skipTLSVerify, proxyOpts, auth, depth)
 		switch {
 		case fetchErr != nil:
 			if !IsCorruptionError(fetchErr) {

--- a/internal/git/repair_test.go
+++ b/internal/git/repair_test.go
@@ -414,6 +414,96 @@ func TestUpdateRepository_BranchMissingOnRemote_SkipsRepair(t *testing.T) {
 	}
 }
 
+func TestUpdateRepository_RemoteBranchDeleted_DoesNotUseStaleLocalBranch(t *testing.T) {
+	t.Parallel()
+
+	originPath, clonePath, _ := setupLocalMainRepoAndClone(t)
+
+	originRepo, err := gogit.PlainOpen(originPath)
+	if err != nil {
+		t.Fatalf("open origin: %v", err)
+	}
+
+	mainRef, err := originRepo.Reference(plumbing.NewBranchReferenceName("main"), true)
+	if err != nil {
+		t.Fatalf("read origin main: %v", err)
+	}
+
+	fallbackRef := plumbing.NewBranchReferenceName("fallback")
+	if err := originRepo.Storer.SetReference(plumbing.NewHashReference(fallbackRef, mainRef.Hash())); err != nil {
+		t.Fatalf("create fallback branch: %v", err)
+	}
+
+	if err := originRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, fallbackRef)); err != nil {
+		t.Fatalf("point origin HEAD at fallback: %v", err)
+	}
+
+	if err := originRepo.Storer.RemoveReference(plumbing.NewBranchReferenceName("main")); err != nil {
+		t.Fatalf("delete origin main: %v", err)
+	}
+
+	_, err = UpdateRepository(clonePath, originPath, MainBranch, false, transport.ProxyOptions{}, nil, false, 0)
+	if !errors.Is(err, ErrInvalidReference) {
+		t.Fatalf("expected invalid reference after remote branch deletion, got: %v", err)
+	}
+}
+
+func TestUpdateRepository_AllowsHeadPseudoReference(t *testing.T) {
+	t.Parallel()
+
+	originPath, clonePath, originHash := setupLocalMainRepoAndClone(t)
+
+	repo, err := UpdateRepository(clonePath, originPath, plumbing.HEAD.String(), false, transport.ProxyOptions{}, nil, false, 0)
+	if err != nil {
+		t.Fatalf("update using HEAD: %v", err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+
+	if head.Hash() != originHash {
+		t.Fatalf("HEAD hash mismatch: got %s want %s", head.Hash(), originHash)
+	}
+}
+
+func TestFetchRepository_UsesPathLock(t *testing.T) {
+	t.Parallel()
+
+	originPath, clonePath, _ := setupLocalMainRepoAndClone(t)
+
+	repo, err := gogit.PlainOpen(clonePath)
+	if err != nil {
+		t.Fatalf("open clone: %v", err)
+	}
+
+	unlock := AcquirePathLock(clonePath)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- FetchRepository(repo, originPath, false, transport.ProxyOptions{}, nil, 0)
+	}()
+
+	select {
+	case err := <-done:
+		unlock()
+		t.Fatalf("fetch completed while path lock was held: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	unlock()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("fetch failed after path lock release: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("fetch did not complete after path lock release")
+	}
+}
+
 func TestRemoteRefExists(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -119,6 +119,20 @@ func effectiveDepth(url string, depth int) int {
 // FetchRepository fetches updates from the remote repository, including all branches and tags, and prunes deleted references.
 // If depth > 0, a shallow fetch is performed with the specified number of commits.
 func FetchRepository(repo *git.Repository, url string, skipTLSVerify bool, proxyOpts transport.ProxyOptions, auth transport.AuthMethod, depth int) error {
+	worktree, err := repo.Worktree()
+	if err != nil {
+		// Bare repositories have no worktree path to use as a lock key.
+		return fetchRepositoryLocked(repo, url, skipTLSVerify, proxyOpts, auth, depth)
+	}
+
+	unlock := AcquirePathLock(worktree.Filesystem.Root())
+	defer unlock()
+
+	return fetchRepositoryLocked(repo, url, skipTLSVerify, proxyOpts, auth, depth)
+}
+
+// fetchRepositoryLocked fetches a repository while the caller holds its path lock.
+func fetchRepositoryLocked(repo *git.Repository, url string, skipTLSVerify bool, proxyOpts transport.ProxyOptions, auth transport.AuthMethod, depth int) error {
 	depth = effectiveDepth(url, depth)
 
 	opts := &git.FetchOptions{
@@ -209,7 +223,7 @@ func updateRepositoryLocked(path, url, ref string, skipTLSVerify bool, proxyOpts
 		return nil, err
 	}
 
-	err = FetchRepository(repo, url, skipTLSVerify, proxyOpts, auth, depth)
+	err = fetchRepositoryLocked(repo, url, skipTLSVerify, proxyOpts, auth, depth)
 	if err != nil {
 		if IsCorruptionError(err) {
 			repairedRepo, repairErr := repairAfterCorruptionLocked(path, url, ref, "fetch", err, skipTLSVerify, proxyOpts, auth, cloneSubmodules, depth)
@@ -221,6 +235,11 @@ func updateRepositoryLocked(path, url, ref string, skipTLSVerify bool, proxyOpts
 		}
 
 		return nil, fmt.Errorf("%w: %w", ErrFetchFailed, err)
+	}
+
+	fetchedExists, fetchedCheckErr := fetchedReferenceExistsAfterFetch(repo, ref)
+	if fetchedCheckErr == nil && !fetchedExists {
+		return nil, fmt.Errorf("%w: %w: %s", ErrCheckoutFailed, ErrInvalidReference, ref)
 	}
 
 	// Pass auth and cloneSubmodules so CheckoutRepository can ensure submodules are updated when needed.
@@ -462,7 +481,7 @@ func deepenAndCheckout(repo *git.Repository, url, ref string, skipTLSVerify bool
 			slog.Int("previous_depth", currentDepth),
 			slog.String("new_depth", label))
 
-		err := FetchRepository(repo, url, skipTLSVerify, proxyOpts, auth, newDepth)
+		err := fetchRepositoryLocked(repo, url, skipTLSVerify, proxyOpts, auth, newDepth)
 		if err != nil {
 			if isNonRecoverableError(err) {
 				return nil, fmt.Errorf("non-recoverable error during deepen: %w", err)


### PR DESCRIPTION
Improved the Git package further:
- Serialized standalone fetches with clone/update/repair operations.
- Canonicalized lock paths to prevent symlink-based concurrency bypasses.
- Prevented deleted remote branches from using stale local refs.
- Added nested branch-ref watcher support.
- Kept watcher setup resilient to transient directory/watch failures.
- Preserved HEAD pseudo-reference updates.