### PR TITLE
feat(openbao): expose full certificate chain as a _FULL companion variable

### DIFF
--- a/internal/docker/cert_rotation_labels.go
+++ b/internal/docker/cert_rotation_labels.go
@@ -26,8 +26,12 @@ const (
 )
 
 // pkiRoleKeySuffix is the suffix appended to a pki-role external secret's env
-// var name for its private key companion entry.
-const pkiRoleKeySuffix = secrettypes.PKIRoleKeySuffix
+// var name for its private key companion entry, and pkiFullChainSuffix the one for the full
+// certificate chain companion entry exposed for both pki and pki-role references.
+const (
+	pkiRoleKeySuffix   = secrettypes.PKIRoleKeySuffix
+	pkiFullChainSuffix = secrettypes.PKIFullChainSuffix
+)
 
 type deployedRotatableCertState struct {
 	Ref    string `json:"ref"`
@@ -50,7 +54,7 @@ func rotatableCertValues(deployConfig *deploy.Config) map[string]string {
 			continue
 		}
 
-		for _, name := range [2]string{envVar, envVar + pkiRoleKeySuffix} {
+		for _, name := range [3]string{envVar, envVar + pkiRoleKeySuffix, envVar + pkiFullChainSuffix} {
 			if v, ok := deployConfig.Internal.Environment[name]; ok && v != "" {
 				values[name] = v
 			}
@@ -80,6 +84,10 @@ func certificateValues(deployConfig *deploy.Config) map[string]string {
 
 		if v, ok := deployConfig.Internal.Environment[envVar]; ok && v != "" {
 			values[envVar] = v
+		}
+
+		if v, ok := deployConfig.Internal.Environment[envVar+pkiFullChainSuffix]; ok && v != "" {
+			values[envVar+pkiFullChainSuffix] = v
 		}
 
 		if isPKIRole {

--- a/internal/secretprovider/openbao/client.go
+++ b/internal/secretprovider/openbao/client.go
@@ -28,14 +28,30 @@ const (
 // expose the matching private key issued alongside the certificate (e.g. CERT -> CERT_KEY).
 const PKIRoleKeySuffix = secrettypes.PKIRoleKeySuffix
 
-// pkiRoleRefRegexp is a precompiled matcher for PKIRoleRefFormat, used where matching happens in a
-// loop (e.g. ResolveSecretReferences) to avoid recompiling the pattern on every call.
-var pkiRoleRefRegexp = regexp.MustCompile(PKIRoleRefFormat)
+// PKIFullChainSuffix is appended to the env var name of a pki or pki-role external secret
+// reference to expose the full certificate chain, i.e. the leaf certificate followed by its
+// issuing CA chain (e.g. CERT -> CERT_FULL), alongside the leaf-only certificate entry.
+const PKIFullChainSuffix = secrettypes.PKIFullChainSuffix
+
+// pkiRefRegexp and pkiRoleRefRegexp are precompiled matchers for PKIRefFormat and
+// PKIRoleRefFormat, used where matching happens in a loop (e.g. ResolveSecretReferences) to avoid
+// recompiling the patterns on every call.
+var (
+	pkiRefRegexp     = regexp.MustCompile(PKIRefFormat)
+	pkiRoleRefRegexp = regexp.MustCompile(PKIRoleRefFormat)
+)
 
 var ErrInvalidSecretReference = errors.New("invalid secret reference")
 
 type Provider struct {
 	Client *openbao.Client
+}
+
+// pkiCertValues holds the resolved values of a read-only pki reference: the leaf certificate and
+// the full chain bundle exposed alongside it under PKIFullChainSuffix.
+type pkiCertValues struct {
+	Certificate string
+	FullChain   string
 }
 
 type deployedCertState struct {
@@ -161,25 +177,43 @@ func (p *Provider) GetSecrets(ctx context.Context, refs []string) (map[string]st
 // ResolveSecretReferences resolves the provided map of environment variable names to secret IDs
 // by fetching the corresponding secret values from the secret provider.
 //
-// A pki-role reference (see PKIRoleRefFormat) issues a fresh certificate and its matching private
-// key, and expands into two output entries: envVar holds the certificate PEM, and envVar + PKIRoleKeySuffix
-// (e.g. CERT_KEY) holds the private key PEM.
+// Certificate references expand into more than one output entry, all named after the env var the
+// reference is mapped to:
+//
+//   - A pki reference (see PKIRefFormat) reads an already-issued certificate and expands into two
+//     entries: envVar holds the leaf certificate PEM, and envVar + PKIFullChainSuffix (e.g.
+//     CERT_FULL) holds the leaf certificate followed by its issuing CA chain.
+//   - A pki-role reference (see PKIRoleRefFormat) issues a fresh certificate and its matching
+//     private key, and expands into three entries: envVar holds the leaf certificate PEM,
+//     envVar + PKIRoleKeySuffix (e.g. CERT_KEY) holds the private key PEM, and
+//     envVar + PKIFullChainSuffix (e.g. CERT_FULL) holds the full chain bundle.
 func (p *Provider) ResolveSecretReferences(ctx context.Context, secrets map[string]string) (secrettypes.ResolvedSecrets, error) {
 	plainSecrets := make(map[string]string, len(secrets))
+	pkiSecrets := make(map[string]string, len(secrets))
 	pkiRoleSecrets := make(map[string]string, len(secrets))
 
 	for envVar, ref := range secrets {
-		if pkiRoleRefRegexp.MatchString(ref) {
+		switch {
+		case pkiRoleRefRegexp.MatchString(ref):
 			pkiRoleSecrets[envVar] = ref
-			continue
+		case pkiRefRegexp.MatchString(ref):
+			pkiSecrets[envVar] = ref
+		default:
+			plainSecrets[envVar] = ref
 		}
-
-		plainSecrets[envVar] = ref
 	}
 
 	for envVar := range pkiRoleSecrets {
 		if _, exists := secrets[envVar+PKIRoleKeySuffix]; exists {
 			return nil, fmt.Errorf("external secret %q conflicts with the private key generated for pki-role secret %q", envVar+PKIRoleKeySuffix, envVar)
+		}
+	}
+
+	for _, certSecrets := range []map[string]string{pkiSecrets, pkiRoleSecrets} {
+		for envVar := range certSecrets {
+			if _, exists := secrets[envVar+PKIFullChainSuffix]; exists {
+				return nil, fmt.Errorf("external secret %q conflicts with the certificate chain generated for certificate secret %q", envVar+PKIFullChainSuffix, envVar)
+			}
 		}
 	}
 
@@ -205,6 +239,18 @@ func (p *Provider) ResolveSecretReferences(ctx context.Context, secrets map[stri
 		}
 	}
 
+	if len(pkiSecrets) > 0 {
+		resolved, err := p.resolvePKICerts(ctx, pkiSecrets)
+		if err != nil {
+			return nil, err
+		}
+
+		for envVar, cert := range resolved {
+			out[envVar] = cert.Certificate
+			out[envVar+PKIFullChainSuffix] = cert.FullChain
+		}
+	}
+
 	if len(pkiRoleSecrets) > 0 {
 		issued, err := p.issuePKIRoleCerts(ctx, pkiRoleSecrets)
 		if err != nil {
@@ -214,6 +260,7 @@ func (p *Provider) ResolveSecretReferences(ctx context.Context, secrets map[stri
 		for envVar, cert := range issued {
 			out[envVar] = cert.Certificate
 			out[envVar+PKIRoleKeySuffix] = cert.PrivateKey
+			out[envVar+PKIFullChainSuffix] = cert.FullChain()
 		}
 	}
 
@@ -271,6 +318,71 @@ func (p *Provider) DeploymentHasRevokedCertificate(ctx context.Context, certStat
 	}
 
 	return false, nil
+}
+
+// resolvePKICerts reads the already-issued certificate behind each read-only pki reference in
+// refs, together with its full chain bundle, keyed by the same env var name used in the input map.
+func (p *Provider) resolvePKICerts(ctx context.Context, refs map[string]string) (map[string]pkiCertValues, error) {
+	resolved := make(map[string]pkiCertValues, len(refs))
+
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+
+	for envVar, ref := range refs {
+		wg.Add(1)
+
+		go func(envVar, ref string) {
+			defer wg.Done()
+
+			fail := func(err error) {
+				select {
+				case errCh <- err:
+					cancel()
+				default:
+				}
+			}
+
+			namespace, _, engineName, commonName, _, err := parseReference(ref)
+			if err != nil {
+				fail(err)
+				return
+			}
+
+			c := p.Client.WithNamespace(namespace)
+
+			serial, err := GetCertSerial(ctx, c, engineName, commonName)
+			if err != nil {
+				fail(fmt.Errorf("failed to retrieve certificate serial for common name %s: %w", commonName, err))
+				return
+			}
+
+			cert, fullChain, err := GetCertWithFullChain(ctx, c, engineName, serial)
+			if err != nil {
+				fail(fmt.Errorf("failed to retrieve certificate with serial %s: %w", serial, err))
+				return
+			}
+
+			mu.Lock()
+			resolved[envVar] = pkiCertValues{Certificate: cert, FullChain: fullChain}
+			mu.Unlock()
+		}(envVar, ref)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	if err, ok := <-errCh; ok {
+		return nil, err
+	}
+
+	return resolved, nil
 }
 
 // issuePKIRoleCerts issues a fresh certificate/key pair for each pki-role reference in refs,

--- a/internal/secretprovider/openbao/client_test.go
+++ b/internal/secretprovider/openbao/client_test.go
@@ -402,6 +402,64 @@ func TestProvider_OpenBao(t *testing.T) {
 		}
 	})
 
+	t.Run("PKIFullChain", func(t *testing.T) {
+		certRef := "pki:pki:test.example.com" // #nosec G101
+
+		resolved, err := provider.ResolveSecretReferences(t.Context(), map[string]string{"CERT": certRef})
+		if err != nil {
+			t.Fatalf("Failed to resolve pki reference: %v", err)
+		}
+
+		leaf, fullChain := resolved["CERT"], resolved["CERT_FULL"]
+
+		if got := countPEMCertificates(t, leaf); got != 1 {
+			t.Errorf("Expected the certificate entry to hold the leaf only, got %d certificates", got)
+		}
+
+		if got := countPEMCertificates(t, fullChain); got < 2 {
+			t.Errorf("Expected CERT_FULL to contain the leaf and at least one CA certificate, got %d", got)
+		}
+
+		if !strings.HasPrefix(fullChain, strings.TrimSpace(leaf)) {
+			t.Error("Expected CERT_FULL to start with the leaf certificate")
+		}
+
+		// A pki reference has no private key companion.
+		if _, exists := resolved["CERT_KEY"]; exists {
+			t.Error("Expected no CERT_KEY entry for a read-only pki reference")
+		}
+	})
+
+	t.Run("PKIRoleFullChain", func(t *testing.T) {
+		resolved, err := provider.ResolveSecretReferences(t.Context(), map[string]string{
+			"CERT": "pki-role:pki:example-dot-com:fullchain.example.com", // #nosec G101
+		})
+		if err != nil {
+			t.Fatalf("Failed to resolve pki-role reference: %v", err)
+		}
+
+		// The certificate entry stays leaf-only so the private key still pairs with it and cert
+		// rotation labels keep reading the leaf's expiry and serial.
+		validateIssuedCertificatePair(t, resolved, "full chain")
+
+		if got := countPEMCertificates(t, resolved["CERT"]); got != 1 {
+			t.Errorf("Expected the certificate entry to hold the leaf only, got %d certificates", got)
+		}
+
+		fullChain := resolved["CERT_FULL"]
+		if got := countPEMCertificates(t, fullChain); got < 2 {
+			t.Errorf("Expected CERT_FULL to contain the leaf and at least one CA certificate, got %d", got)
+		}
+
+		if !strings.HasPrefix(fullChain, strings.TrimSpace(resolved["CERT"])) {
+			t.Error("Expected CERT_FULL to start with the leaf certificate")
+		}
+
+		if got := countPEMCertificates(t, resolved["CERT_KEY"]); got != 0 {
+			t.Errorf("Expected the private key entry to hold no certificates, got %d", got)
+		}
+	})
+
 	t.Run("DeploymentHasRevokedCertificate", func(t *testing.T) {
 		ref := "pki-role:pki:example-dot-com:revoked.example.com" // #nosec G101
 
@@ -493,5 +551,60 @@ func TestResolveSecretReferences_RejectsGeneratedPrivateKeyCollision(t *testing.
 
 	if !strings.Contains(err.Error(), "CERT_KEY") {
 		t.Fatalf("expected collision error to identify CERT_KEY, got: %v", err)
+	}
+}
+
+func TestResolveSecretReferences_RejectsGeneratedFullChainCollision(t *testing.T) {
+	testCases := []struct {
+		name string
+		ref  string
+	}{
+		{
+			name: "pki-role reference",
+			ref:  "pki-role:pki:example-dot-com:issued.example.com", // #nosec G101
+		},
+		{
+			name: "read-only pki reference",
+			ref:  "pki:pki:issued.example.com", // #nosec G101
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &Provider{}
+
+			_, err := provider.ResolveSecretReferences(t.Context(), map[string]string{
+				"CERT":      tc.ref,
+				"CERT_FULL": "kv:secret:chain:value", // #nosec G101
+			})
+			if err == nil {
+				t.Fatal("expected full chain collision to fail")
+			}
+
+			if !strings.Contains(err.Error(), "CERT_FULL") {
+				t.Fatalf("expected collision error to identify CERT_FULL, got: %v", err)
+			}
+		})
+	}
+}
+
+// countPEMCertificates returns how many PEM CERTIFICATE blocks value contains.
+func countPEMCertificates(t *testing.T, value string) int {
+	t.Helper()
+
+	count := 0
+	rest := []byte(value)
+
+	for {
+		var block *pem.Block
+
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			return count
+		}
+
+		if block.Type == "CERTIFICATE" {
+			count++
+		}
 	}
 }

--- a/internal/secretprovider/openbao/pki.go
+++ b/internal/secretprovider/openbao/pki.go
@@ -12,11 +12,75 @@ import (
 )
 
 // IssuedCertificate represents a certificate freshly issued by an OpenBao PKI role,
-// including its matching private key and expiration time.
+// including its matching private key, its issuing CA chain and expiration time.
 type IssuedCertificate struct {
 	Certificate string
+	CAChain     []string
 	PrivateKey  string
 	Expiration  time.Time
+}
+
+// FullChain returns the leaf certificate followed by its issuing CA chain as a single PEM bundle.
+// When no CA chain was returned by OpenBao, it is equivalent to Certificate.
+func (c IssuedCertificate) FullChain() string {
+	return joinPEMChain(c.Certificate, c.CAChain)
+}
+
+// joinPEMChain concatenates a leaf certificate with its issuing CA chain into a single PEM bundle
+// (commonly called a fullchain), skipping empty and duplicate entries.
+func joinPEMChain(leaf string, chain []string) string {
+	parts := make([]string, 0, len(chain)+1)
+	seen := make(map[string]struct{}, len(chain)+1)
+
+	for _, cert := range append([]string{leaf}, chain...) {
+		cert = strings.TrimSpace(cert)
+		if cert == "" {
+			continue
+		}
+
+		if _, exists := seen[cert]; exists {
+			continue
+		}
+
+		seen[cert] = struct{}{}
+
+		parts = append(parts, cert)
+	}
+
+	return strings.Join(parts, "\n")
+}
+
+// parseCAChain extracts the issuing CA chain from a PKI response payload. OpenBao returns the
+// chain as ca_chain; older mounts and some endpoints only expose the single issuing CA, which is
+// then used as a one-element chain.
+func parseCAChain(data map[string]any) []string {
+	switch chain := data["ca_chain"].(type) {
+	case []string:
+		if len(chain) > 0 {
+			return chain
+		}
+	case []any:
+		certs := make([]string, 0, len(chain))
+
+		for _, entry := range chain {
+			cert, ok := entry.(string)
+			if !ok {
+				continue
+			}
+
+			certs = append(certs, cert)
+		}
+
+		if len(certs) > 0 {
+			return certs
+		}
+	}
+
+	if issuingCA, ok := data["issuing_ca"].(string); ok && strings.TrimSpace(issuingCA) != "" {
+		return []string{issuingCA}
+	}
+
+	return nil
 }
 
 // GetCertSerial retrieves the serial number of a certificate from the PKI engine in OpenBao using the provided engine name and common name.
@@ -48,27 +112,78 @@ func GetCertSerial(ctx context.Context, client *api.Client, engineName, commonNa
 
 // GetCert retrieves a certificate from the PKI engine in OpenBao using the provided engine name and serial number.
 func GetCert(ctx context.Context, client *api.Client, engineName, serial string) (string, error) {
+	cert, _, err := readCert(ctx, client, engineName, serial)
+
+	return cert, err
+}
+
+// GetCertWithFullChain retrieves a certificate from the PKI engine in OpenBao and returns both the
+// leaf certificate on its own and the PEM bundle of the leaf followed by its issuing CA chain.
+// When the read response carries no chain, the mount's CA chain is fetched separately.
+func GetCertWithFullChain(ctx context.Context, client *api.Client, engineName, serial string) (cert, fullChain string, err error) {
+	cert, chain, err := readCert(ctx, client, engineName, serial)
+	if err != nil {
+		return "", "", err
+	}
+
+	if len(chain) == 0 {
+		chain, err = GetCAChain(ctx, client, engineName)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	return cert, joinPEMChain(cert, chain), nil
+}
+
+// GetCAChain returns the CA chain of the given PKI mount, from the issuing CA up to the root.
+func GetCAChain(ctx context.Context, client *api.Client, engineName string) ([]string, error) {
+	pathToRead := engineName + "/cert/ca_chain"
+
+	response, err := client.Logical().ReadWithContext(ctx, pathToRead)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read CA chain from OpenBao: %w", err)
+	}
+
+	if response == nil || response.Data == nil {
+		return nil, nil
+	}
+
+	if chain := parseCAChain(response.Data); len(chain) > 0 {
+		return chain, nil
+	}
+
+	// The ca_chain pseudo-serial returns the concatenated chain in the certificate field.
+	if bundle, ok := response.Data["certificate"].(string); ok && strings.TrimSpace(bundle) != "" {
+		return []string{bundle}, nil
+	}
+
+	return nil, nil
+}
+
+// readCert reads a certificate and, when available, its issuing CA chain from the PKI engine.
+func readCert(ctx context.Context, client *api.Client, engineName, serial string) (string, []string, error) {
 	pathToRead := fmt.Sprintf("%s/cert/%s", engineName, serial)
 
 	response, err := client.Logical().ReadWithContext(ctx, pathToRead)
 	if err != nil {
-		return "", fmt.Errorf("unable to read certificate from OpenBao: %w", err)
+		return "", nil, fmt.Errorf("unable to read certificate from OpenBao: %w", err)
 	}
 
 	if response == nil {
-		return "", errors.New("no data found for the given certificate serial: " + serial)
+		return "", nil, errors.New("no data found for the given certificate serial: " + serial)
 	}
 
 	if response.Data == nil {
-		return "", errors.New("no data found in the response")
+		return "", nil, errors.New("no data found in the response")
 	}
 
 	certValue, ok := response.Data["certificate"].(string)
 	if !ok {
-		return "", errors.New("certificate not found in the response data")
+		return "", nil, errors.New("certificate not found in the response data")
 	}
 
-	return certValue, nil
+	return certValue, parseCAChain(response.Data), nil
 }
 
 // ListRevokedCertSerials returns the serial numbers of certificates revoked from the given PKI
@@ -161,6 +276,7 @@ func IssueCert(ctx context.Context, client *api.Client, engineName, roleName, co
 
 	return IssuedCertificate{
 		Certificate: certValue,
+		CAChain:     parseCAChain(response.Data),
 		PrivateKey:  keyValue,
 		Expiration:  expiration,
 	}, nil

--- a/internal/secretprovider/openbao/pki_test.go
+++ b/internal/secretprovider/openbao/pki_test.go
@@ -1,0 +1,124 @@
+package openbao
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	testLeafPEM   = "-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----"
+	testIssuerPEM = "-----BEGIN CERTIFICATE-----\nissuer\n-----END CERTIFICATE-----"
+	testRootPEM   = "-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----"
+)
+
+func TestJoinPEMChain(t *testing.T) {
+	testCases := []struct {
+		name     string
+		leaf     string
+		chain    []string
+		expected string
+	}{
+		{
+			name:     "No chain returns the leaf only",
+			leaf:     testLeafPEM,
+			chain:    nil,
+			expected: testLeafPEM,
+		},
+		{
+			name:     "Leaf is followed by the issuing chain",
+			leaf:     testLeafPEM,
+			chain:    []string{testIssuerPEM, testRootPEM},
+			expected: testLeafPEM + "\n" + testIssuerPEM + "\n" + testRootPEM,
+		},
+		{
+			name:     "Chain entry duplicating the leaf is dropped",
+			leaf:     testLeafPEM,
+			chain:    []string{testLeafPEM, testRootPEM},
+			expected: testLeafPEM + "\n" + testRootPEM,
+		},
+		{
+			name:     "Empty and whitespace-only entries are skipped",
+			leaf:     "\n" + testLeafPEM + "\n",
+			chain:    []string{"", "   ", testRootPEM},
+			expected: testLeafPEM + "\n" + testRootPEM,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := joinPEMChain(tc.leaf, tc.chain); got != tc.expected {
+				t.Errorf("Expected %q but got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseCAChain(t *testing.T) {
+	testCases := []struct {
+		name     string
+		data     map[string]any
+		expected []string
+	}{
+		{
+			name:     "ca_chain returned as a list of strings",
+			data:     map[string]any{"ca_chain": []string{testIssuerPEM, testRootPEM}},
+			expected: []string{testIssuerPEM, testRootPEM},
+		},
+		{
+			name:     "ca_chain returned as a JSON decoded list",
+			data:     map[string]any{"ca_chain": []any{testIssuerPEM, testRootPEM}},
+			expected: []string{testIssuerPEM, testRootPEM},
+		},
+		{
+			name:     "Falls back to issuing_ca when no chain is present",
+			data:     map[string]any{"issuing_ca": testRootPEM},
+			expected: []string{testRootPEM},
+		},
+		{
+			name:     "Falls back to issuing_ca when the chain is empty",
+			data:     map[string]any{"ca_chain": []any{}, "issuing_ca": testRootPEM},
+			expected: []string{testRootPEM},
+		},
+		{
+			name:     "No chain information available",
+			data:     map[string]any{"certificate": testLeafPEM},
+			expected: nil,
+		},
+		{
+			name:     "Blank issuing_ca is ignored",
+			data:     map[string]any{"issuing_ca": "  "},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseCAChain(tc.data); !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("Expected %v but got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestIssuedCertificateFullChain(t *testing.T) {
+	issued := IssuedCertificate{
+		Certificate: testLeafPEM,
+		CAChain:     []string{testRootPEM},
+	}
+
+	expected := testLeafPEM + "\n" + testRootPEM
+	if got := issued.FullChain(); got != expected {
+		t.Errorf("Expected %q but got %q", expected, got)
+	}
+
+	// The certificate itself must stay leaf-only, since it is what the private key pairs with.
+	if issued.Certificate != testLeafPEM {
+		t.Errorf("Expected the leaf certificate but got %q", issued.Certificate)
+	}
+
+	// Without a CA chain the bundle degrades to the leaf.
+	noChain := IssuedCertificate{Certificate: testLeafPEM}
+	if got := noChain.FullChain(); got != testLeafPEM {
+		t.Errorf("Expected the leaf certificate but got %q", got)
+	}
+}

--- a/internal/secretprovider/types/types.go
+++ b/internal/secretprovider/types/types.go
@@ -5,3 +5,8 @@ type ResolvedSecrets map[string]string
 // PKIRoleKeySuffix is the suffix appended to the env var name to hold the
 // private key for a pki-role external secret (e.g. CERT → CERT_KEY).
 const PKIRoleKeySuffix = "_KEY"
+
+// PKIFullChainSuffix is the suffix appended to the env var name to hold the full certificate
+// chain (leaf certificate followed by its issuing CA chain) of a pki or pki-role external
+// secret (e.g. CERT → CERT_FULL).
+const PKIFullChainSuffix = "_FULL"

--- a/internal/stages/stage_2_pre-deploy.go
+++ b/internal/stages/stage_2_pre-deploy.go
@@ -497,10 +497,13 @@ func pkiRoleNormMap(externalSecrets map[string]secrettypes.ExternalSecretRef, en
 			norm[v] = ref.LegacyRef
 		}
 
-		// The matching private-key value is stored under <NAME>_KEY.
-		keyName := envVar + secrettypes.PKIRoleKeySuffix
-		if v, ok := env[keyName]; ok && v != "" {
-			norm[v] = ref.LegacyRef + secrettypes.PKIRoleKeySuffix
+		// The matching private-key value is stored under <NAME>_KEY, and the full certificate
+		// chain bundle under <NAME>_FULL. Both change on every issuance, so they need the same
+		// stable placeholder treatment as the certificate itself.
+		for _, suffix := range [2]string{secrettypes.PKIRoleKeySuffix, secrettypes.PKIFullChainSuffix} {
+			if v, ok := env[envVar+suffix]; ok && v != "" {
+				norm[v] = ref.LegacyRef + suffix
+			}
 		}
 	}
 

--- a/wiki/docs/External-Secrets/Openbao.md
+++ b/wiki/docs/External-Secrets/Openbao.md
@@ -80,6 +80,70 @@ services:
         target: /etc/ssl/certs/example.crt
 ```
 
+## Full certificate chain
+
+A `pki:` or `pki-role:` reference resolves to the **leaf certificate only**. Many TLS servers
+(nginx, HAProxy, Traefik, Postgres, …) instead expect a *fullchain* bundle: the leaf certificate
+followed by the intermediate and root CA certificates that signed it, so clients can build a
+complete trust path.
+
+Every certificate reference therefore automatically exposes that bundle as an additional
+environment variable, named after the certificate's variable with a `_FULL` suffix — the same
+mechanism as the [`_KEY` suffix](#private-key-access) used for private keys. An external secret
+named `CERT` resolves to:
+
+- `CERT` &rarr; the leaf certificate PEM
+- `CERT_FULL` &rarr; the leaf certificate followed by its issuing CA chain
+- `CERT_KEY` &rarr; the matching private key PEM (`pki-role:` references only)
+
+```yaml title=".doco-cd.yml"
+name: myapp
+external_secrets:
+  CERT: pki-role:pki:myapp-role:myapp.example.com
+```
+
+```yaml title="docker-compose.yml"
+configs:
+  myapp-fullchain.crt:
+    environment: CERT_FULL
+  myapp-cert.key:
+    environment: CERT_KEY
+
+services:
+  app:
+    image: myapp:latest
+    configs:
+      - source: myapp-fullchain.crt
+        target: /etc/ssl/certs/myapp-fullchain.crt
+      - source: myapp-cert.key
+        target: /etc/ssl/private/myapp.key
+```
+
+The `_FULL` value is a single PEM bundle, with the leaf certificate always first:
+
+```
+-----BEGIN CERTIFICATE-----   <- leaf certificate (the one issued for your common name)
+-----BEGIN CERTIFICATE-----   <- intermediate CA (if any)
+-----BEGIN CERTIFICATE-----   <- root CA
+```
+
+The chain comes from OpenBao's `ca_chain` response field, falling back to `issuing_ca` when the
+mount does not return a chain. For read-only `pki:` references whose response carries no chain,
+the mount's `<secretEngine>/cert/ca_chain` endpoint is read instead. When no chain is available at
+all, `_FULL` holds the leaf certificate on its own.
+
+!!! note
+    Use `CERT` where a leaf-only certificate is expected and `CERT_FULL` where a bundle is; both
+    are always set, so you can switch without touching the reference.
+    [Automatic certificate rotation](#automatic-certificate-rotation) covers all three entries:
+    expiry and serial tracking always read the leaf from `CERT`, and services consuming
+    `CERT_FULL` are recreated on rotation just like those consuming `CERT` or `CERT_KEY`.
+
+!!! warning
+    Because the `_FULL` and `_KEY` entries are generated, an external secret of your own may not
+    use those names. Mapping both `CERT` and `CERT_FULL` in `external_secrets` is rejected with a
+    conflict error.
+
 ## Automatic Certificate Rotation
 
 Certificates issued via a `pki-role:` reference (see above) are eligible for **automatic rotation**:
@@ -125,8 +189,10 @@ A `pki-role:` reference automatically exposes the certificate's matching private
 environment variable, named after the certificate's variable with a `_KEY` suffix. For example, an
 external secret named `CERT` referencing `pki-role:...` resolves to both:
 
-- `CERT` &rarr; the certificate PEM
+- `CERT` &rarr; the leaf certificate PEM
 - `CERT_KEY` &rarr; the matching private key PEM
+
+The [full certificate chain](#full-certificate-chain) is exposed alongside them as `CERT_FULL`.
 
 ```yaml title=".doco-cd.yml"
 name: myapp


### PR DESCRIPTION
PKI references now always expose the full certificate chain as an companion environment (`CERT_FULL`) similar to `CERT_KEY`.