### PR TITLE
feat: support inline deployments for webhooks

### DIFF
--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -226,6 +226,7 @@ func shouldUsePayloadSSHURL(overrideApplied bool, payloadSSHURL string, resolved
 	return strings.TrimSpace(payloadSSHURL) != "" && resolved.SSHPrivateKey != ""
 }
 
+// matchingInlineWebhookDeployments returns inline deployments whose poll source, reference, and target match the webhook.
 func matchingInlineWebhookDeployments(
 	appConfig *app.Config,
 	payload webhook.ParsedPayload,
@@ -265,6 +266,7 @@ func matchingInlineWebhookDeployments(
 	return deployments
 }
 
+// gitSourceIdentities returns stable repository identities for Git source URLs.
 func gitSourceIdentities(sourceURLs ...string) map[string]struct{} {
 	identities := make(map[string]struct{}, len(sourceURLs))
 
@@ -277,6 +279,7 @@ func gitSourceIdentities(sourceURLs ...string) map[string]struct{} {
 	return identities
 }
 
+// identitySetsOverlap reports whether two repository identity sets intersect.
 func identitySetsOverlap(left, right map[string]struct{}) bool {
 	for identity := range left {
 		if _, ok := right[identity]; ok {
@@ -287,10 +290,12 @@ func identitySetsOverlap(left, right map[string]struct{}) bool {
 	return false
 }
 
+// referencesMatch reports whether configured and webhook references identify the same branch or tag.
 func referencesMatch(configured, webhookRef string) bool {
 	return canonicalWebhookReference(configured) == canonicalWebhookReference(webhookRef)
 }
 
+// canonicalWebhookReference normalizes a ref while retaining its branch, tag, or other-ref type.
 func canonicalWebhookReference(reference string) string {
 	reference = strings.TrimSpace(reference)
 

--- a/cmd/doco-cd/handler_webhook.go
+++ b/cmd/doco-cd/handler_webhook.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kimdre/doco-cd/internal/commitstatus"
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
+	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/config/poll"
 	"github.com/kimdre/doco-cd/internal/controlplane"
 	"github.com/kimdre/doco-cd/internal/docker"
@@ -223,6 +224,86 @@ func shouldUsePayloadSSHURL(overrideApplied bool, payloadSSHURL string, resolved
 	}
 
 	return strings.TrimSpace(payloadSSHURL) != "" && resolved.SSHPrivateKey != ""
+}
+
+func matchingInlineWebhookDeployments(
+	appConfig *app.Config,
+	payload webhook.ParsedPayload,
+	sourceRef string,
+	customTarget string,
+) []*deploy.Config {
+	if appConfig == nil {
+		return nil
+	}
+
+	webhookIdentities := gitSourceIdentities(payload.CloneURL, sourceRef)
+	if len(webhookIdentities) == 0 {
+		return nil
+	}
+
+	customTarget = strings.TrimSpace(customTarget)
+
+	var deployments []*deploy.Config
+
+	for i := range appConfig.PollConfig {
+		pollConfig := &appConfig.PollConfig[i]
+		if config.NormalizeSourceType(pollConfig.Source) != config.SourceTypeGit ||
+			len(pollConfig.Deployments) == 0 ||
+			strings.TrimSpace(pollConfig.CustomTarget) != customTarget ||
+			!referencesMatch(pollConfig.Reference, payload.Ref) {
+			continue
+		}
+
+		rewrittenSource, _ := rewriteSourceURL(pollConfig.SourceUrl, appConfig.SourceURLRewrites)
+		if !identitySetsOverlap(webhookIdentities, gitSourceIdentities(pollConfig.SourceUrl, rewrittenSource)) {
+			continue
+		}
+
+		deployments = append(deployments, pollConfig.Deployments...)
+	}
+
+	return deployments
+}
+
+func gitSourceIdentities(sourceURLs ...string) map[string]struct{} {
+	identities := make(map[string]struct{}, len(sourceURLs))
+
+	for _, sourceURL := range sourceURLs {
+		if identity := git.GetRepoName(config.NormalizeGitURL(sourceURL)); identity != "" && identity != "." {
+			identities[identity] = struct{}{}
+		}
+	}
+
+	return identities
+}
+
+func identitySetsOverlap(left, right map[string]struct{}) bool {
+	for identity := range left {
+		if _, ok := right[identity]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func referencesMatch(configured, webhookRef string) bool {
+	return canonicalWebhookReference(configured) == canonicalWebhookReference(webhookRef)
+}
+
+func canonicalWebhookReference(reference string) string {
+	reference = strings.TrimSpace(reference)
+
+	switch {
+	case strings.HasPrefix(reference, git.BranchPrefix):
+		return "branch:" + strings.TrimPrefix(reference, git.BranchPrefix)
+	case strings.HasPrefix(reference, git.TagPrefix):
+		return "tag:" + strings.TrimPrefix(reference, git.TagPrefix)
+	case strings.HasPrefix(reference, "refs/"):
+		return "ref:" + reference
+	default:
+		return "branch:" + reference
+	}
 }
 
 // repositoryNameFromWebhookPayload extracts the repository name from the webhook payload,
@@ -434,6 +515,7 @@ func handleEvent(ctx context.Context, jobLog *slog.Logger, w http.ResponseWriter
 		CustomTarget: customTarget,
 		TestName:     testName,
 		PollConfig:   poll.Config{},
+		Deployments:  matchingInlineWebhookDeployments(appConfig, payload, sourceRef, customTarget),
 		Payload:      payload,
 	})
 	if errors.Is(deployErr, stages.ErrSkipDeployment) {

--- a/cmd/doco-cd/handler_webhook_source_test.go
+++ b/cmd/doco-cd/handler_webhook_source_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/kimdre/doco-cd/internal/config/app"
+	"github.com/kimdre/doco-cd/internal/config/deploy"
+	"github.com/kimdre/doco-cd/internal/config/poll"
 	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/webhook"
 )
@@ -239,5 +241,148 @@ func TestShouldUsePayloadSSHURL(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tc.expected, usePayloadSSH)
 			}
 		})
+	}
+}
+
+func TestMatchingInlineWebhookDeployments(t *testing.T) {
+	t.Parallel()
+
+	deployment := func(name string) *deploy.Config {
+		return &deploy.Config{Name: name}
+	}
+
+	cfg := &app.Config{
+		SourceURLRewrites: map[string]string{
+			"https://forgejo.example.com/": "http://forgejo:3000/",
+		},
+		PollConfig: []poll.Config{
+			{
+				SourceUrl:   "git@forgejo.example.com:org/repo.git",
+				Reference:   "main",
+				Deployments: []*deploy.Config{deployment("first")},
+			},
+			{
+				SourceUrl:   "https://forgejo.example.com/org/repo.git",
+				Reference:   "refs/heads/main",
+				Deployments: []*deploy.Config{deployment("second")},
+			},
+			{
+				SourceUrl:    "https://forgejo.example.com/org/repo.git",
+				Reference:    "main",
+				CustomTarget: "production",
+				Deployments:  []*deploy.Config{deployment("wrong-target")},
+			},
+			{
+				SourceUrl:   "https://forgejo.example.com/org/repo.git",
+				Reference:   "develop",
+				Deployments: []*deploy.Config{deployment("wrong-ref")},
+			},
+			{
+				SourceUrl:   "https://forgejo.example.com/org/other.git",
+				Reference:   "main",
+				Deployments: []*deploy.Config{deployment("wrong-repo")},
+			},
+			{
+				Source:      "oci",
+				SourceUrl:   "forgejo.example.com/org/repo",
+				Reference:   "main",
+				Deployments: []*deploy.Config{deployment("wrong-source")},
+			},
+			{
+				SourceUrl: "https://forgejo.example.com/org/repo.git",
+				Reference: "main",
+			},
+		},
+	}
+
+	got := matchingInlineWebhookDeployments(cfg, webhook.ParsedPayload{
+		CloneURL: "https://forgejo.example.com/org/repo.git",
+		Ref:      "refs/heads/main",
+	}, "http://forgejo:3000/org/repo.git", "")
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 matching deployments, got %d", len(got))
+	}
+
+	if got[0].Name != "first" || got[1].Name != "second" {
+		t.Fatalf("unexpected deployment order: %q, %q", got[0].Name, got[1].Name)
+	}
+}
+
+func TestMatchingInlineWebhookDeploymentsMatchesRewrittenSource(t *testing.T) {
+	t.Parallel()
+
+	cfg := &app.Config{
+		SourceURLRewrites: map[string]string{
+			"https://public.example.com/": "http://git:3000/",
+		},
+		PollConfig: []poll.Config{{
+			SourceUrl:   "https://public.example.com/org/repo.git",
+			Reference:   "main",
+			Deployments: []*deploy.Config{{Name: "app"}},
+		}},
+	}
+
+	got := matchingInlineWebhookDeployments(cfg, webhook.ParsedPayload{
+		CloneURL: "https://different.example.com/org/repo.git",
+		Ref:      "refs/heads/main",
+	}, "http://git:3000/org/repo.git", "")
+
+	if len(got) != 1 || got[0].Name != "app" {
+		t.Fatalf("expected rewritten source identity to match, got %+v", got)
+	}
+}
+
+func TestMatchingInlineWebhookDeploymentsRequiresMatchingTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg := &app.Config{PollConfig: []poll.Config{{
+		SourceUrl:    "https://example.com/org/repo.git",
+		Reference:    "main",
+		CustomTarget: "production",
+		Deployments:  []*deploy.Config{{Name: "app"}},
+	}}}
+	payload := webhook.ParsedPayload{
+		CloneURL: "https://example.com/org/repo.git",
+		Ref:      "refs/heads/main",
+	}
+
+	if got := matchingInlineWebhookDeployments(cfg, payload, payload.CloneURL, ""); got != nil {
+		t.Fatalf("expected target mismatch not to match, got %+v", got)
+	}
+
+	if got := matchingInlineWebhookDeployments(cfg, payload, payload.CloneURL, " production "); len(got) != 1 {
+		t.Fatalf("expected trimmed target to match, got %+v", got)
+	}
+}
+
+func TestMatchingInlineWebhookDeploymentsIgnoresUnusedSSHURL(t *testing.T) {
+	t.Parallel()
+
+	cfg := &app.Config{PollConfig: []poll.Config{{
+		SourceUrl:   "git@example.com:org/configured.git",
+		Reference:   "main",
+		Deployments: []*deploy.Config{{Name: "configured"}},
+	}}}
+
+	got := matchingInlineWebhookDeployments(cfg, webhook.ParsedPayload{
+		CloneURL: "https://example.com/org/actual.git",
+		SSHUrl:   "git@example.com:org/configured.git",
+		Ref:      "refs/heads/main",
+	}, "https://example.com/org/actual.git", "")
+	if got != nil {
+		t.Fatalf("expected unused SSH URL not to influence matching, got %+v", got)
+	}
+}
+
+func TestReferencesMatchKeepsTagsDistinct(t *testing.T) {
+	t.Parallel()
+
+	if !referencesMatch("main", "refs/heads/main") {
+		t.Fatal("expected short branch and full branch ref to match")
+	}
+
+	if referencesMatch("v1.0.0", "refs/tags/v1.0.0") {
+		t.Fatal("expected short branch-like ref and tag ref to remain distinct")
 	}
 }

