### PR TITLE
fix(deploy): compare auto-discovery config semantically

### DIFF
--- a/internal/docker/auto_discovery_label_test.go
+++ b/internal/docker/auto_discovery_label_test.go
@@ -1,0 +1,99 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/kimdre/doco-cd/internal/config/deploy"
+)
+
+// TestParseAutoDiscoveryConfigIgnoresKeyOrder prevents serialization-only drift (#1818).
+func TestParseAutoDiscoveryConfigIgnoresKeyOrder(t *testing.T) {
+	t.Parallel()
+
+	want := deploy.AutoDiscoveryConfig{
+		Enabled:      true,
+		Delete:       true,
+		RemoveImages: true,
+	}
+
+	labels := []string{
+		"{enabled: true, depth: 0, delete: true, remove_volumes: false, remove_images: true}",
+		"{depth: 0, enabled: true, delete: true, remove_volumes: false, remove_images: true}",
+		"{remove_images: true, remove_volumes: false, delete: true, depth: 0, enabled: true}",
+	}
+
+	for _, label := range labels {
+		if got := ParseAutoDiscoveryConfig(label); got != want {
+			t.Errorf("ParseAutoDiscoveryConfig(%q) = %+v, want %+v", label, got, want)
+		}
+	}
+}
+
+func TestMarshalAutoDiscoveryConfigRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	configs := []deploy.AutoDiscoveryConfig{
+		{Enabled: true, Delete: true, RemoveImages: true},
+		{Enabled: true, ScanDepth: 2, Delete: true, RemoveVolumes: true, RemoveImages: true},
+		{Enabled: false, ScanDepth: 1},
+	}
+
+	for _, cfg := range configs {
+		if got := ParseAutoDiscoveryConfig(MarshalAutoDiscoveryConfig(cfg)); got != cfg {
+			t.Errorf("round trip = %+v, want %+v", got, cfg)
+		}
+	}
+}
+
+func TestAutoDiscoveryConfigsEqual(t *testing.T) {
+	t.Parallel()
+
+	base := deploy.AutoDiscoveryConfig{
+		Enabled:      true,
+		ScanDepth:    2,
+		Delete:       true,
+		RemoveImages: true,
+	}
+
+	tests := []struct {
+		name string
+		a, b deploy.AutoDiscoveryConfig
+		want bool
+	}{
+		{name: "identical", a: base, b: base, want: true},
+		{
+			name: "labels written in a different key order",
+			a:    base,
+			b:    ParseAutoDiscoveryConfig("{depth: 2, enabled: true, delete: true, remove_volumes: false, remove_images: true}"),
+			want: true,
+		},
+		{
+			name: "differing scan depth",
+			a:    base,
+			b:    deploy.AutoDiscoveryConfig{Enabled: true, ScanDepth: 3, Delete: true, RemoveImages: true},
+			want: false,
+		},
+		{
+			name: "differing bool",
+			a:    base,
+			b:    deploy.AutoDiscoveryConfig{Enabled: true, ScanDepth: 2, Delete: false, RemoveImages: true},
+			want: false,
+		},
+		{
+			name: "zero values",
+			a:    deploy.AutoDiscoveryConfig{},
+			b:    deploy.AutoDiscoveryConfig{},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := AutoDiscoveryConfigsEqual(tt.a, tt.b); got != tt.want {
+				t.Fatalf("AutoDiscoveryConfigsEqual(%+v, %+v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/docker/utils.go
+++ b/internal/docker/utils.go
@@ -347,3 +347,9 @@ func ParseAutoDiscoveryConfig(labelValue string) deployConfig.AutoDiscoveryConfi
 
 	return cfg
 }
+
+// AutoDiscoveryConfigsEqual reports whether two auto-discovery configs are equivalent.
+// Compare normalized label values to support future complex fields (#1818).
+func AutoDiscoveryConfigsEqual(a, b deployConfig.AutoDiscoveryConfig) bool {
+	return MarshalAutoDiscoveryConfig(a) == MarshalAutoDiscoveryConfig(b)
+}

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -55,7 +55,10 @@ func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]doc
 		actual, ok := status.Labels[docker.DocoCDLabels.Deployment.AutoDiscoveryConfig]
 
 		actual = strings.TrimSpace(actual)
-		if ok && actual == expected {
+		deployedCfg := docker.ParseAutoDiscoveryConfig(actual)
+
+		// Ignore serialization-only differences (#1818).
+		if ok && docker.AutoDiscoveryConfigsEqual(deployedCfg, expectedCfg) {
 			continue
 		}
 
@@ -63,7 +66,6 @@ func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]doc
 		// cleanup reads containers labeled as auto-discovered. With auto-discovery off in
 		// both configs, including the legacy enabled label when the config label is absent,
 		// the config label is inert, so a changed default is no reason to recreate the stack.
-		deployedCfg := docker.ParseAutoDiscoveryConfig(actual)
 		legacyAutoDiscoveryEnabled, _ := strconv.ParseBool(status.Labels[docker.DocoCDLabels.Deployment.AutoDiscovery])
 
 		if !expectedCfg.Enabled && !deployedCfg.Enabled && (ok || !legacyAutoDiscoveryEnabled) {

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -17,6 +17,7 @@ import (
 	secrettypes "github.com/kimdre/doco-cd/internal/secretprovider/types"
 
 	"github.com/kimdre/doco-cd/internal/config"
+	deployConfig "github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 	"github.com/kimdre/doco-cd/internal/git"
@@ -39,15 +40,12 @@ func shouldSkipDeployment(retryAfterFailure bool,
 		len(mismatchServices) == 0
 }
 
-func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]docker.ServiceStatus, expected string) ([]string, string) {
-	expected = strings.TrimSpace(expected)
-
+func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]docker.ServiceStatus, expectedCfg deployConfig.AutoDiscoveryConfig) ([]string, string) {
 	if len(deployedStatus) == 0 {
 		return nil, ""
 	}
 
 	affected := make([]string, 0, len(deployedStatus))
-	expectedCfg := docker.ParseAutoDiscoveryConfig(expected)
 
 	var firstObserved string
 
@@ -80,7 +78,7 @@ func autoDiscoveryConfigLabelDriftServices(deployedStatus map[docker.Service]doc
 	}
 
 	if len(affected) == 0 {
-		return nil, expected
+		return nil, docker.MarshalAutoDiscoveryConfig(expectedCfg)
 	}
 
 	slices.Sort(affected)
@@ -206,18 +204,19 @@ func (s *StageManager) RunPreDeployStage(ctx context.Context, stageLog *slog.Log
 	// project would touch nothing. Force recreate so the retry re-runs it all.
 	retryForceRecreate := retryAfterFailure && lastFailure.Stage == string(StageDeploy)
 
-	expectedAutoDiscoveryLabel := docker.MarshalAutoDiscoveryConfig(s.DeployConfig.AutoDiscovery)
 	autoDiscoveryDriftServices, deployedAutoDiscoveryLabel := autoDiscoveryConfigLabelDriftServices(
 		deployedState.DeployedStatus,
-		expectedAutoDiscoveryLabel,
+		s.DeployConfig.AutoDiscovery,
 	)
 
 	autoDiscoveryConfigChanged := len(autoDiscoveryDriftServices) > 0
 	if autoDiscoveryConfigChanged {
 		stageLog.Debug("auto-discovery config label changed, proceeding with deployment",
 			slog.Any("affected_services", autoDiscoveryDriftServices),
-			slog.String("deployed_auto_discovery_config", deployedAutoDiscoveryLabel),
-			slog.String("expected_auto_discovery_config", expectedAutoDiscoveryLabel),
+			slog.Group("auto_discovery_config",
+				slog.String("deployed", deployedAutoDiscoveryLabel),
+				slog.String("expected", docker.MarshalAutoDiscoveryConfig(s.DeployConfig.AutoDiscovery)),
+			),
 		)
 	}
 

--- a/internal/stages/stage_2_pre-deploy_test.go
+++ b/internal/stages/stage_2_pre-deploy_test.go
@@ -44,6 +44,19 @@ func TestAutoDiscoveryConfigLabelDriftServices(t *testing.T) {
 			wantFirstLabel: expected,
 		},
 		{
+			// Serialization-only changes must not cause drift (#1818).
+			name: "same config, different key order",
+			status: map[docker.Service]docker.ServiceStatus{
+				"web": {
+					Labels: docker.Labels{
+						docker.DocoCDLabels.Deployment.AutoDiscoveryConfig: "{depth: 0, enabled: true, delete: false, remove_volumes: true, remove_images: true}",
+					},
+				},
+			},
+			wantServices:   nil,
+			wantFirstLabel: expected,
+		},
+		{
 			name: "mismatched labels",
 			status: map[docker.Service]docker.ServiceStatus{
 				"web": {

--- a/internal/stages/stage_2_pre-deploy_test.go
+++ b/internal/stages/stage_2_pre-deploy_test.go
@@ -152,13 +152,20 @@ func TestAutoDiscoveryConfigLabelDriftServices(t *testing.T) {
 				expected = tt.expected
 			}
 
-			gotServices, gotFirst := autoDiscoveryConfigLabelDriftServices(tt.status, expected)
+			expectedCfg := docker.ParseAutoDiscoveryConfig(expected)
+
+			gotServices, gotFirst := autoDiscoveryConfigLabelDriftServices(tt.status, expectedCfg)
 			if !slices.Equal(gotServices, tt.wantServices) {
 				t.Fatalf("autoDiscoveryConfigLabelDriftServices() services = %v, want %v", gotServices, tt.wantServices)
 			}
 
-			if gotFirst != tt.wantFirstLabel {
-				t.Fatalf("autoDiscoveryConfigLabelDriftServices() first label = %q, want %q", gotFirst, tt.wantFirstLabel)
+			wantFirstLabel := tt.wantFirstLabel
+			if wantFirstLabel == expected {
+				wantFirstLabel = docker.MarshalAutoDiscoveryConfig(expectedCfg)
+			}
+
+			if gotFirst != wantFirstLabel {
+				t.Fatalf("autoDiscoveryConfigLabelDriftServices() first label = %q, want %q", gotFirst, wantFirstLabel)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes an issue where a harmless reordering of `AutoDiscoveryConfig` fields caused doco-cd to force-recreate every service in all deployed stacks.

The auto-discovery config label is YAML, but drift detection compared its serialized strings. Reordering fields changed the label from:

```text
{enabled: true, depth: 0, ...}
```

to:

```text
{depth: 0, enabled: true, ...}
```

Although both labels represent the same configuration, every service was detected as changed and deployed with `--force-recreate`.

## Changes

- Compare decoded, normalized auto-discovery configs instead of raw label strings.
- Use a future-safe comparison that supports complex config fields.
- Pass the expected `AutoDiscoveryConfig` directly to drift detection, avoiding an unnecessary marshal/parse round trip.
- Group deployed and expected auto-discovery config values in drift logs.
- Add regression coverage for labels with equivalent values in different key orders.

## Validation

- `go test ./internal/docker/... ./internal/stages/... ./internal/config/deploy/... ./internal/reconciliation/...`