### PR TITLE
fix(scheduler): improve detection for failed jobs in swarm mode

### DIFF
--- a/internal/docker/compose_scheduled_run.go
+++ b/internal/docker/compose_scheduled_run.go
@@ -46,6 +46,13 @@ type composeScheduledServiceRef struct {
 	Reference      string
 }
 
+type ComposeOneOffOptions struct {
+	RunID       string
+	SourceID    string
+	ScheduledAt string
+	StartedAt   string
+}
+
 func RunComposeScheduledContainer(
 	ctx context.Context,
 	dockerCli command.Cli,
@@ -117,6 +124,20 @@ func RunComposeOneOffFromServiceDefinition(
 	secretProvider secretprovider.SecretProvider,
 	opts ScheduledComposeOptions,
 ) error {
+	return RunComposeOneOffFromServiceDefinitionWithOptions(ctx, dockerCli, labels, secretProvider, opts, ComposeOneOffOptions{})
+}
+
+// RunComposeOneOffFromServiceDefinitionWithOptions runs a Compose service as a
+// retained one-off when RunID is set, allowing a replacement process to inspect
+// and finalize it after a forced termination.
+func RunComposeOneOffFromServiceDefinitionWithOptions(
+	ctx context.Context,
+	dockerCli command.Cli,
+	labels map[string]string,
+	secretProvider secretprovider.SecretProvider,
+	opts ScheduledComposeOptions,
+	runOpts ComposeOneOffOptions,
+) error {
 	ref, err := composeScheduledServiceRefFromLabels(labels)
 	if err != nil {
 		return err
@@ -127,7 +148,7 @@ func RunComposeOneOffFromServiceDefinition(
 		return err
 	}
 
-	project, err = prepareComposeProjectForOneOffRun(project, ref.Service)
+	project, err = prepareComposeProjectForOneOffRunWithOptions(project, ref.Service, runOpts)
 	if err != nil {
 		return err
 	}
@@ -140,7 +161,7 @@ func RunComposeOneOffFromServiceDefinition(
 	exitCode, err := service.RunOneOffContainer(ctx, project, api.RunOptions{
 		Service:     ref.Service,
 		NoDeps:      true,
-		AutoRemove:  true,
+		AutoRemove:  runOpts.RunID == "",
 		Tty:         false,
 		Interactive: false,
 	})
@@ -163,6 +184,10 @@ func RunComposeOneOffFromServiceDefinition(
 // one-off containers from being rediscovered as standalone scheduled jobs while
 // preserving the rest of the service definition used to launch them.
 func prepareComposeProjectForOneOffRun(project *types.Project, serviceName string) (*types.Project, error) {
+	return prepareComposeProjectForOneOffRunWithOptions(project, serviceName, ComposeOneOffOptions{})
+}
+
+func prepareComposeProjectForOneOffRunWithOptions(project *types.Project, serviceName string, opts ComposeOneOffOptions) (*types.Project, error) {
 	if project == nil {
 		return nil, errors.New("compose project is required")
 	}
@@ -202,7 +227,27 @@ func prepareComposeProjectForOneOffRun(project *types.Project, serviceName strin
 	svc.CustomLabels[api.OneoffLabel] = "False"
 
 	svc.Labels[DocoCDJobLabels.JobEphemeral] = "true"
+
 	svc.CustomLabels[DocoCDJobLabels.JobEphemeral] = "true"
+	if opts.RunID != "" {
+		svc.Labels[DocoCDJobLabels.JobRunID] = opts.RunID
+		svc.CustomLabels[DocoCDJobLabels.JobRunID] = opts.RunID
+	}
+
+	if opts.SourceID != "" {
+		svc.Labels[DocoCDJobLabels.JobSourceServiceID] = opts.SourceID
+		svc.CustomLabels[DocoCDJobLabels.JobSourceServiceID] = opts.SourceID
+	}
+
+	if opts.ScheduledAt != "" {
+		svc.Labels[DocoCDJobLabels.JobScheduledAt] = opts.ScheduledAt
+		svc.CustomLabels[DocoCDJobLabels.JobScheduledAt] = opts.ScheduledAt
+	}
+
+	if opts.StartedAt != "" {
+		svc.Labels[DocoCDJobLabels.JobStartedAt] = opts.StartedAt
+		svc.CustomLabels[DocoCDJobLabels.JobStartedAt] = opts.StartedAt
+	}
 
 	projectCopy := *project
 	projectCopy.Services = maps.Clone(project.Services)

--- a/internal/docker/container_run.go
+++ b/internal/docker/container_run.go
@@ -3,9 +3,11 @@ package docker
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
 	containerTypes "github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
@@ -123,6 +125,20 @@ func getContainerRunAction(inspectResult containerTypes.InspectResponse) contain
 }
 
 func RunContainerOneOffFromExisting(ctx context.Context, apiClient client.APIClient, containerID string) error {
+	return RunContainerOneOffFromExistingWithOptions(ctx, apiClient, containerID, OneOffContainerOptions{})
+}
+
+type OneOffContainerOptions struct {
+	RunID       string
+	SourceID    string
+	ScheduledAt string
+	StartedAt   string
+}
+
+// RunContainerOneOffFromExistingWithOptions starts a disposable clone of
+// containerID. A run ID retains the completed clone for crash recovery; callers
+// must remove it with RemoveOneOffContainer when finalization is complete.
+func RunContainerOneOffFromExistingWithOptions(ctx context.Context, apiClient client.APIClient, containerID string, opts OneOffContainerOptions) error {
 	inspectResult, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
 	if err != nil {
 		return fmt.Errorf("inspect container %s: %w", containerID, err)
@@ -132,17 +148,39 @@ func RunContainerOneOffFromExisting(ctx context.Context, apiClient client.APICli
 		return fmt.Errorf("container %s has no config", containerID)
 	}
 
-	config := inspectResult.Container.Config
-	if config.Labels == nil {
-		config.Labels = map[string]string{}
+	configCopy := *inspectResult.Container.Config
+
+	configCopy.Labels = maps.Clone(configCopy.Labels)
+	if configCopy.Labels == nil {
+		configCopy.Labels = map[string]string{}
 	}
 
-	config.Labels[DocoCDJobLabels.JobEphemeral] = "true"
+	config := &configCopy
 
-	hostConfig := inspectResult.Container.HostConfig
-	if hostConfig != nil {
+	config.Labels[DocoCDJobLabels.JobEphemeral] = "true"
+	if opts.RunID != "" {
+		config.Labels[DocoCDJobLabels.JobRunID] = opts.RunID
+	}
+
+	if opts.SourceID != "" {
+		config.Labels[DocoCDJobLabels.JobSourceServiceID] = opts.SourceID
+	}
+
+	if opts.ScheduledAt != "" {
+		config.Labels[DocoCDJobLabels.JobScheduledAt] = opts.ScheduledAt
+	}
+
+	if opts.StartedAt != "" {
+		config.Labels[DocoCDJobLabels.JobStartedAt] = opts.StartedAt
+	}
+
+	var hostConfig *containerTypes.HostConfig
+
+	if inspectResult.Container.HostConfig != nil {
+		hostConfigCopy := *inspectResult.Container.HostConfig
+		hostConfig = &hostConfigCopy
 		hostConfig.RestartPolicy = containerTypes.RestartPolicy{Name: "no"}
-		hostConfig.AutoRemove = true
+		hostConfig.AutoRemove = opts.RunID == ""
 	}
 
 	baseName := strings.TrimPrefix(inspectResult.Container.Name, "/")
@@ -174,4 +212,64 @@ func RunContainerOneOffFromExisting(ctx context.Context, apiClient client.APICli
 	}
 
 	return awaitContainerExit(waitResult, createResult.ID)
+}
+
+// WaitOnOneOffContainer waits for a retained container to stop and returns its
+// exit result. It is safe to call for an already-exited container.
+func WaitOnOneOffContainer(ctx context.Context, apiClient client.APIClient, containerID string) error {
+	inspectResult, err := apiClient.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		return fmt.Errorf("inspect one-off container %s: %w", containerID, err)
+	}
+
+	if inspectResult.Container.State == nil {
+		return fmt.Errorf("one-off container %s has no state", containerID)
+	}
+
+	if !inspectResult.Container.State.Running {
+		if inspectResult.Container.State.Status == containerTypes.StateCreated {
+			return fmt.Errorf("one-off container %s was created but never started", containerID)
+		}
+
+		if inspectResult.Container.State.ExitCode != 0 {
+			return &ContainerExitError{ContainerID: containerID, ExitCode: inspectResult.Container.State.ExitCode}
+		}
+
+		return nil
+	}
+
+	waitResult := apiClient.ContainerWait(ctx, containerID, client.ContainerWaitOptions{Condition: containerTypes.WaitConditionNotRunning})
+
+	return awaitContainerExit(waitResult, containerID)
+}
+
+// FindOneOffContainer finds the one retained ephemeral container for runID.
+func FindOneOffContainer(ctx context.Context, apiClient client.APIClient, runID string) (string, error) {
+	filter := make(client.Filters)
+	filter.Add("label", DocoCDJobLabels.JobRunID+"="+runID)
+
+	result, err := apiClient.ContainerList(ctx, client.ContainerListOptions{All: true, Filters: filter})
+	if err != nil {
+		return "", fmt.Errorf("list one-off containers for run %s: %w", runID, err)
+	}
+
+	if len(result.Items) == 0 {
+		return "", nil
+	}
+
+	if len(result.Items) != 1 {
+		return "", fmt.Errorf("found %d one-off containers for run %s", len(result.Items), runID)
+	}
+
+	return result.Items[0].ID, nil
+}
+
+// RemoveOneOffContainer removes a retained one-off container after reporting.
+func RemoveOneOffContainer(ctx context.Context, apiClient client.APIClient, containerID string) error {
+	_, err := apiClient.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true})
+	if err != nil && !errdefs.IsNotFound(err) {
+		return fmt.Errorf("remove one-off container %s: %w", containerID, err)
+	}
+
+	return nil
 }

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -86,6 +86,9 @@ var docoCDJobLabelNames = struct {
 	JobExecutionMode   string // Defines if a run restarts/reruns the job or starts an ephemeral one-off execution
 	JobEphemeral       string // Marks a runtime-created scheduler one-off target that should be ignored as drift
 	JobSourceServiceID string // Identifies the source service of a runtime-created Swarm one-off target
+	JobRunID           string // Identifies one recoverable scheduled one-off execution
+	JobScheduledAt     string // Original scheduled timestamp for a one-off execution
+	JobStartedAt       string // Original start timestamp for a one-off execution
 	JobNotifyOn        string // Controls notification behavior: none, success, failure, all
 	JobSwarmReplicas   string // Number of replicas for one-off replicated-job runs in swarm mode
 	JobRestartReplicas string // Intended replica count for swarm restart-mode jobs deployed at 0 replicas
@@ -100,6 +103,9 @@ var docoCDJobLabelNames = struct {
 	JobExecutionMode:   "cd.doco.job.execution_mode",
 	JobEphemeral:       "cd.doco.job.ephemeral",
 	JobSourceServiceID: "cd.doco.job.source_service_id",
+	JobRunID:           "cd.doco.job.run_id",
+	JobScheduledAt:     "cd.doco.job.scheduled_at",
+	JobStartedAt:       "cd.doco.job.started_at",
 	JobNotifyOn:        "cd.doco.job.notify_on",
 	JobSwarmReplicas:   "cd.doco.job.swarm.replicas",
 	JobRestartReplicas: "cd.doco.job.swarm.restart_replicas",

--- a/internal/docker/labels.go
+++ b/internal/docker/labels.go
@@ -85,6 +85,7 @@ var docoCDJobLabelNames = struct {
 	JobSkipRunning     string // Skip a schedule trigger when a previous run is still in progress
 	JobExecutionMode   string // Defines if a run restarts/reruns the job or starts an ephemeral one-off execution
 	JobEphemeral       string // Marks a runtime-created scheduler one-off target that should be ignored as drift
+	JobSourceServiceID string // Identifies the source service of a runtime-created Swarm one-off target
 	JobNotifyOn        string // Controls notification behavior: none, success, failure, all
 	JobSwarmReplicas   string // Number of replicas for one-off replicated-job runs in swarm mode
 	JobRestartReplicas string // Intended replica count for swarm restart-mode jobs deployed at 0 replicas
@@ -98,6 +99,7 @@ var docoCDJobLabelNames = struct {
 	JobSkipRunning:     "cd.doco.job.skip_running",
 	JobExecutionMode:   "cd.doco.job.execution_mode",
 	JobEphemeral:       "cd.doco.job.ephemeral",
+	JobSourceServiceID: "cd.doco.job.source_service_id",
 	JobNotifyOn:        "cd.doco.job.notify_on",
 	JobSwarmReplicas:   "cd.doco.job.swarm.replicas",
 	JobRestartReplicas: "cd.doco.job.swarm.restart_replicas",

--- a/internal/docker/swarm.go
+++ b/internal/docker/swarm.go
@@ -49,6 +49,31 @@ var (
 	ErrGlobalSwarmServiceNotScalable = errors.New("global-mode swarm service cannot be scaled")
 )
 
+// SwarmServiceReplicas returns the desired replica count before a service is
+// scaled down. Global services return ErrGlobalSwarmServiceNotScalable.
+func SwarmServiceReplicas(ctx context.Context, dockerCLI command.Cli, serviceName string) (uint64, error) {
+	result, err := dockerCLI.Client().ServiceInspect(ctx, serviceName, dockerClient.ServiceInspectOptions{
+		InsertDefaults: true,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("inspect service %s: %w", serviceName, err)
+	}
+
+	svc := result.Service
+	if svc.Spec.Mode.Global != nil || svc.Spec.Mode.GlobalJob != nil {
+		return 0, ErrGlobalSwarmServiceNotScalable
+	}
+
+	switch {
+	case svc.Spec.Mode.Replicated != nil && svc.Spec.Mode.Replicated.Replicas != nil:
+		return *svc.Spec.Mode.Replicated.Replicas, nil
+	case svc.Spec.Mode.ReplicatedJob != nil && svc.Spec.Mode.ReplicatedJob.TotalCompletions != nil:
+		return *svc.Spec.Mode.ReplicatedJob.TotalCompletions, nil
+	default:
+		return 1, nil
+	}
+}
+
 // LoadSwarmStack loads a Docker Swarm stack using the provided project and deploy configuration.
 func LoadSwarmStack(dockerCli command.Cli, project *types.Project,
 	deployConfig *deploy.Config, externalWorkingDir string,

--- a/internal/docker/swarm/deploy.go
+++ b/internal/docker/swarm/deploy.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
+	"github.com/avast/retry-go/v5"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/compose/convert"
 	composetypes "github.com/docker/cli/cli/compose/types"
@@ -101,26 +104,49 @@ func pruneServices(ctx context.Context, dockerCCLI command.Cli, namespace conver
 func ScaleService(ctx context.Context, dockerCLI command.Cli, serviceName string, replicas uint64, wait, force bool) error {
 	apiClient := dockerCLI.Client()
 
-	result, err := apiClient.ServiceInspect(ctx, serviceName, client.ServiceInspectOptions{})
-	if err != nil {
-		return err
-	}
+	err := retry.New(
+		retry.Attempts(5),
+		retry.Delay(250*time.Millisecond),
+		retry.DelayType(retry.BackOffDelay),
+		retry.RetryIf(func(err error) bool {
+			return strings.Contains(err.Error(), "update out of sequence")
+		}),
+	).Do(func() error {
+		result, err := apiClient.ServiceInspect(ctx, serviceName, client.ServiceInspectOptions{})
+		if err != nil {
+			return err
+		}
 
-	service := result.Service
+		service := result.Service
 
-	if force {
-		service.Spec.TaskTemplate.ForceUpdate++
-	}
+		if force {
+			service.Spec.TaskTemplate.ForceUpdate++
+		}
 
-	// Handle replicated-job services
-	if service.Spec.Mode.ReplicatedJob != nil {
-		// Jobs may not have an update config (daemon rejects ServiceUpdate otherwise).
-		service.Spec.UpdateConfig = nil
-		service.Spec.RollbackConfig = nil
+		// Handle replicated-job services
+		if service.Spec.Mode.ReplicatedJob != nil {
+			// Jobs may not have an update config (daemon rejects ServiceUpdate otherwise).
+			service.Spec.UpdateConfig = nil
+			service.Spec.RollbackConfig = nil
 
-		// Treat `replicas` as "how many completions to run" and allow that many concurrently.
-		service.Spec.Mode.ReplicatedJob.TotalCompletions = &replicas
-		service.Spec.Mode.ReplicatedJob.MaxConcurrent = &replicas
+			// Treat `replicas` as "how many completions to run" and allow that many concurrently.
+			service.Spec.Mode.ReplicatedJob.TotalCompletions = &replicas
+			service.Spec.Mode.ReplicatedJob.MaxConcurrent = &replicas
+
+			_, err = apiClient.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{
+				Version: service.Version,
+				Spec:    service.Spec,
+			})
+
+			return err
+		}
+
+		// Handle classic replicated services
+		if service.Spec.Mode.Replicated == nil {
+			return fmt.Errorf("%w: %s", ErrNotReplicatedService, serviceName)
+		}
+
+		service.Spec.Mode.Replicated.Replicas = &replicas
 
 		_, err = apiClient.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{
 			Version: service.Version,
@@ -128,18 +154,6 @@ func ScaleService(ctx context.Context, dockerCLI command.Cli, serviceName string
 		})
 
 		return err
-	}
-
-	// Handle classic replicated services
-	if service.Spec.Mode.Replicated == nil {
-		return fmt.Errorf("%w: %s", ErrNotReplicatedService, serviceName)
-	}
-
-	service.Spec.Mode.Replicated.Replicas = &replicas
-
-	_, err = apiClient.ServiceUpdate(ctx, service.ID, client.ServiceUpdateOptions{
-		Version: service.Version,
-		Spec:    service.Spec,
 	})
 	if err != nil {
 		return err

--- a/internal/docker/swarm/deploy_wait_test.go
+++ b/internal/docker/swarm/deploy_wait_test.go
@@ -47,6 +47,84 @@ func TestWaitOnServicesWithParentCancellation(t *testing.T) {
 	}
 }
 
+func TestJobTaskFailureFromTasks(t *testing.T) {
+	t.Parallel()
+
+	iteration := uint64(7)
+	otherIteration := uint64(6)
+	tests := []struct {
+		name  string
+		tasks []swarmTypes.Task
+		want  string
+	}{
+		{
+			name: "current iteration failed task includes task details",
+			tasks: []swarmTypes.Task{
+				{
+					ID:           "failed-task",
+					JobIteration: &swarmTypes.Version{Index: iteration},
+					Status: swarmTypes.TaskStatus{
+						State: swarmTypes.TaskStateFailed,
+						Err:   "process exited unexpectedly",
+						ContainerStatus: &swarmTypes.ContainerStatus{
+							ExitCode: 7,
+						},
+					},
+				},
+			},
+			want: "job task failed-task ended in failed (exit code 7): process exited unexpectedly",
+		},
+		{
+			name: "previous iteration failure is ignored",
+			tasks: []swarmTypes.Task{
+				{
+					ID:           "old-failed-task",
+					JobIteration: &swarmTypes.Version{Index: otherIteration},
+					Status:       swarmTypes.TaskStatus{State: swarmTypes.TaskStateFailed},
+				},
+				{
+					ID:           "current-complete-task",
+					JobIteration: &swarmTypes.Version{Index: iteration},
+					Status:       swarmTypes.TaskStatus{State: swarmTypes.TaskStateComplete},
+				},
+			},
+		},
+		{
+			name: "current iteration rejected task uses message",
+			tasks: []swarmTypes.Task{
+				{
+					ID:           "rejected-task",
+					JobIteration: &swarmTypes.Version{Index: iteration},
+					Status: swarmTypes.TaskStatus{
+						State:   swarmTypes.TaskStateRejected,
+						Message: "no suitable node",
+					},
+				},
+			},
+			want: "job task rejected-task ended in rejected: no suitable node",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := jobTaskFailureFromTasks(tt.tasks, iteration)
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("jobTaskFailureFromTasks() error = %v, want nil", err)
+				}
+
+				return
+			}
+
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("jobTaskFailureFromTasks() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldWaitForService(t *testing.T) {
 	t.Parallel()
 

--- a/internal/docker/swarm/service.go
+++ b/internal/docker/swarm/service.go
@@ -2,6 +2,7 @@ package swarm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -19,6 +20,7 @@ import (
 const (
 	rollbackStatusObservationTimeout  = 20 * time.Second
 	rollbackStatusObservationInterval = 250 * time.Millisecond
+	jobTaskPollInterval               = 200 * time.Millisecond
 )
 
 // Service represents a service.
@@ -90,6 +92,195 @@ func waitOnService(ctx context.Context, dockerCli command.Cli, serviceID string)
 	}
 
 	return progressErr
+}
+
+// WaitOnJobService waits for one Swarm job execution to complete. Unlike
+// ServiceProgress alone, it also reports terminal task failures, which do not
+// converge and would otherwise leave callers blocked indefinitely.
+//
+// When previousJobIteration is provided, the service must first advance beyond
+// that iteration before its progress is observed. This prevents a reused job
+// service from reporting an earlier successful execution as the current run.
+func WaitOnJobService(
+	ctx context.Context,
+	dockerCli command.Cli,
+	serviceID string,
+	previousJobIteration *uint64,
+) error {
+	iteration, err := waitForJobIteration(ctx, dockerCli.Client(), serviceID, previousJobIteration)
+	if err != nil {
+		return err
+	}
+
+	waitCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	progressResult := make(chan error, 1)
+	failureResult := make(chan error, 1)
+
+	go func() {
+		progressResult <- waitOnService(waitCtx, dockerCli, serviceID)
+	}()
+
+	go func() {
+		failureResult <- waitForJobTaskFailure(waitCtx, dockerCli.Client(), serviceID, iteration)
+	}()
+
+	select {
+	case err = <-progressResult:
+		cancel()
+
+		failureErr := <-failureResult
+		if err != nil {
+			if failureErr != nil && !errors.Is(failureErr, context.Canceled) {
+				return failureErr
+			}
+
+			return err
+		}
+
+		if failureErr = ensureJobIteration(ctx, dockerCli.Client(), serviceID, iteration); failureErr != nil {
+			return failureErr
+		}
+
+		if failureErr = jobTaskFailure(ctx, dockerCli.Client(), serviceID, iteration); failureErr != nil {
+			return failureErr
+		}
+
+		return nil
+	case err = <-failureResult:
+		cancel()
+
+		progressErr := <-progressResult
+
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+
+		return progressErr
+	}
+}
+
+func waitForJobIteration(
+	ctx context.Context,
+	apiClient client.APIClient,
+	serviceID string,
+	previousJobIteration *uint64,
+) (uint64, error) {
+	ticker := time.NewTicker(jobTaskPollInterval)
+	defer ticker.Stop()
+
+	for {
+		result, err := apiClient.ServiceInspect(ctx, serviceID, client.ServiceInspectOptions{})
+		if err != nil {
+			return 0, fmt.Errorf("inspect job service %s: %w", serviceID, err)
+		}
+
+		if result.Service.Spec.Mode.ReplicatedJob == nil && result.Service.Spec.Mode.GlobalJob == nil {
+			return 0, fmt.Errorf("service %s is not a Swarm job service", serviceID)
+		}
+
+		if result.Service.JobStatus != nil {
+			iteration := result.Service.JobStatus.JobIteration.Index
+			if previousJobIteration == nil || iteration > *previousJobIteration {
+				return iteration, nil
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForJobTaskFailure(ctx context.Context, apiClient client.APIClient, serviceID string, iteration uint64) error {
+	ticker := time.NewTicker(jobTaskPollInterval)
+	defer ticker.Stop()
+
+	for {
+		if err := ensureJobIteration(ctx, apiClient, serviceID, iteration); err != nil {
+			return err
+		}
+
+		if err := jobTaskFailure(ctx, apiClient, serviceID, iteration); err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func ensureJobIteration(ctx context.Context, apiClient client.APIClient, serviceID string, iteration uint64) error {
+	result, err := apiClient.ServiceInspect(ctx, serviceID, client.ServiceInspectOptions{})
+	if err != nil {
+		return fmt.Errorf("inspect job service %s: %w", serviceID, err)
+	}
+
+	if result.Service.JobStatus == nil {
+		return fmt.Errorf("job service %s no longer reports an active job iteration", serviceID)
+	}
+
+	if result.Service.JobStatus.JobIteration.Index != iteration {
+		return fmt.Errorf(
+			"job service %s advanced from iteration %d to %d while waiting",
+			serviceID,
+			iteration,
+			result.Service.JobStatus.JobIteration.Index,
+		)
+	}
+
+	return nil
+}
+
+func jobTaskFailure(ctx context.Context, apiClient client.APIClient, serviceID string, iteration uint64) error {
+	tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
+		Filters: make(client.Filters).Add("service", serviceID),
+	})
+	if err != nil {
+		return fmt.Errorf("list tasks for job service %s: %w", serviceID, err)
+	}
+
+	return jobTaskFailureFromTasks(tasks.Items, iteration)
+}
+
+func jobTaskFailureFromTasks(tasks []swarm.Task, iteration uint64) error {
+	for _, task := range tasks {
+		if task.JobIteration == nil || task.JobIteration.Index != iteration {
+			continue
+		}
+
+		switch task.Status.State {
+		case swarm.TaskStateFailed, swarm.TaskStateRejected, swarm.TaskStateOrphaned,
+			swarm.TaskStateShutdown, swarm.TaskStateRemove:
+			return newJobTaskFailure(task)
+		}
+	}
+
+	return nil
+}
+
+func newJobTaskFailure(task swarm.Task) error {
+	details := strings.TrimSpace(task.Status.Err)
+	if details == "" {
+		details = strings.TrimSpace(task.Status.Message)
+	}
+
+	exitCode := ""
+	if task.Status.ContainerStatus != nil {
+		exitCode = fmt.Sprintf(" (exit code %d)", task.Status.ContainerStatus.ExitCode)
+	}
+
+	if details == "" {
+		return fmt.Errorf("job task %s ended in %s%s", task.ID, task.Status.State, exitCode)
+	}
+
+	return fmt.Errorf("job task %s ended in %s%s: %s", task.ID, task.Status.State, exitCode, details)
 }
 
 // waitForRollbackUpdateStatus keeps observing a service update for a short time

--- a/internal/docker/swarm_job.go
+++ b/internal/docker/swarm_job.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
+	"maps"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/avast/retry-go/v5"
+	"github.com/containerd/errdefs"
 	"github.com/docker/cli/cli/command"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
@@ -24,6 +25,8 @@ import (
 
 var swarmJobLock = sync.Map{}
 
+const swarmOneOffCleanupTimeout = 30 * time.Second
+
 func getSwarmJobLock(name string) *sync.Mutex {
 	lock, _ := swarmJobLock.LoadOrStore(name, &sync.Mutex{})
 	return lock.(*sync.Mutex)
@@ -35,8 +38,9 @@ func RunSwarmJob(ctx context.Context, dockerCLI command.Cli, mode swarm.DeployMo
 	apiClient := dockerCLI.Client()
 
 	var (
-		serviceMode swarmTypes.ServiceMode
-		serviceId   string
+		serviceMode          swarmTypes.ServiceMode
+		serviceID            string
+		previousJobIteration *uint64
 	)
 
 	switch mode {
@@ -96,7 +100,7 @@ func RunSwarmJob(ctx context.Context, dockerCLI command.Cli, mode swarm.DeployMo
 		QueryRegistry: true,
 	})
 	if err == nil {
-		serviceId = response.ID
+		serviceID = response.ID
 	} else {
 		// Update existing service to trigger a new job run
 		if strings.Contains(err.Error(), "already exists") {
@@ -114,12 +118,12 @@ func RunSwarmJob(ctx context.Context, dockerCLI command.Cli, mode swarm.DeployMo
 
 			for _, service := range listResult.Items {
 				if service.Spec.Name == newServiceSpec.Name {
-					serviceId = service.ID
+					serviceID = service.ID
 					break
 				}
 			}
 
-			if serviceId == "" {
+			if serviceID == "" {
 				return errors.New("service already exists but could not find its ID")
 			}
 
@@ -132,25 +136,24 @@ func RunSwarmJob(ctx context.Context, dockerCLI command.Cli, mode swarm.DeployMo
 				}),
 			).Do(
 				func() error {
-					inspectResult, getErr := apiClient.ServiceInspect(ctx, serviceId, client.ServiceInspectOptions{})
+					inspectResult, getErr := apiClient.ServiceInspect(ctx, serviceID, client.ServiceInspectOptions{})
 					if getErr != nil {
 						return fmt.Errorf("error inspecting existing service: %w", getErr)
 					}
 
 					existingService := inspectResult.Service
-
-					// already up to date, no need to update
-					if existingService.Spec.TaskTemplate.ForceUpdate == newServiceSpec.TaskTemplate.ForceUpdate &&
-						reflect.DeepEqual(existingService.Spec.TaskTemplate.ContainerSpec.Labels, newServiceSpec.TaskTemplate.ContainerSpec.Labels) &&
-						reflect.DeepEqual(existingService.Spec.TaskTemplate.ContainerSpec.Command, newServiceSpec.TaskTemplate.ContainerSpec.Command) {
-						return nil
+					if existingService.JobStatus != nil {
+						iteration := existingService.JobStatus.JobIteration.Index
+						previousJobIteration = &iteration
 					}
-					// Update the ForceUpdate to trigger a new job run
+
+					// Update ForceUpdate monotonically so every invocation starts a
+					// new job iteration, including multiple runs in one second.
 					existingService.Spec.TaskTemplate.ContainerSpec.Labels = newServiceSpec.TaskTemplate.ContainerSpec.Labels
 					existingService.Spec.TaskTemplate.ContainerSpec.Command = newServiceSpec.TaskTemplate.ContainerSpec.Command
-					existingService.Spec.TaskTemplate.ForceUpdate = newServiceSpec.TaskTemplate.ForceUpdate
+					existingService.Spec.TaskTemplate.ForceUpdate++
 
-					_, updateErr := apiClient.ServiceUpdate(ctx, serviceId, client.ServiceUpdateOptions{
+					_, updateErr := apiClient.ServiceUpdate(ctx, serviceID, client.ServiceUpdateOptions{
 						Version:       existingService.Version,
 						Spec:          existingService.Spec,
 						QueryRegistry: true,
@@ -166,10 +169,10 @@ func RunSwarmJob(ctx context.Context, dockerCLI command.Cli, mode swarm.DeployMo
 		}
 	}
 
-	// Wait for container to complete
-	err = swarm.WaitOnServices(ctx, dockerCLI, []string{serviceId})
+	// Wait for the job's current iteration to complete or fail.
+	err = swarm.WaitOnJobService(ctx, dockerCLI, serviceID, previousJobIteration)
 	if err != nil {
-		return fmt.Errorf("error waiting for one-off job service: %w", err)
+		return fmt.Errorf("error waiting for job service: %w", err)
 	}
 
 	return nil
@@ -192,7 +195,7 @@ type SwarmOneOffFromServiceOptions struct {
 }
 
 // RunSwarmOneOffFromService creates a temporary job service from an existing service spec and waits for completion.
-func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, serviceName string, opts SwarmOneOffFromServiceOptions) error {
+func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, serviceName string, opts SwarmOneOffFromServiceOptions) (err error) {
 	apiClient := dockerCLI.Client()
 
 	if opts.Replicas == 0 {
@@ -212,14 +215,28 @@ func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, servi
 		return fmt.Errorf("service %s has no task container spec", serviceName)
 	}
 
+	// Copy the nested reference fields before changing the clone. A direct
+	// ServiceSpec assignment shares the source service's label maps and
+	// ContainerSpec pointer.
+	containerSpec := *oneOffSpec.TaskTemplate.ContainerSpec
+	containerSpec.Labels = maps.Clone(containerSpec.Labels)
+	oneOffSpec.TaskTemplate.ContainerSpec = &containerSpec
+	oneOffSpec.Labels = maps.Clone(oneOffSpec.Labels)
+
 	if oneOffSpec.TaskTemplate.ContainerSpec.Labels == nil {
 		oneOffSpec.TaskTemplate.ContainerSpec.Labels = map[string]string{}
 	}
 
-	oneOffSpec.TaskTemplate.ContainerSpec.Labels[DocoCDJobLabels.JobEphemeral] = "true"
-
 	if oneOffSpec.Labels == nil {
 		oneOffSpec.Labels = map[string]string{}
+	}
+
+	for _, labels := range []map[string]string{
+		oneOffSpec.TaskTemplate.ContainerSpec.Labels,
+		oneOffSpec.Labels,
+	} {
+		labels[DocoCDJobLabels.JobEphemeral] = "true"
+		labels[DocoCDJobLabels.JobSourceServiceID] = sourceService.ID
 	}
 
 	oneOffSpec.Labels[DocoCDLabels.Metadata.Manager] = app.Name
@@ -263,10 +280,23 @@ func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, servi
 	}
 
 	defer func() {
-		_, _ = apiClient.ServiceRemove(context.WithoutCancel(ctx), createResult.ID, client.ServiceRemoveOptions{})
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), swarmOneOffCleanupTimeout)
+		defer cancel()
+
+		_, cleanupErr := apiClient.ServiceRemove(cleanupCtx, createResult.ID, client.ServiceRemoveOptions{})
+		if cleanupErr == nil || errdefs.IsNotFound(cleanupErr) {
+			return
+		}
+
+		cleanupErr = fmt.Errorf("remove one-off service %s: %w", createResult.ID, cleanupErr)
+		if err == nil {
+			err = cleanupErr
+		} else {
+			err = errors.Join(err, cleanupErr)
+		}
 	}()
 
-	if err = swarm.WaitOnServices(ctx, dockerCLI, []string{createResult.ID}); err != nil {
+	if err = swarm.WaitOnJobService(ctx, dockerCLI, createResult.ID, nil); err != nil {
 		return fmt.Errorf("wait one-off service %s: %w", createResult.ID, err)
 	}
 

--- a/internal/docker/swarm_job.go
+++ b/internal/docker/swarm_job.go
@@ -192,6 +192,10 @@ func RunImageRemoveJob(ctx context.Context, dockerCLI command.Cli, images []stri
 type SwarmOneOffFromServiceOptions struct {
 	Replicas         uint64
 	SendRegistryAuth bool
+	RunID            string
+	ScheduledAt      string
+	StartedAt        string
+	KeepService      bool
 }
 
 // RunSwarmOneOffFromService creates a temporary job service from an existing service spec and waits for completion.
@@ -236,7 +240,19 @@ func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, servi
 		oneOffSpec.Labels,
 	} {
 		labels[DocoCDJobLabels.JobEphemeral] = "true"
+
 		labels[DocoCDJobLabels.JobSourceServiceID] = sourceService.ID
+		if opts.RunID != "" {
+			labels[DocoCDJobLabels.JobRunID] = opts.RunID
+		}
+
+		if opts.ScheduledAt != "" {
+			labels[DocoCDJobLabels.JobScheduledAt] = opts.ScheduledAt
+		}
+
+		if opts.StartedAt != "" {
+			labels[DocoCDJobLabels.JobStartedAt] = opts.StartedAt
+		}
 	}
 
 	oneOffSpec.Labels[DocoCDLabels.Metadata.Manager] = app.Name
@@ -279,25 +295,70 @@ func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, servi
 		return fmt.Errorf("create one-off service from %s: %w", serviceName, err)
 	}
 
-	defer func() {
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), swarmOneOffCleanupTimeout)
-		defer cancel()
+	if !opts.KeepService {
+		defer func() {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), swarmOneOffCleanupTimeout)
+			defer cancel()
 
-		_, cleanupErr := apiClient.ServiceRemove(cleanupCtx, createResult.ID, client.ServiceRemoveOptions{})
-		if cleanupErr == nil || errdefs.IsNotFound(cleanupErr) {
-			return
-		}
+			_, cleanupErr := apiClient.ServiceRemove(cleanupCtx, createResult.ID, client.ServiceRemoveOptions{})
+			if cleanupErr == nil || errdefs.IsNotFound(cleanupErr) {
+				return
+			}
 
-		cleanupErr = fmt.Errorf("remove one-off service %s: %w", createResult.ID, cleanupErr)
-		if err == nil {
-			err = cleanupErr
-		} else {
-			err = errors.Join(err, cleanupErr)
-		}
-	}()
+			cleanupErr = fmt.Errorf("remove one-off service %s: %w", createResult.ID, cleanupErr)
+			if err == nil {
+				err = cleanupErr
+			} else {
+				err = errors.Join(err, cleanupErr)
+			}
+		}()
+	}
 
 	if err = swarm.WaitOnJobService(ctx, dockerCLI, createResult.ID, nil); err != nil {
 		return fmt.Errorf("wait one-off service %s: %w", createResult.ID, err)
+	}
+
+	return nil
+}
+
+// RemoveSwarmOneOffService removes a retained temporary job service.
+func RemoveSwarmOneOffService(ctx context.Context, dockerCLI command.Cli, serviceID string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), swarmOneOffCleanupTimeout)
+	defer cancel()
+
+	_, err := dockerCLI.Client().ServiceRemove(cleanupCtx, serviceID, client.ServiceRemoveOptions{})
+	if err != nil && !errdefs.IsNotFound(err) {
+		return fmt.Errorf("remove one-off service %s: %w", serviceID, err)
+	}
+
+	return nil
+}
+
+// FindSwarmOneOffService finds the single retained temporary service for runID.
+func FindSwarmOneOffService(ctx context.Context, dockerCLI command.Cli, runID string) (string, error) {
+	filter := make(client.Filters)
+	filter.Add("label", DocoCDJobLabels.JobRunID+"="+runID)
+
+	result, err := dockerCLI.Client().ServiceList(ctx, client.ServiceListOptions{Filters: filter})
+	if err != nil {
+		return "", fmt.Errorf("list one-off services for run %s: %w", runID, err)
+	}
+
+	if len(result.Items) == 0 {
+		return "", nil
+	}
+
+	if len(result.Items) != 1 {
+		return "", fmt.Errorf("found %d one-off services for run %s", len(result.Items), runID)
+	}
+
+	return result.Items[0].ID, nil
+}
+
+// WaitOnSwarmOneOffService adopts a retained temporary job service.
+func WaitOnSwarmOneOffService(ctx context.Context, dockerCLI command.Cli, serviceID string) error {
+	if err := swarm.WaitOnJobService(ctx, dockerCLI, serviceID, nil); err != nil {
+		return fmt.Errorf("wait one-off service %s: %w", serviceID, err)
 	}
 
 	return nil

--- a/internal/docker/swarm_job.go
+++ b/internal/docker/swarm_job.go
@@ -25,8 +25,10 @@ import (
 
 var swarmJobLock = sync.Map{}
 
-const swarmOneOffCleanupTimeout = 30 * time.Second
-const maxSwarmServiceNameLength = 63
+const (
+	swarmOneOffCleanupTimeout = 30 * time.Second
+	maxSwarmServiceNameLength = 63
+)
 
 func getSwarmJobLock(name string) *sync.Mutex {
 	lock, _ := swarmJobLock.LoadOrStore(name, &sync.Mutex{})

--- a/internal/docker/swarm_job.go
+++ b/internal/docker/swarm_job.go
@@ -26,6 +26,7 @@ import (
 var swarmJobLock = sync.Map{}
 
 const swarmOneOffCleanupTimeout = 30 * time.Second
+const maxSwarmServiceNameLength = 63
 
 func getSwarmJobLock(name string) *sync.Mutex {
 	lock, _ := swarmJobLock.LoadOrStore(name, &sync.Mutex{})
@@ -213,7 +214,7 @@ func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, servi
 
 	sourceService := inspectResult.Service
 	oneOffSpec := sourceService.Spec
-	oneOffSpec.Name = fmt.Sprintf("%s-doco-job-%d", sourceService.Spec.Name, time.Now().UTC().UnixNano())
+	oneOffSpec.Name = swarmOneOffServiceName(sourceService.Spec.Name, time.Now())
 
 	if oneOffSpec.TaskTemplate.ContainerSpec == nil {
 		return fmt.Errorf("service %s has no task container spec", serviceName)
@@ -319,6 +320,17 @@ func RunSwarmOneOffFromService(ctx context.Context, dockerCLI command.Cli, servi
 	}
 
 	return nil
+}
+
+func swarmOneOffServiceName(sourceServiceName string, now time.Time) string {
+	suffix := fmt.Sprintf("%s%d", oneOffServiceNameSeparator, now.UTC().UnixNano())
+	maxSourceServiceNameLength := maxSwarmServiceNameLength - len(suffix)
+
+	if len(sourceServiceName) > maxSourceServiceNameLength {
+		sourceServiceName = sourceServiceName[:maxSourceServiceNameLength]
+	}
+
+	return sourceServiceName + suffix
 }
 
 // RemoveSwarmOneOffService removes a retained temporary job service.

--- a/internal/docker/swarm_job_test.go
+++ b/internal/docker/swarm_job_test.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
@@ -22,9 +23,11 @@ func TestRunSwarmJob(t *testing.T) {
 		mode    swarm.DeployMode
 		command []string
 		title   string
+		wantErr string
 	}{
 		{mode: swarm.DeployModeGlobalJob, command: []string{"docker", "info"}, title: "global-docker-info"},
 		{mode: swarm.DeployModeReplicatedJob, command: []string{"docker", "info"}, title: "replicated-docker-info"},
+		{mode: swarm.DeployModeReplicatedJob, command: []string{"sh", "-c", "exit 7"}, title: "replicated-exit-7", wantErr: "exit code 7"},
 	}
 
 	for _, tc := range testCases {
@@ -34,8 +37,16 @@ func TestRunSwarmJob(t *testing.T) {
 			t.Logf("Running job with mode: %s, command: %v, title: %s", tc.mode, tc.command, tc.title)
 
 			err := RunSwarmJob(t.Context(), dockerCli, tc.mode, tc.command, tc.title)
-			if err != nil {
-				t.Errorf("RunSwarmJob failed: %v", err)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("RunSwarmJob failed: %v", err)
+				}
+
+				return
+			}
+
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("RunSwarmJob error = %v, want error containing %q", err, tc.wantErr)
 			}
 		})
 	}

--- a/internal/docker/swarm_job_test.go
+++ b/internal/docker/swarm_job_test.go
@@ -3,9 +3,48 @@ package docker
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
 )
+
+func TestSwarmOneOffServiceName(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(0, 1730000000000000000)
+	suffix := "-doco-job-1730000000000000000"
+
+	testCases := []struct {
+		name              string
+		sourceServiceName string
+		want              string
+	}{
+		{
+			name:              "keeps short source service name",
+			sourceServiceName: "stack_backup",
+			want:              "stack_backup" + suffix,
+		},
+		{
+			name:              "truncates source service name to Docker limit",
+			sourceServiceName: strings.Repeat("a", maxSwarmServiceNameLength),
+			want:              strings.Repeat("a", maxSwarmServiceNameLength-len(suffix)) + suffix,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := swarmOneOffServiceName(tc.sourceServiceName, now)
+
+			if got != tc.want {
+				t.Errorf("swarmOneOffServiceName() = %q, want %q", got, tc.want)
+			}
+
+			if len(got) > maxSwarmServiceNameLength {
+				t.Errorf("swarmOneOffServiceName() length = %d, want <= %d", len(got), maxSwarmServiceNameLength)
+			}
+		})
+	}
+}
 
 func TestRunSwarmJob(t *testing.T) {
 	t.Parallel()

--- a/internal/scheduler/execution_recovery.go
+++ b/internal/scheduler/execution_recovery.go
@@ -1,0 +1,296 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/moby/moby/client"
+
+	"github.com/kimdre/doco-cd/internal/docker"
+	"github.com/kimdre/doco-cd/internal/logger"
+	"github.com/kimdre/doco-cd/internal/prometheus"
+)
+
+func (s *scheduler) newExecutionRecord(runID string, job scheduledJob, cfg docker.JobScheduleConfig) executionRecord {
+	return executionRecord{
+		Version:      executionRecordVersion,
+		RunID:        runID,
+		Context:      s.contextName,
+		Mode:         s.mode,
+		Job:          executionJobFromScheduled(job),
+		Finalization: executionFinalizationConfigFromSchedule(cfg),
+	}
+}
+
+// completeExecutionRecord records delivery before removing the retained
+// workload artifact. If this process dies between delivery and persistence,
+// recovery can send the notification again, which is intentionally
+// at-least-once rather than silently losing a terminal result.
+func (s *scheduler) completeExecutionRecord(ctx context.Context, record *executionRecord) {
+	if record == nil {
+		return
+	}
+
+	record.Reported = true
+
+	if err := s.executions.update(*record); err != nil {
+		s.log.Error("failed to persist scheduled execution reporting state", slog.String("run_id", record.RunID), logger.ErrAttr(err))
+		return
+	}
+
+	if err := s.cleanupExecutionArtifact(ctx, record); err != nil {
+		s.log.Error("failed to clean up scheduled execution artifact", slog.String("run_id", record.RunID), logger.ErrAttr(err))
+		return
+	}
+
+	if len(record.Finalization.StopServices) > 0 && !record.Restored {
+		return
+	}
+
+	if err := s.executions.remove(record.RunID); err != nil {
+		s.log.Error("failed to remove completed scheduled execution record", slog.String("run_id", record.RunID), logger.ErrAttr(err))
+	}
+}
+
+func (s *scheduler) cleanupExecutionArtifact(ctx context.Context, record *executionRecord) error {
+	switch record.Mode {
+	case scheduledJobModeContainer:
+		resourceID, err := docker.FindOneOffContainer(ctx, s.dockerCli.Client(), record.RunID)
+		if err != nil {
+			return err
+		}
+
+		if resourceID == "" {
+			return nil
+		}
+
+		return docker.RemoveOneOffContainer(ctx, s.dockerCli.Client(), resourceID)
+	case scheduledJobModeSwarm:
+		resourceID, err := docker.FindSwarmOneOffService(ctx, s.dockerCli, record.RunID)
+		if err != nil {
+			return err
+		}
+
+		if resourceID == "" {
+			return nil
+		}
+
+		return docker.RemoveSwarmOneOffService(ctx, s.dockerCli, resourceID)
+	default:
+		return fmt.Errorf("unsupported scheduled execution mode %q", record.Mode)
+	}
+}
+
+// recoverExecutions adopts retained one-off workloads before the worker
+// calculates normal schedules. A missing workload is terminally failed so any
+// services that were held for it are restored by executeScheduledRun's normal
+// finalization path on the next recovered completion.
+func (s *scheduler) recoverExecutions(ctx context.Context) {
+	records, err := s.executions.list(s.contextName, s.mode)
+	if err != nil {
+		s.log.Error("failed to load scheduled execution recovery records", logger.ErrAttr(err))
+		return
+	}
+
+	for _, record := range records {
+		job := record.Job.scheduled()
+		if job.key == "" {
+			continue
+		}
+
+		if !s.claimRecovery(record.RunID) {
+			continue
+		}
+
+		s.seedRecoveredStopHolds(&record, job)
+		s.setRunInProgress(job.key, true)
+
+		s.runs.Go(func() {
+			defer s.setRunInProgress(job.key, false)
+			defer s.releaseRecovery(record.RunID)
+
+			s.recoverExecution(ctx, &record, job)
+		})
+	}
+}
+
+func (s *scheduler) recoverExecution(ctx context.Context, record *executionRecord, job scheduledJob) {
+	stackName := getJobStackName(job)
+	cfg := record.Finalization.scheduleConfig()
+	metricLabels := getScheduledRunMetricLabels(job, cfg, stackName)
+
+	unlockStacks := lockStacks(s.contextName, append([]string{stackName}, resolveStopServiceStacks(cfg.StopServices, stackName)...)...)
+	defer unlockStacks()
+
+	var (
+		runErr   error
+		runStart *time.Time
+	)
+
+	if !record.Reported {
+		runStart = s.recoveredExecutionStartedAt(ctx, record)
+
+		if runStart == nil {
+			now := time.Now()
+			runStart = &now
+		}
+
+		prometheus.ScheduledRunsActive.WithLabelValues(metricLabels...).Inc()
+
+		runErr = s.waitForRecoveredArtifact(ctx, record)
+
+		prometheus.ScheduledRunsActive.WithLabelValues(metricLabels...).Dec()
+
+		// Leave ownership and finalization state untouched on worker shutdown so
+		// the next process can adopt the same retained artifact.
+		if ctx.Err() != nil {
+			return
+		}
+	}
+
+	if len(cfg.StopServices) > 0 && !record.Restored {
+		if err := s.startServicesForJob(context.WithoutCancel(ctx), job.mode, getJobStackName(job), cfg.StopServices); err != nil {
+			s.log.Error("failed to restore services for recovered scheduled execution", slog.String("run_id", record.RunID), logger.ErrAttr(err))
+			return
+		}
+
+		record.Restored = true
+		if err := s.executions.update(*record); err != nil {
+			s.log.Error("failed to persist recovered scheduled execution restoration state", slog.String("run_id", record.RunID), logger.ErrAttr(err))
+			return
+		}
+	}
+
+	if !record.Reported {
+		prometheus.ScheduledRunDuration.WithLabelValues(metricLabels...).Observe(time.Since(*runStart).Seconds())
+		prometheus.ScheduledRunsTotal.WithLabelValues(metricLabels...).Inc()
+
+		if runErr != nil {
+			prometheus.ScheduledRunErrorsTotal.WithLabelValues(metricLabels...).Inc()
+		}
+
+		s.runtime.updateRunStatus(job, cfg, runErr)
+
+		if runErr != nil {
+			s.sendRunNotification(job, cfg, record.RunID, false, "Scheduled job failed", fmt.Sprintf("scheduled job '%s' failed to run: %v", job.name, runErr))
+		} else {
+			s.sendRunNotification(job, cfg, record.RunID, true, "Scheduled job completed", fmt.Sprintf("scheduled job '%s' completed successfully", job.name))
+		}
+	}
+
+	s.completeExecutionRecord(ctx, record)
+}
+
+func (s *scheduler) recoveredExecutionStartedAt(ctx context.Context, record *executionRecord) *time.Time {
+	var labels map[string]string
+
+	switch record.Mode {
+	case scheduledJobModeContainer:
+		containerID, err := docker.FindOneOffContainer(ctx, s.dockerCli.Client(), record.RunID)
+		if err != nil || containerID == "" {
+			return nil
+		}
+
+		result, err := s.dockerCli.Client().ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+		if err != nil || result.Container.Config == nil {
+			return nil
+		}
+
+		labels = result.Container.Config.Labels
+	case scheduledJobModeSwarm:
+		serviceID, err := docker.FindSwarmOneOffService(ctx, s.dockerCli, record.RunID)
+		if err != nil || serviceID == "" {
+			return nil
+		}
+
+		result, err := s.dockerCli.Client().ServiceInspect(ctx, serviceID, client.ServiceInspectOptions{})
+		if err != nil {
+			return nil
+		}
+
+		labels = docker.SwarmJobLabels(result.Service)
+	}
+
+	return parseRFC3339Time(labels[docker.DocoCDJobLabels.JobStartedAt])
+}
+
+func (s *scheduler) claimRecovery(runID string) bool {
+	s.recoveryMu.Lock()
+	defer s.recoveryMu.Unlock()
+
+	if _, exists := s.recovering[runID]; exists {
+		return false
+	}
+
+	s.recovering[runID] = struct{}{}
+
+	return true
+}
+
+func (s *scheduler) releaseRecovery(runID string) {
+	s.recoveryMu.Lock()
+	defer s.recoveryMu.Unlock()
+
+	delete(s.recovering, runID)
+}
+
+func (s *scheduler) waitForRecoveredArtifact(ctx context.Context, record *executionRecord) error {
+	switch record.Mode {
+	case scheduledJobModeContainer:
+		resourceID, err := docker.FindOneOffContainer(ctx, s.dockerCli.Client(), record.RunID)
+		if err != nil {
+			return err
+		}
+
+		if resourceID == "" {
+			return fmt.Errorf("recover scheduled one-off run %s: container was not found", record.RunID)
+		}
+
+		return docker.WaitOnOneOffContainer(ctx, s.dockerCli.Client(), resourceID)
+	case scheduledJobModeSwarm:
+		resourceID, err := docker.FindSwarmOneOffService(ctx, s.dockerCli, record.RunID)
+		if err != nil {
+			return err
+		}
+
+		if resourceID == "" {
+			return fmt.Errorf("recover scheduled one-off run %s: service was not found", record.RunID)
+		}
+
+		return docker.WaitOnSwarmOneOffService(ctx, s.dockerCli, resourceID)
+	default:
+		return fmt.Errorf("unsupported scheduled execution mode %q", record.Mode)
+	}
+}
+
+func (s *scheduler) seedRecoveredStopHolds(record *executionRecord, job scheduledJob) {
+	if record.Restored || len(record.Finalization.StopServices) == 0 {
+		return
+	}
+
+	stackName := getJobStackName(job)
+
+	plans := make(map[string]executionStopPlan, len(record.StopPlans))
+	for _, plan := range record.StopPlans {
+		plans[plan.Project+"\x00"+plan.Service] = plan
+	}
+
+	for _, ref := range record.Finalization.StopServices {
+		project := ref.Project
+		if project == "" {
+			project = stackName
+		}
+
+		s.acquireStopHold(job.mode, project, ref.Service)
+
+		if plan, ok := plans[project+"\x00"+ref.Service]; ok && plan.Replicas > 0 {
+			s.setStopHoldReplicas(job.mode, project, ref.Service, plan.Replicas)
+		}
+
+		if job.mode == scheduledJobModeContainer && s.stopHoldTracker != nil {
+			s.stopHoldTracker.MarkSchedulerStopHeld(s.contextName, project, ref.Service)
+		}
+	}
+}

--- a/internal/scheduler/execution_recovery.go
+++ b/internal/scheduler/execution_recovery.go
@@ -83,10 +83,8 @@ func (s *scheduler) cleanupExecutionArtifact(ctx context.Context, record *execut
 	}
 }
 
-// recoverExecutions adopts retained one-off workloads before the worker
-// calculates normal schedules. A missing workload is terminally failed so any
-// services that were held for it are restored by executeScheduledRun's normal
-// finalization path on the next recovered completion.
+// recoverExecutions finds in-flight jobs by RunID label and continues monitoring
+// them until completion. Runs on startup after forced termination or crash.
 func (s *scheduler) recoverExecutions(ctx context.Context) {
 	records, err := s.executions.list(s.contextName, s.mode)
 	if err != nil {
@@ -130,6 +128,8 @@ func (s *scheduler) recoverExecution(ctx context.Context, record *executionRecor
 	)
 
 	if !record.Reported {
+		// Extract original start time from artifact labels for accurate metrics.
+		// If artifact was removed, use current time instead.
 		runStart = s.recoveredExecutionStartedAt(ctx, record)
 
 		if runStart == nil {
@@ -183,6 +183,8 @@ func (s *scheduler) recoverExecution(ctx context.Context, record *executionRecor
 	s.completeExecutionRecord(ctx, record)
 }
 
+// recoveredExecutionStartedAt reads the start time from Docker artifact labels.
+// Returns nil if artifact or label is missing.
 func (s *scheduler) recoveredExecutionStartedAt(ctx context.Context, record *executionRecord) *time.Time {
 	var labels map[string]string
 
@@ -216,6 +218,8 @@ func (s *scheduler) recoveredExecutionStartedAt(ctx context.Context, record *exe
 	return parseRFC3339Time(labels[docker.DocoCDJobLabels.JobStartedAt])
 }
 
+// claimRecovery acquires exclusive local ownership of a run to prevent
+// duplicate adoption. Returns true if claimed, false if already held.
 func (s *scheduler) claimRecovery(runID string) bool {
 	s.recoveryMu.Lock()
 	defer s.recoveryMu.Unlock()
@@ -265,6 +269,8 @@ func (s *scheduler) waitForRecoveredArtifact(ctx context.Context, record *execut
 	}
 }
 
+// seedRecoveredStopHolds re-acquires stop holds for services from persisted stop
+// plans. Restores each service to its original replica count.
 func (s *scheduler) seedRecoveredStopHolds(record *executionRecord, job scheduledJob) {
 	if record.Restored || len(record.Finalization.StopServices) == 0 {
 		return

--- a/internal/scheduler/execution_store.go
+++ b/internal/scheduler/execution_store.go
@@ -107,6 +107,9 @@ func (j executionJob) scheduled() scheduledJob {
 	}
 }
 
+// executionStore persists finalization state that cannot be stored in Docker
+// labels: stop plans, notification status, and restoration markers.
+// All writes are atomic: temp file → sync → rename → directory sync.
 type executionStore struct {
 	mu   sync.Mutex
 	root string
@@ -205,6 +208,8 @@ func (s *executionStore) list(contextName string, mode scheduledJobMode) ([]exec
 
 		var record executionRecord
 		if unmarshalErr := json.Unmarshal(data, &record); unmarshalErr != nil {
+			// Corrupt files are renamed with .corrupt suffix to prevent
+			// parse errors on every startup.
 			if err := s.quarantine(path); err != nil {
 				return nil, fmt.Errorf("quarantine malformed execution record %s: %w", entry.Name(), err)
 			}
@@ -213,6 +218,8 @@ func (s *executionStore) list(contextName string, mode scheduledJobMode) ([]exec
 		}
 
 		if record.Version != executionRecordVersion {
+			// Unsupported schema versions are quarantined to allow future
+			// migrations without breaking startup.
 			if err := s.quarantine(path); err != nil {
 				return nil, fmt.Errorf("quarantine unsupported execution record %s: %w", entry.Name(), err)
 			}
@@ -243,6 +250,8 @@ func (s *executionStore) write(record executionRecord) error {
 		return fmt.Errorf("encode execution record %s: %w", record.RunID, err)
 	}
 
+	// Write to temp file, sync, then rename to final name. Then sync directory.
+	// Prevents corruption if process crashes during write.
 	file, err := os.CreateTemp(s.root, ".execution-*.json")
 	if err != nil {
 		return fmt.Errorf("create temporary execution record: %w", err)
@@ -272,6 +281,7 @@ func (s *executionStore) write(record executionRecord) error {
 		return fmt.Errorf("publish execution record %s: %w", record.RunID, err)
 	}
 
+	// Sync directory inode to durably link the new/updated record.
 	dir, err := os.Open(s.root)
 	if err != nil {
 		return fmt.Errorf("open execution record directory: %w", err)

--- a/internal/scheduler/execution_store.go
+++ b/internal/scheduler/execution_store.go
@@ -1,0 +1,294 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/kimdre/doco-cd/internal/docker"
+	"github.com/kimdre/doco-cd/internal/filesystem"
+)
+
+const executionRecordVersion = 1
+
+// executionRecord only persists finalization state that cannot be stored in
+// Docker labels before side effects occur. Runtime identity and timestamps
+// live on the temporary container or service itself.
+type executionRecord struct {
+	Version      int                         `json:"version"`
+	RunID        string                      `json:"run_id"`
+	Context      string                      `json:"context"`
+	Mode         scheduledJobMode            `json:"mode"`
+	Job          executionJob                `json:"job"`
+	Finalization executionFinalizationConfig `json:"finalization"`
+	StopPlans    []executionStopPlan         `json:"stop_plans,omitempty"`
+	Restored     bool                        `json:"restored"`
+	Reported     bool                        `json:"reported"`
+}
+
+type executionStopPlan struct {
+	Project  string `json:"project"`
+	Service  string `json:"service"`
+	Replicas uint64 `json:"replicas,omitempty"`
+}
+
+type executionFinalizationConfig struct {
+	NotifyOn     docker.JobNotifyOn      `json:"notify_on"`
+	StopServices []docker.StopServiceRef `json:"stop_services,omitempty"`
+}
+
+func executionFinalizationConfigFromSchedule(cfg docker.JobScheduleConfig) executionFinalizationConfig {
+	return executionFinalizationConfig{
+		NotifyOn:     cfg.NotifyOn,
+		StopServices: slices.Clone(cfg.StopServices),
+	}
+}
+
+func (c executionFinalizationConfig) scheduleConfig() docker.JobScheduleConfig {
+	return docker.JobScheduleConfig{
+		ExecutionMode: docker.JobExecutionModeOneOff,
+		NotifyOn:      c.NotifyOn,
+		StopServices:  slices.Clone(c.StopServices),
+	}
+}
+
+type executionJob struct {
+	Key     string            `json:"key"`
+	Name    string            `json:"name"`
+	ID      string            `json:"id"`
+	Mode    scheduledJobMode  `json:"mode"`
+	Labels  map[string]string `json:"labels"`
+	Context string            `json:"context"`
+}
+
+func executionJobFromScheduled(job scheduledJob) executionJob {
+	return executionJob{
+		Key:     job.key,
+		Name:    job.name,
+		ID:      job.id,
+		Mode:    job.mode,
+		Labels:  executionNotificationLabels(job.labels),
+		Context: job.context,
+	}
+}
+
+func executionNotificationLabels(labels map[string]string) map[string]string {
+	keys := []string{
+		docker.DocoCDLabels.Source.Name,
+		docker.DocoCDLabels.Deployment.Name,
+		docker.DocoCDLabels.Deployment.ConfigTarget,
+		docker.DocoCDLabels.Deployment.CommitSHA,
+	}
+
+	result := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := labels[key]; ok {
+			result[key] = value
+		}
+	}
+
+	return result
+}
+
+func (j executionJob) scheduled() scheduledJob {
+	return scheduledJob{
+		key:     j.Key,
+		name:    j.Name,
+		id:      j.ID,
+		mode:    j.Mode,
+		labels:  maps.Clone(j.Labels),
+		context: j.Context,
+	}
+}
+
+type executionStore struct {
+	mu   sync.Mutex
+	root string
+}
+
+func newExecutionStore(dataMountPath string) *executionStore {
+	dataMountPath = strings.TrimSpace(dataMountPath)
+	if dataMountPath == "" {
+		return &executionStore{}
+	}
+
+	return &executionStore{root: filepath.Join(dataMountPath, "scheduler-executions")}
+}
+
+func (s *executionStore) enabled() bool {
+	return s != nil && s.root != ""
+}
+
+func (s *executionStore) create(record *executionRecord) error {
+	if !s.enabled() {
+		return nil
+	}
+
+	if record == nil {
+		return errors.New("execution record is required")
+	}
+
+	if record.Version == 0 {
+		record.Version = executionRecordVersion
+	}
+
+	if record.RunID == "" {
+		return errors.New("execution record run ID is required")
+	}
+
+	return s.write(*record)
+}
+
+func (s *executionStore) update(record executionRecord) error {
+	if !s.enabled() {
+		return nil
+	}
+
+	if record.RunID == "" {
+		return errors.New("execution record run ID is required")
+	}
+
+	return s.write(record)
+}
+
+func (s *executionStore) remove(runID string) error {
+	if !s.enabled() {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	err := os.Remove(s.path(runID))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove execution record %s: %w", runID, err)
+	}
+
+	return nil
+}
+
+func (s *executionStore) list(contextName string, mode scheduledJobMode) ([]executionRecord, error) {
+	if !s.enabled() {
+		return nil, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := os.ReadDir(s.root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("read execution records: %w", err)
+	}
+
+	records := make([]executionRecord, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		path := filepath.Join(s.root, entry.Name())
+
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, fmt.Errorf("read execution record %s: %w", entry.Name(), readErr)
+		}
+
+		var record executionRecord
+		if unmarshalErr := json.Unmarshal(data, &record); unmarshalErr != nil {
+			if err := s.quarantine(path); err != nil {
+				return nil, fmt.Errorf("quarantine malformed execution record %s: %w", entry.Name(), err)
+			}
+
+			continue
+		}
+
+		if record.Version != executionRecordVersion {
+			if err := s.quarantine(path); err != nil {
+				return nil, fmt.Errorf("quarantine unsupported execution record %s: %w", entry.Name(), err)
+			}
+
+			continue
+		}
+
+		if record.RunID == "" || record.Context != contextName || record.Mode != mode {
+			continue
+		}
+
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+func (s *executionStore) write(record executionRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(s.root, filesystem.PermDir); err != nil {
+		return fmt.Errorf("create execution record directory: %w", err)
+	}
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("encode execution record %s: %w", record.RunID, err)
+	}
+
+	file, err := os.CreateTemp(s.root, ".execution-*.json")
+	if err != nil {
+		return fmt.Errorf("create temporary execution record: %w", err)
+	}
+
+	tempPath := file.Name()
+
+	defer func() {
+		_ = os.Remove(tempPath)
+	}()
+
+	if _, err = file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write execution record %s: %w", record.RunID, err)
+	}
+
+	if err = file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync execution record %s: %w", record.RunID, err)
+	}
+
+	if err = file.Close(); err != nil {
+		return fmt.Errorf("close execution record %s: %w", record.RunID, err)
+	}
+
+	if err = os.Rename(tempPath, s.path(record.RunID)); err != nil {
+		return fmt.Errorf("publish execution record %s: %w", record.RunID, err)
+	}
+
+	dir, err := os.Open(s.root)
+	if err != nil {
+		return fmt.Errorf("open execution record directory: %w", err)
+	}
+	defer dir.Close() // nolint:errcheck
+
+	if err = dir.Sync(); err != nil {
+		return fmt.Errorf("sync execution record directory: %w", err)
+	}
+
+	return nil
+}
+
+func (s *executionStore) path(runID string) string {
+	return filepath.Join(s.root, runID+".json")
+}
+
+func (s *executionStore) quarantine(path string) error {
+	return os.Rename(path, path+".corrupt")
+}

--- a/internal/scheduler/execution_store_test.go
+++ b/internal/scheduler/execution_store_test.go
@@ -1,0 +1,83 @@
+package scheduler
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kimdre/doco-cd/internal/docker"
+)
+
+func TestExecutionStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := newExecutionStore(t.TempDir())
+	record := executionRecord{
+		RunID:        "run-1",
+		Context:      "production",
+		Mode:         scheduledJobModeContainer,
+		Job:          executionJob{Key: "container:job", Name: "job", ID: "source", Mode: scheduledJobModeContainer},
+		Finalization: executionFinalizationConfig{NotifyOn: docker.JobNotifyAll},
+		Restored:     false,
+	}
+
+	if err := store.create(&record); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	record.Reported = true
+	if err := store.update(record); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	records, err := store.list("production", scheduledJobModeContainer)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(records) != 1 || !records[0].Reported {
+		t.Fatalf("records = %#v, want updated record", records)
+	}
+
+	if err := store.remove(record.RunID); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	records, err = store.list("production", scheduledJobModeContainer)
+	if err != nil {
+		t.Fatalf("list after remove: %v", err)
+	}
+
+	if len(records) != 0 {
+		t.Fatalf("records after remove = %#v, want none", records)
+	}
+}
+
+func TestExecutionStoreQuarantinesMalformedRecords(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	store := newExecutionStore(root)
+	if err := os.MkdirAll(store.root, 0o755); err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	badPath := filepath.Join(store.root, "bad.json")
+	if err := os.WriteFile(badPath, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write malformed record: %v", err)
+	}
+
+	records, err := store.list("", scheduledJobModeContainer)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if len(records) != 0 {
+		t.Fatalf("records = %#v, want none", records)
+	}
+
+	if _, err := os.Stat(badPath + ".corrupt"); err != nil {
+		t.Fatalf("malformed record was not quarantined: %v", err)
+	}
+}

--- a/internal/scheduler/scheduler_api.go
+++ b/internal/scheduler/scheduler_api.go
@@ -144,15 +144,21 @@ func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (
 
 	runStart := time.Now()
 	runFailed := false
+	recordTerminalMetrics := true
 
 	prometheus.ScheduledRunsActive.WithLabelValues(metricLabels...).Inc()
 	defer prometheus.ScheduledRunsActive.WithLabelValues(metricLabels...).Dec()
 	defer func() {
-		prometheus.ScheduledRunDuration.WithLabelValues(metricLabels...).Observe(time.Since(runStart).Seconds())
+		if recordTerminalMetrics {
+			prometheus.ScheduledRunDuration.WithLabelValues(metricLabels...).Observe(time.Since(runStart).Seconds())
+		}
 	}()
-	defer prometheus.ScheduledRunsTotal.WithLabelValues(metricLabels...).Inc()
 	defer func() {
-		if runFailed {
+		if recordTerminalMetrics {
+			prometheus.ScheduledRunsTotal.WithLabelValues(metricLabels...).Inc()
+		}
+
+		if recordTerminalMetrics && runFailed {
 			prometheus.ScheduledRunErrorsTotal.WithLabelValues(metricLabels...).Inc()
 		}
 	}()
@@ -166,7 +172,30 @@ func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (
 	s.setRunInProgress(job.key, true)
 	defer s.setRunInProgress(job.key, false)
 
-	err = s.executeScheduledRun(ctx, job, cfg)
+	var record *executionRecord
+
+	if cfg.ExecutionMode == docker.JobExecutionModeOneOff {
+		if !s.claimRecovery(runID) {
+			return runID, fmt.Errorf("scheduled run %s is already active", runID)
+		}
+
+		defer s.releaseRecovery(runID)
+
+		newRecord := s.newExecutionRecord(runID, job, cfg)
+		if err := s.executions.create(&newRecord); err != nil {
+			return runID, fmt.Errorf("persist scheduled execution before launch: %w", err)
+		}
+
+		record = &newRecord
+	}
+
+	err = s.executeScheduledRun(ctx, job, cfg, record, schedulerNow(), runStart)
+	if ctx.Err() != nil {
+		recordTerminalMetrics = false
+
+		return runID, errors.Join(err, ctx.Err())
+	}
+
 	s.runtime.updateRunStatus(job, cfg, err)
 	s.runtime.setLastRun(job.key, schedulerNow())
 
@@ -176,11 +205,15 @@ func (s *scheduler) triggerNow(ctx context.Context, jobName, stackName string) (
 		runLog.Error("scheduled run failed", logger.ErrAttr(err))
 		s.sendRunNotification(job, cfg, runID, false, "Scheduled job failed", fmt.Sprintf("scheduled job '%s' failed to run: %v", job.name, err))
 
+		s.completeExecutionRecord(ctx, record)
+
 		return runID, err
 	}
 
 	runLog.Info("scheduled run completed")
 	s.sendRunNotification(job, cfg, runID, true, "Scheduled job completed", fmt.Sprintf("scheduled job '%s' completed successfully", job.name))
+
+	s.completeExecutionRecord(ctx, record)
 
 	return runID, nil
 }

--- a/internal/scheduler/scheduler_discovery.go
+++ b/internal/scheduler/scheduler_discovery.go
@@ -3,12 +3,14 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/docker/compose/v5/pkg/api"
 	"github.com/moby/moby/api/types/container"
+	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 
 	"github.com/kimdre/doco-cd/internal/docker"
@@ -27,6 +29,10 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 		}
 
 		result := make([]scheduledJob, 0, len(services.Items))
+		jobIndexByServiceID := make(map[string]int, len(services.Items))
+		jobIndexByServiceName := make(map[string]int, len(services.Items))
+		ephemeralServices := make([]swarmTypes.Service, 0)
+
 		for _, svc := range services.Items {
 			// Deployment metadata and job runtime metadata are read from the service
 			// spec, but the job configuration itself must come from the task template
@@ -34,7 +40,13 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 			// from. Picking up job config labels from the service spec here would
 			// schedule services that the deploy path does not treat as jobs.
 			labels := docker.SwarmJobLabels(svc)
+			if isEphemeralScheduledContainer(labels) {
+				ephemeralServices = append(ephemeralServices, svc)
+				continue
+			}
 
+			jobIndexByServiceID[svc.ID] = len(result)
+			jobIndexByServiceName[svc.Spec.Name] = len(result)
 			result = append(result, scheduledJob{
 				key:     jobKeyPrefix(s.contextName) + "swarm:" + svc.ID,
 				name:    svc.Spec.Name,
@@ -43,6 +55,34 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 				labels:  labels,
 				context: s.contextName,
 			})
+		}
+
+		for _, svc := range ephemeralServices {
+			active, taskErr := isActiveSwarmEphemeralService(ctx, s.dockerCli.Client(), svc.ID)
+			if taskErr != nil {
+				return nil, fmt.Errorf("list tasks for ephemeral service %s: %w", svc.Spec.Name, taskErr)
+			}
+
+			if !active {
+				continue
+			}
+
+			labels := docker.SwarmJobLabels(svc)
+
+			sourceID := strings.TrimSpace(labels[docker.DocoCDJobLabels.JobSourceServiceID])
+			if index, ok := jobIndexByServiceID[sourceID]; ok {
+				result[index].running = true
+				continue
+			}
+
+			sourceName := strings.TrimSpace(svc.Spec.Name)
+			if index := strings.LastIndex(sourceName, "-doco-job-"); index > 0 {
+				sourceName = sourceName[:index]
+			}
+
+			if index, ok := jobIndexByServiceName[sourceName]; ok {
+				result[index].running = true
+			}
 		}
 
 		return result, nil
@@ -110,6 +150,31 @@ func (s *scheduler) discoverJobs(ctx context.Context) ([]scheduledJob, error) {
 	}
 
 	return result, nil
+}
+
+func isActiveSwarmEphemeralService(ctx context.Context, apiClient client.APIClient, serviceID string) (bool, error) {
+	tasks, err := apiClient.TaskList(ctx, client.TaskListOptions{
+		Filters: make(client.Filters).Add("service", serviceID),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if slices.ContainsFunc(tasks.Items, isActiveSwarmTask) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func isActiveSwarmTask(task swarmTypes.Task) bool {
+	switch task.Status.State {
+	case swarmTypes.TaskStateComplete, swarmTypes.TaskStateShutdown, swarmTypes.TaskStateFailed,
+		swarmTypes.TaskStateRejected, swarmTypes.TaskStateOrphaned, swarmTypes.TaskStateRemove:
+		return false
+	default:
+		return true
+	}
 }
 
 func getScheduleFingerprint(cfg docker.JobScheduleConfig) string {

--- a/internal/scheduler/scheduler_discovery_test.go
+++ b/internal/scheduler/scheduler_discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/compose/v5/pkg/api"
+	swarmTypes "github.com/moby/moby/api/types/swarm"
 
 	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/docker/swarm"
@@ -174,6 +175,35 @@ func TestIsEphemeralScheduledContainer(t *testing.T) {
 			got := isEphemeralScheduledContainer(tt.labels)
 			if got != tt.want {
 				t.Fatalf("isEphemeralScheduledContainer()=%v want=%v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsActiveSwarmTask(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state swarmTypes.TaskState
+		want  bool
+	}{
+		{state: swarmTypes.TaskStateNew, want: true},
+		{state: swarmTypes.TaskStatePending, want: true},
+		{state: swarmTypes.TaskStateRunning, want: true},
+		{state: swarmTypes.TaskStateComplete, want: false},
+		{state: swarmTypes.TaskStateShutdown, want: false},
+		{state: swarmTypes.TaskStateFailed, want: false},
+		{state: swarmTypes.TaskStateRejected, want: false},
+		{state: swarmTypes.TaskStateOrphaned, want: false},
+		{state: swarmTypes.TaskStateRemove, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			t.Parallel()
+
+			if got := isActiveSwarmTask(swarmTypes.Task{Status: swarmTypes.TaskStatus{State: tt.state}}); got != tt.want {
+				t.Fatalf("isActiveSwarmTask(%q) = %v, want %v", tt.state, got, tt.want)
 			}
 		})
 	}

--- a/internal/scheduler/scheduler_execution.go
+++ b/internal/scheduler/scheduler_execution.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/notification"
 )
 
-func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, cfg docker.JobScheduleConfig) error {
+func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, cfg docker.JobScheduleConfig, record *executionRecord, scheduledAt, startedAt time.Time) (err error) {
 	// Stop any declared services before executing the job, then restart them
 	// afterwards regardless of whether the job succeeds or fails.
 	//
@@ -26,15 +26,44 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 	// service 2 of 3 fails, service 1 must still be restarted). Restarting an
 	// already-running service/container is a harmless no-op.
 	if len(cfg.StopServices) > 0 {
+		if record != nil {
+			if err := s.prepareExecutionStopPlans(ctx, job, cfg, record); err != nil {
+				return err
+			}
+
+			if err := s.executions.update(*record); err != nil {
+				return fmt.Errorf("persist scheduled execution before stopping services: %w", err)
+			}
+		}
+
 		stackName := getJobStackName(job)
 		restoreCtx := context.WithoutCancel(ctx)
 
 		defer func() {
-			if err := s.startServicesForJob(restoreCtx, job.mode, stackName, cfg.StopServices); err != nil {
+			if record != nil && ctx.Err() != nil {
+				return
+			}
+
+			if restoreErr := s.startServicesForJob(restoreCtx, job.mode, stackName, cfg.StopServices); restoreErr != nil {
 				s.log.Error("failed to restart services after scheduled job",
 					slog.String("job", job.name),
-					logger.ErrAttr(err),
+					logger.ErrAttr(restoreErr),
 				)
+				err = errors.Join(err, fmt.Errorf("restarting services after job: %w", restoreErr))
+
+				return
+			}
+
+			if record != nil {
+				record.Restored = true
+
+				if persistErr := s.executions.update(*record); persistErr != nil {
+					s.log.Error("failed to persist scheduled execution restoration state",
+						slog.String("run_id", record.RunID),
+						logger.ErrAttr(persistErr),
+					)
+					err = errors.Join(err, fmt.Errorf("persisting service restoration state: %w", persistErr))
+				}
 			}
 		}()
 
@@ -47,7 +76,17 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 	case scheduledJobModeContainer:
 		switch cfg.ExecutionMode {
 		case docker.JobExecutionModeOneOff:
-			err := docker.RunComposeOneOffFromServiceDefinition(ctx, s.dockerCli, job.labels, s.secretProvider, s.composeOptions)
+			runOpts := docker.ComposeOneOffOptions{}
+			if record != nil {
+				runOpts = docker.ComposeOneOffOptions{
+					RunID:       record.RunID,
+					SourceID:    job.id,
+					ScheduledAt: scheduledAt.Format(time.RFC3339Nano),
+					StartedAt:   startedAt.Format(time.RFC3339Nano),
+				}
+			}
+
+			err := docker.RunComposeOneOffFromServiceDefinitionWithOptions(ctx, s.dockerCli, job.labels, s.secretProvider, s.composeOptions, runOpts)
 			if err == nil {
 				return nil
 			}
@@ -56,7 +95,17 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 				return err
 			}
 
-			return docker.RunContainerOneOffFromExisting(ctx, s.dockerCli.Client(), job.id)
+			containerOpts := docker.OneOffContainerOptions{}
+			if record != nil {
+				containerOpts = docker.OneOffContainerOptions{
+					RunID:       record.RunID,
+					SourceID:    job.id,
+					ScheduledAt: scheduledAt.Format(time.RFC3339Nano),
+					StartedAt:   startedAt.Format(time.RFC3339Nano),
+				}
+			}
+
+			return docker.RunContainerOneOffFromExistingWithOptions(ctx, s.dockerCli.Client(), job.id, containerOpts)
 		default:
 			err := docker.RunComposeScheduledContainer(ctx, s.dockerCli, job.id, job.labels, len(cfg.StopServices) > 0, s.secretProvider, s.composeOptions)
 			if err == nil {
@@ -79,10 +128,18 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 	case scheduledJobModeSwarm:
 		switch cfg.ExecutionMode {
 		case docker.JobExecutionModeOneOff:
-			return docker.RunSwarmOneOffFromService(ctx, s.dockerCli, job.id, docker.SwarmOneOffFromServiceOptions{
+			swarmOpts := docker.SwarmOneOffFromServiceOptions{
 				Replicas:         cfg.SwarmReplicas,
 				SendRegistryAuth: true,
-			})
+			}
+			if record != nil {
+				swarmOpts.RunID = record.RunID
+				swarmOpts.KeepService = true
+				swarmOpts.ScheduledAt = scheduledAt.Format(time.RFC3339Nano)
+				swarmOpts.StartedAt = startedAt.Format(time.RFC3339Nano)
+			}
+
+			return docker.RunSwarmOneOffFromService(ctx, s.dockerCli, job.id, swarmOpts)
 		default:
 			err := docker.RerunJobService(ctx, s.dockerCli.Client(), job.id)
 			if err == nil {
@@ -98,6 +155,39 @@ func (s *scheduler) executeScheduledRun(ctx context.Context, job scheduledJob, c
 	default:
 		return fmt.Errorf("unsupported scheduled job mode %q", job.mode)
 	}
+}
+
+func (s *scheduler) prepareExecutionStopPlans(ctx context.Context, job scheduledJob, cfg docker.JobScheduleConfig, record *executionRecord) error {
+	stackName := getJobStackName(job)
+
+	plans := make([]executionStopPlan, 0, len(cfg.StopServices))
+	for _, ref := range cfg.StopServices {
+		project := ref.Project
+		if project == "" {
+			project = stackName
+		}
+
+		plan := executionStopPlan{Project: project, Service: ref.Service}
+		if job.mode == scheduledJobModeSwarm {
+			replicas, err := docker.SwarmServiceReplicas(ctx, s.dockerCli, project+"_"+ref.Service)
+			if errors.Is(err, docker.ErrGlobalSwarmServiceNotScalable) {
+				plans = append(plans, plan)
+				continue
+			}
+
+			if err != nil {
+				return fmt.Errorf("record restoration plan for swarm service %s_%s: %w", project, ref.Service, err)
+			}
+
+			plan.Replicas = replicas
+		}
+
+		plans = append(plans, plan)
+	}
+
+	record.StopPlans = plans
+
+	return s.executions.update(*record)
 }
 
 const stopServicesTimeout = 30 * time.Second

--- a/internal/scheduler/scheduler_types.go
+++ b/internal/scheduler/scheduler_types.go
@@ -66,6 +66,7 @@ type scheduler struct {
 	wg              *sync.WaitGroup
 	startedAt       time.Time
 	runtime         *runtimeStore
+	executions      *executionStore
 	runs            sync.WaitGroup
 	// composeOptions bundles the Docker-owned settings needed to reload the compose project for
 	// a scheduled run (see docker.ScheduledComposeOptions), resolved explicitly by the caller
@@ -85,6 +86,8 @@ type scheduler struct {
 	// restored when the last holder releases it.
 	stopHoldsMu sync.Mutex
 	stopHolds   map[stopHoldKey]*stopHoldState
+	recoveryMu  sync.Mutex
+	recovering  map[string]struct{}
 }
 
 // ServiceStopHoldTracker suppresses reconciliation while scheduled jobs
@@ -159,8 +162,10 @@ func newSchedulerForMode(cc docker.ContextClient, mode scheduledJobMode, log *sl
 		wg:              wg,
 		startedAt:       schedulerNow(),
 		runtime:         runtime,
+		executions:      newExecutionStore(composeOptions.ComposeLoad.DataMountPath),
 		composeOptions:  composeOptions,
 		states:          map[string]scheduledJobState{},
 		stopHolds:       map[stopHoldKey]*stopHoldState{},
+		recovering:      map[string]struct{}{},
 	}
 }

--- a/internal/scheduler/scheduler_worker.go
+++ b/internal/scheduler/scheduler_worker.go
@@ -248,7 +248,7 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 	stackName := getJobStackName(job)
 	metricLabels := getScheduledRunMetricLabels(job, cfg, stackName)
 
-	if cfg.SkipRunning && s.isRunInProgress(job.key) {
+	if cfg.SkipRunning && (job.running || s.isRunInProgress(job.key)) {
 		s.log.Warn("skipping scheduled run because previous run is still in progress",
 			slog.String("job", job.name),
 			slog.String("stack", stackName),

--- a/internal/scheduler/scheduler_worker.go
+++ b/internal/scheduler/scheduler_worker.go
@@ -19,6 +19,7 @@ import (
 const (
 	schedulerEventReconnectDelay = time.Second
 	schedulerRefreshRetryDelay   = time.Second
+	schedulerRecoverySweepDelay  = time.Minute
 )
 
 func (s *scheduler) run(ctx context.Context) {
@@ -26,11 +27,15 @@ func (s *scheduler) run(ctx context.Context) {
 
 	jobChanges := s.watchJobChanges(ctx)
 	timer := time.NewTimer(time.Hour)
+	recoveryTicker := time.NewTicker(schedulerRecoverySweepDelay)
 
 	stopTimer(timer)
 	defer timer.Stop()
+	defer recoveryTicker.Stop()
 
 	s.log.Info("starting scheduler")
+
+	s.recoverExecutions(ctx)
 
 	nextRun, hasNextRun := s.refreshJobs(ctx, schedulerNow())
 
@@ -50,6 +55,8 @@ func (s *scheduler) run(ctx context.Context) {
 			nextRun, hasNextRun = s.refreshJobs(ctx, schedulerNow())
 		case t := <-timer.C:
 			nextRun, hasNextRun = s.refreshJobs(ctx, t)
+		case <-recoveryTicker.C:
+			s.recoverExecutions(ctx)
 		}
 	}
 }
@@ -307,7 +314,38 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 
 		runLog.Debug("triggering scheduled run")
 
-		err := s.executeScheduledRun(ctx, job, cfg)
+		var record *executionRecord
+
+		if cfg.ExecutionMode == docker.JobExecutionModeOneOff {
+			if !s.claimRecovery(runID) {
+				runFailed = true
+
+				runLog.Error("scheduled run ID is already active")
+
+				return
+			}
+
+			defer s.releaseRecovery(runID)
+
+			newRecord := s.newExecutionRecord(runID, job, cfg)
+			if err := s.executions.create(&newRecord); err != nil {
+				runFailed = true
+				err = fmt.Errorf("persist scheduled execution before launch: %w", err)
+				s.runtime.updateRunStatus(job, cfg, err)
+				runLog.Error("scheduled run failed", logger.ErrAttr(err))
+				s.sendRunNotification(job, cfg, runID, false, "Scheduled job failed", fmt.Sprintf("scheduled job '%s' failed to run: %v", job.name, err))
+
+				return
+			}
+
+			record = &newRecord
+		}
+
+		err := s.executeScheduledRun(ctx, job, cfg, record, now, runStart)
+		if ctx.Err() != nil {
+			return
+		}
+
 		s.runtime.updateRunStatus(job, cfg, err)
 
 		if err != nil {
@@ -316,11 +354,15 @@ func (s *scheduler) triggerRun(ctx context.Context, job scheduledJob, cfg docker
 			runLog.Error("scheduled run failed", logger.ErrAttr(err))
 			s.sendRunNotification(job, cfg, runID, false, "Scheduled job failed", fmt.Sprintf("scheduled job '%s' failed to run: %v", job.name, err))
 
+			s.completeExecutionRecord(ctx, record)
+
 			return
 		}
 
 		runLog.Info("scheduled run completed", slog.String("next_run", s.states[job.key].nextRun.Format(time.RFC3339)))
 		s.sendRunNotification(job, cfg, runID, true, "Scheduled job completed", fmt.Sprintf("scheduled job '%s' completed successfully", job.name))
+
+		s.completeExecutionRecord(ctx, record)
 	})
 }
 

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -41,11 +41,13 @@ type Harness struct {
 	ctx      context.Context
 	scenario string
 
-	workDir    string // host tmp dir: repos/<scenario>.git + src/<scenario>
-	repoPath   string // bare repo dir the gitserver container mounts read-only
-	worktree   string // host worktree dir used to build fixture/commits
-	dataVolume string
-	volumes    []string
+	workDir      string // host tmp dir: repos/<scenario>.git + src/<scenario>
+	repoPath     string // bare repo dir the gitserver container mounts read-only
+	worktree     string // host worktree dir used to build fixture/commits
+	pollConfig   string
+	pollInterval time.Duration
+	dataVolume   string
+	volumes      []string
 
 	wt     *git.Worktree
 	docker *client.Client
@@ -121,6 +123,13 @@ func (h *Harness) TrackVolume(name string) {
 	h.volumes = append(h.volumes, name)
 }
 
+// SetPollInterval sets the poll interval for the test daemon.
+// Call before Start.
+func (h *Harness) SetPollInterval(interval time.Duration) {
+	h.t.Helper()
+	h.pollInterval = interval
+}
+
 // Start creates the initial fixture commit, builds and starts the gitserver
 // + doco-cd containers, and waits for the daemon to become healthy.
 func (h *Harness) Start() {
@@ -156,8 +165,43 @@ func (h *Harness) Start() {
 	}
 
 	pollPath := h.writePollConfig()
+	h.pollConfig = pollPath
 	h.logf("starting daemon")
 	h.startDaemon(pollPath)
+}
+
+// KillAndRestartDaemon forcibly removes the daemon container, then starts a
+// replacement with the same scenario data volume and poll configuration.
+func (h *Harness) KillAndRestartDaemon() {
+	h.t.Helper()
+
+	if h.daemon == nil {
+		h.t.Fatal("doco-cd daemon is not running")
+	}
+
+	if h.pollConfig == "" {
+		h.t.Fatal("doco-cd poll configuration is unavailable")
+	}
+
+	daemonID := h.daemon.GetContainerID()
+	h.logf("force-killing doco-cd container %s", shortContainerID(daemonID))
+
+	if _, err := h.docker.ContainerKill(h.ctx, daemonID, client.ContainerKillOptions{Signal: "SIGKILL"}); err != nil {
+		h.t.Fatalf("force-kill doco-cd container: %v", err)
+	}
+
+	h.WaitFor(10*time.Second, "doco-cd container stopped", func() bool {
+		inspect, err := h.docker.ContainerInspect(h.ctx, daemonID, client.ContainerInspectOptions{})
+		return err == nil && inspect.Container.State != nil && !inspect.Container.State.Running
+	})
+
+	if _, err := h.docker.ContainerRemove(h.ctx, daemonID, client.ContainerRemoveOptions{Force: true}); err != nil {
+		h.t.Fatalf("remove force-killed doco-cd container: %v", err)
+	}
+
+	h.daemon = nil
+	h.logf("starting replacement doco-cd container")
+	h.startDaemon(h.pollConfig)
 }
 
 func (h *Harness) startGitServer() {
@@ -444,7 +488,12 @@ func daemonImageName() string {
 func (h *Harness) writePollConfig() string {
 	h.t.Helper()
 
-	content := fmt.Sprintf("- url: http://gitserver/%s.git\n  reference: refs/heads/main\n  interval: 10\n", h.scenario)
+	interval := h.pollInterval
+	if interval == 0 {
+		interval = 10 * time.Second
+	}
+
+	content := fmt.Sprintf("- url: http://gitserver/%s.git\n  reference: refs/heads/main\n  interval: %s\n", h.scenario, interval)
 
 	path := filepath.Join(h.workDir, "poll.yaml")
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {

--- a/test/e2e/harness.go
+++ b/test/e2e/harness.go
@@ -32,6 +32,8 @@ import (
 // repoDir is the doco-cd repo root, relative to this package (test/e2e).
 const repoDir = "../.."
 
+const e2eStopTimeout = time.Second
+
 // Harness owns one gitserver + one doco-cd container built from the working
 // tree, plus the host-side git repo the daemon polls. Every scenario gets
 // its own instance (own network, own containers, own workdir), so scenarios
@@ -541,7 +543,7 @@ func (h *Harness) teardownSuite() {
 func (h *Harness) teardownInternal() {
 	h.teardownOnce.Do(func() {
 		if h.daemon != nil {
-			_ = h.daemon.Terminate(h.ctx)
+			h.terminateContainer(h.daemon)
 		}
 
 		h.cleanupStacks()
@@ -557,11 +559,11 @@ func (h *Harness) teardownInternal() {
 		}
 
 		if h.remoteDaemon != nil {
-			_ = h.remoteDaemon.Terminate(h.ctx)
+			h.terminateContainer(h.remoteDaemon)
 		}
 
 		if h.gitSrv != nil {
-			_ = h.gitSrv.Terminate(h.ctx)
+			h.terminateContainer(h.gitSrv)
 		}
 
 		if h.net != nil {
@@ -572,6 +574,10 @@ func (h *Harness) teardownInternal() {
 
 		_ = os.RemoveAll(h.workDir)
 	})
+}
+
+func (h *Harness) terminateContainer(container testcontainers.Container) {
+	_ = container.Terminate(h.ctx, testcontainers.StopTimeout(e2eStopTimeout))
 }
 
 func (h *Harness) logFailure() {

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -343,7 +343,8 @@ func (h *Harness) SwarmServiceHasRunningTask(serviceID string) bool {
 	}
 
 	for _, task := range tasks.Items {
-		if task.DesiredState == swarmTypes.TaskStateRunning && task.Status.State == swarmTypes.TaskStateRunning {
+		// Swarm job tasks are desired to complete even while their status is running.
+		if task.Status.State == swarmTypes.TaskStateRunning {
 			return true
 		}
 	}

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/filesystem"
+	swarmTypes "github.com/moby/moby/api/types/swarm"
 	"github.com/moby/moby/client"
 	"go.yaml.in/yaml/v4"
 
@@ -297,6 +298,57 @@ func (h *Harness) OneOffContainerID(project, service string) string {
 	h.t.Helper()
 
 	return h.oneOffContainerID(h.docker, project, service)
+}
+
+// SwarmOneOffServiceID returns the single temporary Swarm one-off service for
+// a stack, or "" after doco-cd has completed its cleanup.
+func (h *Harness) SwarmOneOffServiceID(stack string) string {
+	h.t.Helper()
+
+	f := client.Filters{}.Add("label", "com.docker.stack.namespace="+stack)
+
+	services, err := h.docker.ServiceList(h.ctx, client.ServiceListOptions{Filters: f})
+	if err != nil {
+		h.t.Fatalf("list one-off services for %s: %v", stack, err)
+	}
+
+	var oneOffServices []swarmTypes.Service
+
+	for _, service := range services.Items {
+		if service.Spec.Labels[docker.DocoCDJobLabels.JobEphemeral] == "true" {
+			oneOffServices = append(oneOffServices, service)
+		}
+	}
+
+	if len(oneOffServices) == 0 {
+		return ""
+	}
+
+	if len(oneOffServices) != 1 {
+		h.t.Fatalf("found %d temporary one-off services for %s", len(oneOffServices), stack)
+	}
+
+	return oneOffServices[0].ID
+}
+
+// SwarmServiceHasRunningTask reports whether serviceID has a running task.
+func (h *Harness) SwarmServiceHasRunningTask(serviceID string) bool {
+	h.t.Helper()
+
+	tasks, err := h.docker.TaskList(h.ctx, client.TaskListOptions{
+		Filters: client.Filters{}.Add("service", serviceID),
+	})
+	if err != nil {
+		h.t.Fatalf("list tasks for service %s: %v", serviceID, err)
+	}
+
+	for _, task := range tasks.Items {
+		if task.DesiredState == swarmTypes.TaskStateRunning && task.Status.State == swarmTypes.TaskStateRunning {
+			return true
+		}
+	}
+
+	return false
 }
 
 // RemoteOneOffContainerID returns a retained one-off container from the

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -22,6 +22,8 @@ import (
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/moby/moby/client"
 	"go.yaml.in/yaml/v4"
+
+	"github.com/kimdre/doco-cd/internal/docker"
 )
 
 // initRepo creates the repo the gitserver container mounts read-only, plus a
@@ -234,6 +236,14 @@ func (h *Harness) ComposeContainerID(project, service string) string {
 	return h.containerID(h.docker, false, project, service)
 }
 
+// RemoteComposeContainerID returns a Compose container from the disposable
+// remote Docker context enabled with EnableRemoteContext.
+func (h *Harness) RemoteComposeContainerID(project, service string) string {
+	h.t.Helper()
+
+	return h.containerID(h.remoteDockerClient(), false, project, service)
+}
+
 // SwarmContainerID returns the running Swarm task container for a deployment.
 func (h *Harness) SwarmContainerID(project, service string) string {
 	h.t.Helper()
@@ -246,11 +256,7 @@ func (h *Harness) SwarmContainerID(project, service string) string {
 func (h *Harness) RemoteContainerID(project, service string) string {
 	h.t.Helper()
 
-	if h.remoteDocker == nil {
-		h.t.Fatal("remote Docker context is not enabled")
-	}
-
-	return h.containerID(h.remoteDocker, false, project, service)
+	return h.containerID(h.remoteDockerClient(), false, project, service)
 }
 
 func (h *Harness) ContainerImage(containerID string) string {
@@ -259,14 +265,85 @@ func (h *Harness) ContainerImage(containerID string) string {
 	return h.containerImage(h.docker, containerID)
 }
 
+// ContainerRunning reports whether containerID is currently running.
+func (h *Harness) ContainerRunning(containerID string) bool {
+	h.t.Helper()
+
+	return h.containerRunning(h.docker, containerID)
+}
+
+// RemoteContainerRunning reports whether containerID is running in the
+// disposable remote Docker context.
+func (h *Harness) RemoteContainerRunning(containerID string) bool {
+	h.t.Helper()
+
+	return h.containerRunning(h.remoteDockerClient(), containerID)
+}
+
+func (h *Harness) containerRunning(dockerClient *client.Client, containerID string) bool {
+	h.t.Helper()
+
+	inspect, err := dockerClient.ContainerInspect(h.ctx, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		h.t.Fatalf("inspect container %s: %v", shortContainerID(containerID), err)
+	}
+
+	return inspect.Container.State != nil && inspect.Container.State.Running
+}
+
+// OneOffContainerID returns the retained Compose one-off container for a
+// scheduled job, or "" after doco-cd has completed its cleanup.
+func (h *Harness) OneOffContainerID(project, service string) string {
+	h.t.Helper()
+
+	return h.oneOffContainerID(h.docker, project, service)
+}
+
+// RemoteOneOffContainerID returns a retained one-off container from the
+// disposable remote Docker context.
+func (h *Harness) RemoteOneOffContainerID(project, service string) string {
+	h.t.Helper()
+
+	return h.oneOffContainerID(h.remoteDockerClient(), project, service)
+}
+
+func (h *Harness) oneOffContainerID(dockerClient *client.Client, project, service string) string {
+	h.t.Helper()
+
+	f := client.Filters{}.
+		Add("label", "com.docker.compose.project="+project).
+		Add("label", "com.docker.compose.service="+service).
+		Add("label", docker.DocoCDJobLabels.JobEphemeral+"=true").
+		Add("label", docker.DocoCDJobLabels.JobRunID)
+
+	containers, err := dockerClient.ContainerList(h.ctx, client.ContainerListOptions{All: true, Filters: f})
+	if err != nil {
+		h.t.Fatalf("list one-off containers for %s/%s: %v", project, service, err)
+	}
+
+	if len(containers.Items) == 0 {
+		return ""
+	}
+
+	if len(containers.Items) != 1 {
+		h.t.Fatalf("found %d retained one-off containers for %s/%s", len(containers.Items), project, service)
+	}
+
+	return containers.Items[0].ID
+}
+
 func (h *Harness) RemoteContainerImage(containerID string) string {
 	h.t.Helper()
 
+	return h.containerImage(h.remoteDockerClient(), containerID)
+}
+
+func (h *Harness) remoteDockerClient() *client.Client {
 	if h.remoteDocker == nil {
 		h.t.Fatal("remote Docker context is not enabled")
 	}
 
-	return h.containerImage(h.remoteDocker, containerID)
+	return h.remoteDocker
 }
 
 func (h *Harness) containerImage(dockerClient *client.Client, containerID string) string {

--- a/test/e2e/scenarios/scheduled-one-off-recovery/fixture/.doco-cd.yml
+++ b/test/e2e/scenarios/scheduled-one-off-recovery/fixture/.doco-cd.yml
@@ -1,0 +1,7 @@
+name: e2e-scheduled-one-off-recovery
+working_dir: deploy
+compose_files: [compose.yaml]
+context: remote
+swarm:
+  enabled: false
+reconciliation: false

--- a/test/e2e/scenarios/scheduled-one-off-recovery/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/scheduled-one-off-recovery/fixture/deploy/compose.yaml
@@ -1,0 +1,16 @@
+services:
+  app:
+    image: alpine:3.22
+    command: ["sh", "-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+
+  backup:
+    image: alpine:3.22
+    command: ["sleep", "30"]
+    restart: "no"
+    labels:
+      cd.doco.job.enabled: "true"
+      cd.doco.job.schedule: "@every 10s"
+      cd.doco.job.execution_mode: "one_off"
+      cd.doco.job.skip_running: "true"
+      cd.doco.job.notify_on: "none"
+      cd.doco.job.stop_services: "app"

--- a/test/e2e/scenarios/scheduled-one-off-swarm-recovery/fixture/.doco-cd.yml
+++ b/test/e2e/scenarios/scheduled-one-off-swarm-recovery/fixture/.doco-cd.yml
@@ -1,0 +1,6 @@
+name: e2e-scheduled-one-off-swarm-recovery
+working_dir: deploy
+compose_files: [compose.yaml]
+swarm:
+  enabled: true
+reconciliation: false

--- a/test/e2e/scenarios/scheduled-one-off-swarm-recovery/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/scheduled-one-off-swarm-recovery/fixture/deploy/compose.yaml
@@ -1,0 +1,15 @@
+services:
+  app:
+    image: alpine:3.22
+    command: ["sh", "-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+
+  backup:
+    image: alpine:3.22
+    command: ["sleep", "30"]
+    labels:
+      cd.doco.job.enabled: "true"
+      cd.doco.job.schedule: "@every 10s"
+      cd.doco.job.execution_mode: "one_off"
+      cd.doco.job.skip_running: "true"
+      cd.doco.job.notify_on: "none"
+      cd.doco.job.stop_services: "app"

--- a/test/e2e/scenarios/scheduled-one-off/fixture/.doco-cd.yml
+++ b/test/e2e/scenarios/scheduled-one-off/fixture/.doco-cd.yml
@@ -1,0 +1,7 @@
+name: e2e-scheduled-one-off
+working_dir: deploy
+compose_files: [compose.yaml]
+context: remote
+swarm:
+  enabled: false
+reconciliation: false

--- a/test/e2e/scenarios/scheduled-one-off/fixture/deploy/compose.yaml
+++ b/test/e2e/scenarios/scheduled-one-off/fixture/deploy/compose.yaml
@@ -1,0 +1,16 @@
+services:
+  app:
+    image: alpine:3.22
+    command: ["sh", "-c", "trap 'exit 0' TERM; while :; do sleep 1; done"]
+
+  backup:
+    image: alpine:3.22
+    command: ["sleep", "30"]
+    restart: "no"
+    labels:
+      cd.doco.job.enabled: "true"
+      cd.doco.job.schedule: "@every 10s"
+      cd.doco.job.execution_mode: "one_off"
+      cd.doco.job.skip_running: "true"
+      cd.doco.job.notify_on: "none"
+      cd.doco.job.stop_services: "app"

--- a/test/e2e/scheduled_one_off_test.go
+++ b/test/e2e/scheduled_one_off_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	scheduledOneOffStack         = "e2e-scheduled-one-off"
-	scheduledOneOffRecoveryStack = "e2e-scheduled-one-off-recovery"
-	scheduledOneOffJobService    = "backup"
-	scheduledOneOffAppService    = "app"
+	scheduledOneOffStack              = "e2e-scheduled-one-off"
+	scheduledOneOffRecoveryStack      = "e2e-scheduled-one-off-recovery"
+	scheduledOneOffSwarmRecoveryStack = "e2e-scheduled-one-off-swarm-recovery"
+	scheduledOneOffJobService         = "backup"
+	scheduledOneOffAppService         = "app"
 )
 
 func TestScheduledOneOff(t *testing.T) {
@@ -75,6 +76,43 @@ func TestScheduledOneOff_RecoversAfterForcedDaemonTermination(t *testing.T) {
 	})
 }
 
+func TestScheduledOneOff_SwarmRecoversAfterForcedDaemonTermination(t *testing.T) {
+	t.Parallel()
+
+	h := NewHarness(t, "scheduled-one-off-swarm-recovery")
+	if !h.isSwarmMode() {
+		t.Skip("scheduled one-off Swarm recovery requires a Swarm manager")
+	}
+
+	h.SetPollInterval(time.Minute)
+	h.Start()
+
+	h.WaitFor(2*time.Minute, "initial Swarm dependency service", func() bool {
+		return h.SwarmContainerID(scheduledOneOffSwarmRecoveryStack, scheduledOneOffAppService) != ""
+	})
+
+	oneOffID := waitForRunningSwarmScheduledOneOff(t, h, scheduledOneOffSwarmRecoveryStack)
+
+	h.WaitFor(30*time.Second, "Swarm dependency stopped before daemon termination", func() bool {
+		return h.SwarmContainerID(scheduledOneOffSwarmRecoveryStack, scheduledOneOffAppService) == ""
+	})
+
+	h.KillAndRestartDaemon()
+
+	h.WaitFor(30*time.Second, "replacement daemon reuses running Swarm one-off service", func() bool {
+		return h.SwarmOneOffServiceID(scheduledOneOffSwarmRecoveryStack) == oneOffID &&
+			h.SwarmServiceHasRunningTask(oneOffID)
+	})
+
+	h.WaitFor(2*time.Minute, "recovered Swarm one-off service cleanup", func() bool {
+		return h.SwarmOneOffServiceID(scheduledOneOffSwarmRecoveryStack) == ""
+	})
+
+	h.WaitFor(30*time.Second, "Swarm dependency restored by recovered one-off job", func() bool {
+		return h.SwarmContainerID(scheduledOneOffSwarmRecoveryStack, scheduledOneOffAppService) != ""
+	})
+}
+
 func waitForRunningScheduledOneOff(t *testing.T, h *Harness, stack string) string {
 	t.Helper()
 
@@ -83,6 +121,19 @@ func waitForRunningScheduledOneOff(t *testing.T, h *Harness, stack string) strin
 	h.WaitFor(2*time.Minute, "running scheduled one-off job", func() bool {
 		oneOffID = h.RemoteOneOffContainerID(stack, scheduledOneOffJobService)
 		return oneOffID != "" && h.RemoteContainerRunning(oneOffID)
+	})
+
+	return oneOffID
+}
+
+func waitForRunningSwarmScheduledOneOff(t *testing.T, h *Harness, stack string) string {
+	t.Helper()
+
+	var oneOffID string
+
+	h.WaitFor(2*time.Minute, "running scheduled Swarm one-off job", func() bool {
+		oneOffID = h.SwarmOneOffServiceID(stack)
+		return oneOffID != "" && h.SwarmServiceHasRunningTask(oneOffID)
 	})
 
 	return oneOffID

--- a/test/e2e/scheduled_one_off_test.go
+++ b/test/e2e/scheduled_one_off_test.go
@@ -77,8 +77,8 @@ func TestScheduledOneOff_RecoversAfterForcedDaemonTermination(t *testing.T) {
 }
 
 func TestScheduledOneOff_SwarmRecoversAfterForcedDaemonTermination(t *testing.T) {
-	t.Parallel()
-
+	// Scheduled-job discovery spans the shared Swarm cluster, so this test must
+	// not run alongside other E2E scenarios that create scheduled services.
 	h := NewHarness(t, "scheduled-one-off-swarm-recovery")
 	if !h.isSwarmMode() {
 		t.Skip("scheduled one-off Swarm recovery requires a Swarm manager")

--- a/test/e2e/scheduled_one_off_test.go
+++ b/test/e2e/scheduled_one_off_test.go
@@ -1,0 +1,89 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+	"time"
+)
+
+const (
+	scheduledOneOffStack         = "e2e-scheduled-one-off"
+	scheduledOneOffRecoveryStack = "e2e-scheduled-one-off-recovery"
+	scheduledOneOffJobService    = "backup"
+	scheduledOneOffAppService    = "app"
+)
+
+func TestScheduledOneOff(t *testing.T) {
+	t.Parallel()
+
+	h := NewHarness(t, "scheduled-one-off")
+	h.EnableRemoteContext()
+	h.SetPollInterval(time.Minute)
+	h.Start()
+
+	h.WaitFor(2*time.Minute, "initial dependency container", func() bool {
+		return h.RemoteComposeContainerID(scheduledOneOffStack, scheduledOneOffAppService) != ""
+	})
+
+	waitForRunningScheduledOneOff(t, h, scheduledOneOffStack)
+
+	h.WaitFor(30*time.Second, "dependency stopped while one-off job runs", func() bool {
+		return h.RemoteComposeContainerID(scheduledOneOffStack, scheduledOneOffAppService) == ""
+	})
+
+	h.WaitFor(2*time.Minute, "one-off job artifact cleanup", func() bool {
+		return h.RemoteOneOffContainerID(scheduledOneOffStack, scheduledOneOffJobService) == ""
+	})
+
+	h.WaitFor(30*time.Second, "dependency restored after one-off job", func() bool {
+		return h.RemoteComposeContainerID(scheduledOneOffStack, scheduledOneOffAppService) != ""
+	})
+}
+
+func TestScheduledOneOff_RecoversAfterForcedDaemonTermination(t *testing.T) {
+	t.Parallel()
+
+	h := NewHarness(t, "scheduled-one-off-recovery")
+	h.EnableRemoteContext()
+	h.SetPollInterval(time.Minute)
+	h.Start()
+
+	h.WaitFor(2*time.Minute, "initial dependency container", func() bool {
+		return h.RemoteComposeContainerID(scheduledOneOffRecoveryStack, scheduledOneOffAppService) != ""
+	})
+
+	oneOffID := waitForRunningScheduledOneOff(t, h, scheduledOneOffRecoveryStack)
+
+	h.WaitFor(30*time.Second, "dependency stopped before daemon termination", func() bool {
+		return h.RemoteComposeContainerID(scheduledOneOffRecoveryStack, scheduledOneOffAppService) == ""
+	})
+
+	h.KillAndRestartDaemon()
+
+	h.WaitFor(30*time.Second, "replacement daemon retains running one-off job", func() bool {
+		return h.RemoteOneOffContainerID(scheduledOneOffRecoveryStack, scheduledOneOffJobService) == oneOffID &&
+			h.RemoteContainerRunning(oneOffID)
+	})
+
+	h.WaitFor(2*time.Minute, "recovered one-off job artifact cleanup", func() bool {
+		return h.RemoteOneOffContainerID(scheduledOneOffRecoveryStack, scheduledOneOffJobService) == ""
+	})
+
+	h.WaitFor(30*time.Second, "dependency restored by recovered one-off job", func() bool {
+		return h.RemoteComposeContainerID(scheduledOneOffRecoveryStack, scheduledOneOffAppService) != ""
+	})
+}
+
+func waitForRunningScheduledOneOff(t *testing.T, h *Harness, stack string) string {
+	t.Helper()
+
+	var oneOffID string
+
+	h.WaitFor(2*time.Minute, "running scheduled one-off job", func() bool {
+		oneOffID = h.RemoteOneOffContainerID(stack, scheduledOneOffJobService)
+		return oneOffID != "" && h.RemoteContainerRunning(oneOffID)
+	})
+
+	return oneOffID
+}

--- a/wiki/docs/Advanced/Docker-API-Permissions.md
+++ b/wiki/docs/Advanced/Docker-API-Permissions.md
@@ -100,7 +100,7 @@ These endpoints are only needed when the corresponding setting is enabled.
 #### `SCHEDULER_ENABLED` endpoint details
 
 - Default (`execution_mode: restart`): `POST /containers/{id}/restart`; Swarm: `GET /services/{id}`, `POST /services/{id}/update`
-- `execution_mode: one_off`: `POST /containers/create`, `POST /containers/{id}/wait`, `POST /containers/{id}/start`; Swarm: `POST /services/create`, `DELETE /services/{id}`, `GET /tasks`
+- `execution_mode: one_off`: `GET /containers/json`, `GET /containers/{id}/json`, `POST /containers/create`, `POST /containers/{id}/wait`, `POST /containers/{id}/start`, `DELETE /containers/{id}`; Swarm: `GET /services`, `GET /services/{id}`, `POST /services/create`, `DELETE /services/{id}`, `GET /tasks`
 - `stop_services`: `POST /containers/{id}/stop|start`; Swarm: `POST /services/{id}/update`, `GET /tasks`
 
 #### REST API endpoint details

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -115,13 +115,26 @@ and then re-/started at the scheduled time without being removed after completio
 
 ### `one_off`
 
-Alternatively, you can configure scheduled jobs to run in `one_off` mode, which means a new ephemeral container will 
-be created for each scheduled run and removed after completion.
+Alternatively, you can configure scheduled jobs to run in `one_off` mode, which means a new ephemeral container will
+be created for each scheduled run and removed after completion and reporting.
 
 !!! note
-    You won't be able to see the container or its logs after the job has completed, 
+    You won't be able to see the container or its logs after the job has completed,
     so make sure to configure appropriate logging (e.g., log to a persistent file or logging service like [Loki](https://grafana.com/docs/loki/latest/)) 
     if you need to keep track of job runs and [notifications](Notifications.md) if needed.
+
+??? info "Recovery after forced termination"
+    For `one_off` jobs, doco-cd labels the temporary container or Swarm service with the execution identity
+    and retains it until its result has been reported, and it has been cleaned up. 
+    It writes only the small finalization record needed to restore `stop_services` and avoid duplicate reporting to `DATA_MOUNT_PATH`.
+    If doco-cd is forcibly terminated and recreated with the same data mount, the replacement adopts the labeled execution, 
+    waits for it, restores dependencies, reports the result, and removes the artifact.
+
+
+    !!! note "Duplicate notifications"
+        This does not apply to `restart` mode. Notification delivery is best-effort at-least-once: a termination
+        after a notification is sent but before it is recorded can result in a duplicate notification. Keep a
+        single scheduler-enabled doco-cd instance per Docker host/context.
 
 ??? info "`one_off` behavior in Docker Swarm"
 

--- a/wiki/docs/Advanced/Job-Scheduling.md
+++ b/wiki/docs/Advanced/Job-Scheduling.md
@@ -162,20 +162,22 @@ be created for each scheduled run and removed after completion.
 
 Use the following service labels to configure scheduled jobs:
 
-| Label                           | Type    | Description                                                                                                                                                                                 | Default   |
-|---------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
-| `cd.doco.job.enabled`           | boolean | Enable scheduling for this service/container                                                                                                                                                | `false`   |
-| `cd.doco.job.schedule`          | string  | [Schedule format](#schedule-formats) to use                                                                                                                                                 |           |
-| `cd.doco.job.wait_running_jobs` | boolean | Override deploy-config-wide [`wait_running_jobs`](../Deploy-Settings.md#wait-for-running-scheduled-jobs-before-deployment) behavior for this job service during deployments                 | (inherit) |
-| `cd.doco.job.execution_mode`    | string  | [`restart`](#restart) (default behavior) or [`one_off`](#one_off) (ephemeral execution)                                                                                                     | `restart` |
-| `cd.doco.job.skip_running`      | boolean | Do not run the job if a previous scheduled run is still active/running                                                                                                                      | `false`   |
-| `cd.doco.job.notify_on`         | string  | [Notification](Notifications.md) behavior for scheduled runs: `none`, `success`, `failure`, `all`                                                                                           | `all`     |
-| `cd.doco.job.swarm.replicas`    | integer | Number of completions/concurrency for swarm one-off jobs in `replicated` [deploy mode](#swarm-deploymode)                                                                                   | `1`       |
+| Label                           | Type    | Description                                                                                                                                                                                       | Default   |
+|---------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| `cd.doco.job.enabled`           | boolean | Enable scheduling for this service/container                                                                                                                                                      | `false`   |
+| `cd.doco.job.schedule`          | string  | [Schedule format](#schedule-formats) to use                                                                                                                                                       |           |
+| `cd.doco.job.wait_running_jobs` | boolean | Override deploy-config-wide [`wait_running_jobs`](../Deploy-Settings.md#wait-for-running-scheduled-jobs-before-deployment) behavior for this job service during deployments                       | (inherit) |
+| `cd.doco.job.execution_mode`    | string  | [`restart`](#restart) (default behavior) or [`one_off`](#one_off) (ephemeral execution)                                                                                                           | `restart` |
+| `cd.doco.job.skip_running`      | boolean | Do not run the job if a previous scheduled run is still active/running                                                                                                                            | `false`   |
+| `cd.doco.job.notify_on`         | string  | [Notification](Notifications.md) behavior for scheduled runs: `none`, `success`, `failure`, `all`                                                                                                 | `all`     |
+| `cd.doco.job.swarm.replicas`    | integer | Number of completions/concurrency for swarm one-off jobs in `replicated` [deploy mode](#swarm-deploymode)                                                                                         | `1`       |
 | `cd.doco.job.stop_services`     | string  | Comma-separated services to [temporarily stop during a job run](#temporarily-stop-services-during-a-job-run) (supports `service` and `project/service`; Swarm requires `execution_mode: one_off`) |           |
 
 !!! note "Using scheduled jobs with multiple doco-cd instances"
-    `cd.doco.job.skip_running` only prevents overlapping runs within the same doco-cd process.
-    It does not coordinate scheduled runs across multiple doco-cd instances that share the same Docker host.
+    `cd.doco.job.skip_running` prevents overlapping runs within the same doco-cd process. For Swarm
+    `one_off` jobs, it also recognizes an active temporary execution left by a restarted process.
+    It does not coordinate simultaneously triggered runs across multiple doco-cd instances that share
+    the same Docker host.
 
     For multi-instance setups, prefer a single scheduler owner by disabling the scheduler on the other instances with [`SCHEDULER_ENABLED`](../App-Settings.md#:~:text=when%20not%20specified-,SCHEDULER_ENABLED,-boolean).
 


### PR DESCRIPTION
Swarm job waits now detect failed terminal tasks for the specific job iteration, so non-zero one-off exits return an error and release scheduler state, stack locks, and temporary services. Temporary Swarm clones are explicitly marked and attributed to their source, excluded from scheduling, and recognized by `skip_running` after restart.