--- a/internal/config/deploy/deploy.go
+++ b/internal/config/deploy/deploy.go
@@ -606,16 +606,17 @@ func ValidateUniqueProjectNames(configs []*Config) error {
 	return nil
 }
 
-// ResolveConfigs returns Deployment Config's for a poll run, preferring inline
-// deployments defined on the PollConfig when provided. Inline deployments bypass
-// repository config file discovery. When no inline deployments are present,
-// repository config files are required.
+// ResolveConfigs returns deployment configs, preferring supplied inline
+// deployments. Inline deployments bypass repository config file discovery.
+// When no inline deployments are present, repository config files are required.
 // repoRoot is the absolute path to the repository root.
 // configBaseDir is the relative path from repo root where config files are located.
 // gitOpts is optional (may be nil) and is only required when AutoDiscovery with a remote RepositoryUrl is used.
 func ResolveConfigs(inlineDeployments []*Config, customTarget, reference, repoRoot, configBaseDir string, gitOpts *GitOptions) ([]*Config, error) {
 	// Prefer inline deployments when present
 	if len(inlineDeployments) > 0 {
+		inlineDeployments = cloneConfigSlice(inlineDeployments)
+
 		// Apply reference to inline deployments if not already set
 		for _, d := range inlineDeployments {
 			if d.Reference == "" {
@@ -630,6 +631,10 @@ func ResolveConfigs(inlineDeployments []*Config, customTarget, reference, repoRo
 
 		for _, cfg := range configs {
 			cfg.Internal.OciTrustPolicyOverrideTrusted = true
+		}
+
+		if err := ValidateUniqueProjectNames(configs); err != nil {
+			return nil, err
 		}
 
 		return configs, nil

--- a/internal/config/deploy/deploy_test.go
+++ b/internal/config/deploy/deploy_test.go
@@ -650,6 +650,45 @@ func TestCloneConfigSliceDeepCopiesMutableFields(t *testing.T) {
 	}
 }
 
+func TestResolveConfigsCopiesInlineDeployments(t *testing.T) {
+	t.Parallel()
+
+	inline := &Config{
+		Name:             "app",
+		WorkingDirectory: ".",
+		ComposeFiles:     []string{"compose.yaml"},
+	}
+
+	configs, err := ResolveConfigs([]*Config{inline}, "", "main", t.TempDir(), ".", nil)
+	if err != nil {
+		t.Fatalf("ResolveConfigs() error = %v", err)
+	}
+
+	if configs[0] == inline {
+		t.Fatal("expected ResolveConfigs to copy inline deployment")
+	}
+
+	if inline.Reference != "" {
+		t.Fatalf("expected input reference to remain unchanged, got %q", inline.Reference)
+	}
+
+	if configs[0].Reference != "main" {
+		t.Fatalf("expected resolved reference %q, got %q", "main", configs[0].Reference)
+	}
+}
+
+func TestResolveConfigsRejectsDuplicateInlineProjectNames(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveConfigs([]*Config{
+		{Name: "app", Context: "production"},
+		{Name: "app", Context: "production"},
+	}, "", "main", t.TempDir(), ".", nil)
+	if !errors.Is(err, ErrDuplicateProjectName) {
+		t.Fatalf("expected ErrDuplicateProjectName, got %v", err)
+	}
+}
+
 func TestResolveConfigs_InlineMissingName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/deploy.go
+++ b/internal/controlplane/deploy.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/common/validation"
 	"github.com/kimdre/doco-cd/internal/config"
+	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/config/poll"
 	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/notification"
@@ -73,7 +74,7 @@ func NewDeployment(dependencies DeploymentDependencies) (*Deployment, error) {
 // DeploymentRequest bundles Deployment.Deploy's per-call, per-deployment-request
 // input: the source location and its trigger/reference/visibility,
 // notification metadata, an optional custom deploy target, an optional test
-// identity, poll configuration (used only for poll-triggered requests), and
+// identity, poll configuration, optional centrally supplied deployments, and
 // the parsed webhook payload (zero value for non-webhook triggers).
 type DeploymentRequest struct {
 	Logger       *slog.Logger      `validate:"required,nostructlevel"`
@@ -86,6 +87,7 @@ type DeploymentRequest struct {
 	CustomTarget string
 	TestName     string
 	PollConfig   poll.Config
+	Deployments  []*deploy.Config
 	Payload      webhook.ParsedPayload
 }
 
@@ -193,6 +195,7 @@ func (d *Deployment) Deploy(ctx context.Context, req DeploymentRequest) error {
 		Private:        req.Private,
 		CustomTarget:   req.CustomTarget,
 		PollConfig:     req.PollConfig,
+		Deployments:    req.Deployments,
 		Payload:        req.Payload,
 		DataMountPoint: d.dataMountPoint,
 	})

--- a/internal/source/deployconfig.go
+++ b/internal/source/deployconfig.go
@@ -7,11 +7,9 @@ import (
 	"github.com/kimdre/doco-cd/internal/stages"
 )
 
-// resolveDeployConfigs resolves the deployment configuration(s) for req: for
-// webhook triggers it reads .doco-cd(.<target>).y(a)ml from internalRepoPath,
-// for poll triggers it resolves the (optionally inline) configured
-// deployments. ref is the reference used to select the branch/tag-scoped
-// deploy config file for webhook triggers (the webhook payload's ref).
+// resolveDeployConfigs resolves the deployment configuration(s) for req.
+// Webhooks prefer centrally supplied deployments and otherwise read
+// .doco-cd(.<target>).y(a)ml; polls resolve their optionally inline config.
 func (p *Preparer) resolveDeployConfigs(req Request, internalRepoPath, ref string) ([]*deploy.Config, error) {
 	gitOpts := &deploy.GitOptions{
 		SSHPrivateKey:           p.appConfig.SSHPrivateKey,
@@ -25,6 +23,15 @@ func (p *Preparer) resolveDeployConfigs(req Request, internalRepoPath, ref strin
 
 	switch req.JobTrigger {
 	case stages.JobTriggerWebhook:
+		if len(req.Deployments) > 0 {
+			deployConfigs, err := deploy.ResolveConfigs(req.Deployments, req.CustomTarget, req.Ref, internalRepoPath, p.appConfig.DeployConfigBaseDir, gitOpts)
+			if err != nil {
+				return nil, wrapPrepareError(ErrDeployConfig, err)
+			}
+
+			return deployConfigs, nil
+		}
+
 		deployConfigs, err := deploy.GetConfigs(internalRepoPath, p.appConfig.DeployConfigBaseDir, req.CustomTarget, ref, gitOpts)
 		if err != nil {
 			return nil, wrapPrepareError(ErrDeployConfig, err)

--- a/internal/source/request.go
+++ b/internal/source/request.go
@@ -6,6 +6,7 @@ import (
 	"github.com/moby/moby/api/types/container"
 
 	"github.com/kimdre/doco-cd/internal/config"
+	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/config/poll"
 	"github.com/kimdre/doco-cd/internal/stages"
 	"github.com/kimdre/doco-cd/internal/webhook"
@@ -13,7 +14,7 @@ import (
 
 // Request holds the per-call input for Preparer.Prepare: the source location
 // and its trigger/reference/visibility, an optional custom deploy target,
-// poll configuration (used only for poll-triggered requests), the parsed
+// poll configuration, optional centrally supplied deployments, the parsed
 // webhook payload (zero value for non-webhook triggers), and the data mount
 // point used to compute safe internal/external filesystem paths.
 type Request struct {
@@ -25,6 +26,7 @@ type Request struct {
 	Private        bool
 	CustomTarget   string
 	PollConfig     poll.Config
+	Deployments    []*deploy.Config
 	Payload        webhook.ParsedPayload
 	DataMountPoint container.MountPoint `validate:"required"`
 }

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kimdre/doco-cd/internal/config"
 	"github.com/kimdre/doco-cd/internal/config/app"
+	"github.com/kimdre/doco-cd/internal/config/deploy"
 	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/stages"
@@ -222,6 +223,48 @@ func TestPrepare_GitSuccess(t *testing.T) {
 
 	if result.PathInternal == "" || result.PathExternal == "" {
 		t.Fatal("expected internal/external paths to be set")
+	}
+}
+
+func TestPrepare_WebhookInlineDeploymentsOverrideRepositoryConfig(t *testing.T) {
+	t.Parallel()
+
+	srcPath, _ := createLocalGitFixture(t, map[string]string{
+		".doco-cd.yaml": `
+name: repository-config
+reference: main
+`,
+		"compose.yaml": "services: {}\n",
+	})
+
+	inline := &deploy.Config{
+		Name:             "inline-config",
+		Reference:        git.MainBranch,
+		WorkingDirectory: ".",
+		ComposeFiles:     []string{"compose.yaml"},
+	}
+	p := newTestPreparer(t, &app.Config{})
+
+	result, err := p.Prepare(t.Context(), Request{
+		Logger:         logger.New(logger.LevelCritical).Logger,
+		JobTrigger:     stages.JobTriggerWebhook,
+		SourceType:     config.SourceTypeGit,
+		SourceRef:      "file://" + srcPath,
+		Ref:            git.MainBranch,
+		Deployments:    []*deploy.Config{inline},
+		Payload:        webhook.ParsedPayload{Ref: git.MainBranch},
+		DataMountPoint: testMountPoint(t),
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	if len(result.DeployConfigs) != 1 || result.DeployConfigs[0].Name != "inline-config" {
+		t.Fatalf("expected inline config to override repository config, got %+v", result.DeployConfigs)
+	}
+
+	if result.DeployConfigs[0] == inline {
+		t.Fatal("expected inline deployment to be copied before resolution")
 	}
 }
 

--- a/wiki/docs/Endpoints/Webhook-Listener.md
+++ b/wiki/docs/Endpoints/Webhook-Listener.md
@@ -20,6 +20,15 @@ Set both `HTTP_TLS_CERT_FILE` and `HTTP_TLS_KEY_FILE` to serve the endpoint over
 By default, all incoming webhooks are accepted and trigger deployments if they match a deployment configuration.
 See [Webhook Filter](../Deploy-Settings.md#webhook-filter) for more granular control over which webhooks should trigger deployments.
 
+## Inline deployment configuration
+
+Git webhooks automatically reuse inline deployments from matching [`POLL_CONFIG`](../Poll-Settings.md#inline-deploy-configs) entries. Matching uses the repository, reference, and webhook target. Short branch names such as `main` match their full `refs/heads/main` form.
+
+If multiple poll entries match, their inline deployments are combined in configuration order. Deployment names must be unique within each Docker context.
+
+!!! warning "Inline configuration overrides repository configuration"
+    If a matching inline deployment exists, `.doco-cd.yml` in the repository is ignored. The inline and repository configurations are never merged. The webhook reads repository configuration files only when no inline poll entry matches.
+
 ## With custom Target
 
 You can specify multiple deployment target configurations in a mono-repo style setup using the application's dynamic webhook path.

--- a/wiki/docs/Poll-Settings.md
+++ b/wiki/docs/Poll-Settings.md
@@ -194,6 +194,13 @@ Inline deployments reuse the same fields as `.doco-cd.yml` files (See [Deploy Se
 
 If the poll config has an inline deployment config and the target repository also contains a `.doco-cd.yml` file, the file will be ignored in favor of the inline deployment config.
 
+Matching Git webhooks also reuse inline deployments. A poll entry matches a webhook when its repository, reference, and optional `target` match the webhook request. Short branch names such as `main` are equivalent to full branch references such as `refs/heads/main`.
+
+!!! warning "Inline configuration takes precedence"
+    When one or more inline poll entries match a webhook, their deployments are combined and the repository's `.doco-cd.yml` is ignored. Inline and repository configurations are never merged. Repository configuration discovery is used only when no inline poll entry matches.
+
+    Deployment names must remain unique within each Docker context across all matching inline entries.
+
 ```yaml title="Poll Config with inline deploy config"
 - url: https://github.com/example/app.git
   reference: refs/heads/main


### PR DESCRIPTION
- Reuse matching inline `POLL_CONFIG` deployments for Git webhooks.
- Match by repository, equivalent branch ref (for example `main` and `refs/heads/main`), and webhook target; combine all matching entries in configuration order.
- Make matching inline configuration take precedence over repository `.doco-cd.yml`; no configuration sources are merged, and repository discovery remains the fallback when no inline entry matches.
- Deep-copy shared inline templates for safe concurrent execution and reject duplicate deployment names within a Docker context.
- Document the behavior in Poll Settings and Webhook Listener.