### PR TITLE
fix(encryption): keep decrypted files from every bind-mounted directory

### DIFF
--- a/internal/docker/compose_load.go
+++ b/internal/docker/compose_load.go
@@ -238,7 +238,7 @@ func DecryptProjectFiles(repoPath string, p *types.Project) ([]string, error) {
 				}
 
 				if info.IsDir() {
-					decryptedFiles, err = encryption.DecryptFilesInDirectory(repoPath, v.Source)
+					files, err := encryption.DecryptFilesInDirectory(repoPath, v.Source)
 					if err != nil {
 						if errors.Is(err, filesystem.ErrPathTraversal) {
 							continue
@@ -246,6 +246,8 @@ func DecryptProjectFiles(repoPath string, p *types.Project) ([]string, error) {
 
 						return decryptedFiles, fmt.Errorf("failed to decrypt files in bind mount directory '%s': %w", v.Source, err)
 					}
+
+					decryptedFiles = append(decryptedFiles, files...)
 
 					continue
 				}

--- a/internal/docker/compose_test.go
+++ b/internal/docker/compose_test.go
@@ -2705,6 +2705,47 @@ func TestDecryptProjectFiles(t *testing.T) {
 			},
 			expectedDecryptedFileBasenames: []string{},
 		},
+		{
+			name: "bind-mounted directory without encrypted files does not discard earlier results",
+			buildProject: func(t *testing.T, tmpDir string) *types.Project {
+				t.Helper()
+
+				secretsDir := filepath.Join(tmpDir, "secrets")
+				if err := os.Mkdir(secretsDir, filesystem.PermDir); err != nil {
+					t.Fatalf("failed to create %s: %v", secretsDir, err)
+				}
+
+				envFile := filepath.Join(secretsDir, "app.env")
+				copyFile(t, encryptedEnvSrc, envFile)
+
+				staticDir := filepath.Join(tmpDir, "static")
+				if err := os.Mkdir(staticDir, filesystem.PermDir); err != nil {
+					t.Fatalf("failed to create %s: %v", staticDir, err)
+				}
+
+				// #nosec G703 -- path is constructed from t.TempDir(), not user input
+				if err := os.WriteFile(filepath.Join(staticDir, "index.html"), []byte("<html></html>"), filesystem.PermOwner); err != nil {
+					t.Fatalf("failed to write plain file: %v", err)
+				}
+
+				return &types.Project{
+					WorkingDir: tmpDir,
+					Services: types.Services{
+						"svc1": {
+							Name:     "svc1",
+							EnvFiles: []types.EnvFile{{Path: envFile}},
+							// The directory with the encrypted file is walked first, the
+							// directory without encrypted files second.
+							Volumes: []types.ServiceVolumeConfig{
+								{Type: "bind", Source: secretsDir, Target: "/run/secrets"},
+								{Type: "bind", Source: staticDir, Target: "/srv"},
+							},
+						},
+					},
+				}
+			},
+			expectedDecryptedFileBasenames: []string{"app.env"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #1836

## Problem

`DecryptProjectFiles` assigns the result of each bind-mounted directory walk to `decryptedFiles` instead of appending to it:

```go
if info.IsDir() {
    decryptedFiles, err = encryption.DecryptFilesInDirectory(repoPath, v.Source)
    ...
    continue
}
```

When a directory without encrypted files (e.g. ./html) is walked after the directory that contains the encrypted env file (e.g. ./.config), the list becomes empty. The env file itself has already been decrypted by the earlier walk, so the final `DecryptFileInPlace` loop adds nothing either. `projectFilesDecrypted` ends up false, `LoadCompose` does not reload the project, and the environment resolved during the first `LoadProject` (read from the still-encrypted `env_file`) is deployed. Containers then receive values such as `POSTGRES_USER=ENC[AES256_GCM,...]`.

Because `p.Services` is a map, the walk order is random and the bug is intermittent. It shows up on the first deployment of a repository and after every commit that changes the encrypted file, i.e. whenever the file on disk was replaced by the git sync.

## Change

- Append the result of each directory walk to `decryptedFiles` instead of overwriting it.

## Test

- Added a case to `TestDecryptProjectFiles`: one service with a bind-mounted directory containing an encrypted env file followed by a bind-mounted directory without encrypted files (volumes are a slice, so the order is deterministic), and the same file referenced via `env_file`. The case fails on main (expected 1 decrypted file(s), got 0) and passes with this change.
