### PR TITLE
perf(git): improve performance for resetting tracked files 

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/kimdre/doco-cd/internal/encryption"
 )
@@ -28,49 +29,75 @@ func ResetTrackedFiles(repo *git.Repository) error {
 
 	resetFiles := make([]string, 0, len(changedFiles))
 
+	headRef, err := repo.Head()
+	if err != nil {
+		return resetChangedFiles(worktree, changedFiles)
+	}
+
+	commit, err := repo.CommitObject(headRef.Hash())
+	if err != nil {
+		return resetChangedFiles(worktree, changedFiles)
+	}
+
+	tree, err := commit.Tree()
+	if err != nil {
+		return resetChangedFiles(worktree, changedFiles)
+	}
+
 	for file, status := range changedFiles {
 		// Do not touch files that are not part of the Git repository (e.g. created by a container process)
 		if status.Staging == git.Untracked {
 			continue
 		}
 
-		if shouldResetDecryptedFile(repo, repoRoot, file) {
+		if shouldResetDecryptedFile(tree, repoRoot, file) {
 			resetFiles = append(resetFiles, file)
 		}
 	}
 
-	if len(resetFiles) > 0 {
-		err = worktree.Reset(&git.ResetOptions{
-			Mode:  git.HardReset,
-			Files: resetFiles,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to reset worktree: %w", err)
+	return resetFilesInWorktree(worktree, resetFiles)
+}
+
+func resetChangedFiles(worktree *git.Worktree, changedFiles git.Status) error {
+	resetFiles := make([]string, 0, len(changedFiles))
+
+	for file, status := range changedFiles {
+		if status.Staging != git.Untracked {
+			resetFiles = append(resetFiles, file)
 		}
+	}
+
+	return resetFilesInWorktree(worktree, resetFiles)
+}
+
+func resetFilesInWorktree(worktree *git.Worktree, files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	if err := worktree.Reset(&git.ResetOptions{
+		Mode:  git.HardReset,
+		Files: files,
+	}); err != nil {
+		return fmt.Errorf("failed to reset worktree: %w", err)
 	}
 
 	return nil
 }
 
 // shouldResetDecryptedFile determines whether a file should be reset based on its decrypted content.
-func shouldResetDecryptedFile(repo *git.Repository, repoRoot, file string) bool {
-	headRef, err := repo.Head()
-	if err != nil {
-		return true
-	}
-
-	commit, err := repo.CommitObject(headRef.Hash())
-	if err != nil {
-		return true
-	}
-	// Get file from commit tree
-	fileObj, err := commit.File(file)
+func shouldResetDecryptedFile(tree *object.Tree, repoRoot, file string) bool {
+	fileObj, err := tree.File(file)
 	if err != nil {
 		return true // Not tracked, default to reset
 	}
 
 	committedBytes, err := fileObj.Contents()
 	if err != nil {
+		return true
+	}
+
+	if !encryption.IsEncryptedContent(committedBytes) {
 		return true
 	}
 

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -58,6 +58,7 @@ func ResetTrackedFiles(repo *git.Repository) error {
 	return resetFilesInWorktree(worktree, resetFiles)
 }
 
+// resetChangedFiles resets all changed files in the worktree to their last committed state.
 func resetChangedFiles(worktree *git.Worktree, changedFiles git.Status) error {
 	resetFiles := make([]string, 0, len(changedFiles))
 
@@ -70,6 +71,7 @@ func resetChangedFiles(worktree *git.Worktree, changedFiles git.Status) error {
 	return resetFilesInWorktree(worktree, resetFiles)
 }
 
+// resetFilesInWorktree resets the specified files in the worktree to their last committed state.
 func resetFilesInWorktree(worktree *git.Worktree, files []string) error {
 	if len(files) == 0 {
 		return nil

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,11 +1,46 @@
 package git_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
 	"github.com/kimdre/doco-cd/internal/git"
 )
+
+func TestResetTrackedFiles_ResetsTrackedFilesAndKeepsUntrackedFiles(t *testing.T) {
+	t.Parallel()
+
+	repoPath := t.TempDir()
+	repo := initLocalTestRepo(t, repoPath)
+
+	readmePath := filepath.Join(repoPath, "README.md")
+	if err := os.WriteFile(readmePath, []byte("modified\n"), 0o600); err != nil {
+		t.Fatalf("failed to modify tracked file: %v", err)
+	}
+
+	untrackedPath := filepath.Join(repoPath, "untracked.txt")
+	if err := os.WriteFile(untrackedPath, []byte("untracked\n"), 0o600); err != nil {
+		t.Fatalf("failed to create untracked file: %v", err)
+	}
+
+	if err := git.ResetTrackedFiles(repo); err != nil {
+		t.Fatalf("failed to reset tracked files: %v", err)
+	}
+
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("failed to read reset tracked file: %v", err)
+	}
+	if string(content) != "initial\n" {
+		t.Errorf("tracked file = %q, want %q", content, "initial\n")
+	}
+
+	if _, err := os.Stat(untrackedPath); err != nil {
+		t.Errorf("untracked file was removed: %v", err)
+	}
+}
 
 func TestUpdateRepository_KeepUntrackedFiles(t *testing.T) {
 	t.Parallel()

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -33,6 +33,7 @@ func TestResetTrackedFiles_ResetsTrackedFilesAndKeepsUntrackedFiles(t *testing.T
 	if err != nil {
 		t.Fatalf("failed to read reset tracked file: %v", err)
 	}
+
 	if string(content) != "initial\n" {
 		t.Errorf("tracked file = %q, want %q", content, "initial\n")
 	}


### PR DESCRIPTION
This pull request refactors and improves the logic for resetting tracked files in the Git worktree, making the code more robust and testable. The main changes include refactoring `ResetTrackedFiles` to use commit trees instead of repositories, extracting helper functions for resetting files, improving the logic for determining which files to reset, and adding a new test to verify correct behavior.