### PR TITLE
feat(notification): filter commit changelog by files of the stack

### DIFF
--- a/internal/docker/compose_load.go
+++ b/internal/docker/compose_load.go
@@ -16,7 +16,6 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/docker/cli/cli/command"
 
-	"github.com/kimdre/doco-cd/internal/common/types/slice"
 	"github.com/kimdre/doco-cd/internal/encryption"
 	"github.com/kimdre/doco-cd/internal/filesystem"
 )
@@ -204,97 +203,36 @@ func CheckDefaultComposeFiles(composeFiles []string, workingDir string) ([]strin
 // Since absolute file paths in types.Project are paths on the docker host, repoPath also needs to be the external path to the repository.
 // We use the symlink inside the container to follow the external path to the correct internal path.
 func DecryptProjectFiles(repoPath string, p *types.Project) ([]string, error) {
-	var (
-		projectFiles   []string
-		decryptedFiles []string
-	)
+	var decryptedFiles []string
 
-	for _, s := range p.Services {
-		for _, cfg := range s.Configs {
-			if cfg.Source != "" {
-				if cfgConfig, ok := p.Configs[cfg.Source]; ok && cfgConfig.File != "" {
-					projectFiles = append(projectFiles, cfgConfig.File)
-				}
-			}
-		}
+	projectFiles, err := serviceFiles(p)
+	if err != nil {
+		return decryptedFiles, err
+	}
 
-		for _, secret := range s.Secrets {
-			if secret.Source != "" {
-				if secretConfig, ok := p.Secrets[secret.Source]; ok && secretConfig.File != "" {
-					projectFiles = append(projectFiles, secretConfig.File)
-				}
-			}
-		}
-
-		for _, v := range s.Volumes {
-			if v.Type == "bind" && v.Source != "" {
-				info, err := os.Stat(v.Source)
-				if err != nil {
-					if errors.Is(err, os.ErrNotExist) {
-						continue
-					}
-
-					return decryptedFiles, fmt.Errorf("failed to stat bind mount source '%s': %w", v.Source, err)
-				}
-
-				if info.IsDir() {
-					files, err := encryption.DecryptFilesInDirectory(repoPath, v.Source)
-					if err != nil {
-						if errors.Is(err, filesystem.ErrPathTraversal) {
-							continue
-						}
-
-						return decryptedFiles, fmt.Errorf("failed to decrypt files in bind mount directory '%s': %w", v.Source, err)
-					}
-
-					decryptedFiles = append(decryptedFiles, files...)
-
+	for _, f := range projectFiles {
+		if f.IsDir {
+			files, err := encryption.DecryptFilesInDirectory(repoPath, f.Path)
+			if err != nil {
+				if errors.Is(err, filesystem.ErrPathTraversal) {
 					continue
 				}
 
-				projectFiles = append(projectFiles, v.Source)
-			}
-		}
-
-		for _, envFile := range s.EnvFiles {
-			if envFile.Path != "" {
-				projectFiles = append(projectFiles, envFile.Path)
-			}
-		}
-
-		if s.Build != nil {
-			if s.Build.Dockerfile != "" {
-				if filepath.IsAbs(s.Build.Dockerfile) {
-					projectFiles = append(projectFiles, s.Build.Dockerfile)
-				} else {
-					projectFiles = append(projectFiles, filepath.Join(s.Build.Context, s.Build.Dockerfile))
-				}
+				return decryptedFiles, fmt.Errorf("failed to decrypt files in bind mount directory '%s': %w", f.Path, err)
 			}
 
-			for _, secret := range s.Build.Secrets {
-				if secret.Source != "" {
-					if filepath.IsAbs(secret.Source) {
-						projectFiles = append(projectFiles, secret.Source)
-					} else {
-						projectFiles = append(projectFiles, filepath.Join(s.Build.Context, secret.Source))
-					}
-				}
-			}
-		}
-	}
+			decryptedFiles = append(decryptedFiles, files...)
 
-	for _, f := range slice.Unique(projectFiles) {
-		if !filepath.IsAbs(f) {
-			f = filepath.Join(p.WorkingDir, f)
+			continue
 		}
 
-		decrypted, err := encryption.DecryptFileInPlace(f)
+		decrypted, err := encryption.DecryptFileInPlace(f.Path)
 		if err != nil {
-			return decryptedFiles, fmt.Errorf("failed to decrypt project file '%s': %w", f, err)
+			return decryptedFiles, fmt.Errorf("failed to decrypt project file '%s': %w", f.Path, err)
 		}
 
 		if decrypted {
-			decryptedFiles = append(decryptedFiles, f)
+			decryptedFiles = append(decryptedFiles, f.Path)
 		}
 	}
 

--- a/internal/docker/project_files.go
+++ b/internal/docker/project_files.go
@@ -1,0 +1,261 @@
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/compose-spec/compose-go/v2/types"
+
+	"github.com/kimdre/doco-cd/internal/common/types/set"
+	"github.com/kimdre/doco-cd/internal/filesystem"
+)
+
+// projectFile is a single path of the file set a compose project resolves to.
+// Paths are absolute and on the docker host, like the paths in types.Project.
+type projectFile struct {
+	Path string
+	// IsDir marks a directory whose whole content belongs to the project,
+	// e.g. a bind mounted directory or a build context.
+	IsDir bool
+}
+
+// projectFileSet collects projectFiles without duplicates.
+type projectFileSet struct {
+	index map[string]int
+	files []projectFile
+}
+
+func newProjectFileSet() *projectFileSet {
+	return &projectFileSet{index: make(map[string]int)}
+}
+
+// absProjectPath resolves path against the working directory of the project if it is relative.
+func absProjectPath(p *types.Project, path string) string {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(p.WorkingDir, path)
+	}
+
+	return filepath.Clean(path)
+}
+
+// add resolves path against the working directory of the project if it is relative
+// and adds it to the set.
+func (s *projectFileSet) add(p *types.Project, path string, isDir bool) {
+	if path == "" {
+		return
+	}
+
+	path = absProjectPath(p, path)
+
+	if i, ok := s.index[path]; ok {
+		// A path used as file and as directory is a directory.
+		s.files[i].IsDir = s.files[i].IsDir || isDir
+
+		return
+	}
+
+	s.index[path] = len(s.files)
+	s.files = append(s.files, projectFile{Path: path, IsDir: isDir})
+}
+
+// list returns the collected files sorted by path.
+func (s *projectFileSet) list() []projectFile {
+	slices.SortFunc(s.files, func(a, b projectFile) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+
+	return s.files
+}
+
+// serviceFiles resolves the files the services of a compose project read at deploy time:
+// configs, secrets, bind mount sources, env files, dockerfiles and build secrets.
+// Bind mount sources are the only entries that can be a directory.
+//
+// DecryptProjectFiles and resolvedProjectFiles both build on this, so the file set they
+// work on cannot drift apart.
+func serviceFiles(p *types.Project) ([]projectFile, error) {
+	files := newProjectFileSet()
+
+	for _, s := range p.Services {
+		for _, cfg := range s.Configs {
+			if cfg.Source != "" {
+				if cfgConfig, ok := p.Configs[cfg.Source]; ok && cfgConfig.File != "" {
+					files.add(p, cfgConfig.File, false)
+				}
+			}
+		}
+
+		for _, secret := range s.Secrets {
+			if secret.Source != "" {
+				if secretConfig, ok := p.Secrets[secret.Source]; ok && secretConfig.File != "" {
+					files.add(p, secretConfig.File, false)
+				}
+			}
+		}
+
+		for _, v := range s.Volumes {
+			if v.Type != "bind" || v.Source == "" {
+				continue
+			}
+
+			source := absProjectPath(p, v.Source)
+
+			info, err := os.Stat(source)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+
+				return nil, fmt.Errorf("failed to stat bind mount source '%s': %w", v.Source, err)
+			}
+
+			files.add(p, source, info.IsDir())
+		}
+
+		for _, envFile := range s.EnvFiles {
+			files.add(p, envFile.Path, false)
+		}
+
+		if s.Build == nil {
+			continue
+		}
+
+		if s.Build.Dockerfile != "" {
+			if filepath.IsAbs(s.Build.Dockerfile) {
+				files.add(p, s.Build.Dockerfile, false)
+			} else {
+				files.add(p, filepath.Join(s.Build.Context, s.Build.Dockerfile), false)
+			}
+		}
+
+		for _, secret := range s.Build.Secrets {
+			if secret.Source == "" {
+				continue
+			}
+
+			if filepath.IsAbs(secret.Source) {
+				files.add(p, secret.Source, false)
+			} else {
+				files.add(p, filepath.Join(s.Build.Context, secret.Source), false)
+			}
+		}
+	}
+
+	return files.list(), nil
+}
+
+// resolvedProjectFiles returns the full file set of a compose project: the compose files,
+// everything serviceFiles resolves and the build contexts. A change has to touch one of
+// these paths to affect the stack.
+func resolvedProjectFiles(p *types.Project) ([]projectFile, error) {
+	deployFiles, err := serviceFiles(p)
+	if err != nil {
+		return nil, err
+	}
+
+	files := newProjectFileSet()
+
+	for _, f := range deployFiles {
+		files.add(p, f.Path, f.IsDir)
+	}
+
+	for _, composeFile := range p.ComposeFiles {
+		files.add(p, composeFile, false)
+	}
+
+	for _, s := range p.Services {
+		if s.Build == nil {
+			continue
+		}
+
+		files.add(p, s.Build.Context, true)
+
+		for _, ctx := range s.Build.AdditionalContexts {
+			if ctx == "" {
+				continue
+			}
+
+			// Additional contexts also take non-path values like docker-image://alpine,
+			// which simply never match a path in the repository.
+			files.add(p, ctx, filesystem.IsDir(absProjectPath(p, ctx)))
+		}
+	}
+
+	return files.list(), nil
+}
+
+// ProjectPathFilter builds a filter for git.LogOptions.PathFilter that matches the file
+// set of a compose project, so a commit log can be reduced to the commits that touch this
+// stack. go-git reports paths relative to the root of the repository, so the file set is
+// converted to that form. Files match exactly, directories match everything below them.
+//
+// repoPath is the path to the repository on the docker host, like the absolute paths in
+// types.Project.
+//
+// The returned filter is nil when the project covers the repository root or resolves to no
+// path inside the repository. Both match every path, so filtering would only cost tree
+// diffs, and callers read a nil filter as "do not filter".
+func ProjectPathFilter(repoPath string, p *types.Project) (func(string) bool, error) {
+	if p == nil {
+		return nil, nil
+	}
+
+	projectFiles, err := resolvedProjectFiles(p)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		files = set.New[string]()
+		dirs  []string
+	)
+
+	for _, f := range projectFiles {
+		if !filesystem.InBasePath(repoPath, f.Path) {
+			// Outside the repository, e.g. a host path or a remote include.
+			continue
+		}
+
+		rel, err := filepath.Rel(filepath.Clean(repoPath), f.Path)
+		if err != nil {
+			continue
+		}
+
+		rel = filepath.ToSlash(rel)
+
+		if !f.IsDir {
+			files.Add(rel)
+
+			continue
+		}
+
+		if rel == "." {
+			// The stack owns the whole repository, every path is relevant.
+			return nil, nil
+		}
+
+		dirs = append(dirs, rel+"/")
+	}
+
+	if len(files) == 0 && len(dirs) == 0 {
+		return nil, nil
+	}
+
+	return func(path string) bool {
+		if files.Contains(path) {
+			return true
+		}
+
+		for _, dir := range dirs {
+			if strings.HasPrefix(path, dir) {
+				return true
+			}
+		}
+
+		return false
+	}, nil
+}

--- a/internal/docker/project_files_test.go
+++ b/internal/docker/project_files_test.go
@@ -1,0 +1,256 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+
+	"github.com/kimdre/doco-cd/internal/filesystem"
+)
+
+func TestProjectPathFilter(t *testing.T) {
+	writeFile := func(t *testing.T, path string) string {
+		t.Helper()
+
+		if err := os.MkdirAll(filepath.Dir(path), filesystem.PermDir); err != nil {
+			t.Fatalf("failed to create %s: %v", filepath.Dir(path), err)
+		}
+
+		if err := os.WriteFile(path, []byte("test\n"), filesystem.PermOwner); err != nil {
+			t.Fatalf("failed to write %s: %v", path, err)
+		}
+
+		return path
+	}
+
+	mkDir := func(t *testing.T, path string) string {
+		t.Helper()
+
+		if err := os.MkdirAll(path, filesystem.PermDir); err != nil {
+			t.Fatalf("failed to create %s: %v", path, err)
+		}
+
+		return path
+	}
+
+	testCases := []struct {
+		name string
+		// buildProject gets the repository root and returns the project to filter for.
+		buildProject func(t *testing.T, repoPath string) *types.Project
+		// wantNilFilter expects no filter at all, meaning every commit is relevant.
+		wantNilFilter bool
+		matching      []string
+		notMatching   []string
+	}{
+		{
+			name: "compose file, env file and config of the stack",
+			buildProject: func(t *testing.T, repoPath string) *types.Project {
+				t.Helper()
+
+				workingDir := mkDir(t, filepath.Join(repoPath, "stacks", "a"))
+
+				return &types.Project{
+					WorkingDir:   workingDir,
+					ComposeFiles: []string{writeFile(t, filepath.Join(workingDir, "compose.yaml"))},
+					Services: types.Services{
+						"svc": {
+							Name:     "svc",
+							EnvFiles: []types.EnvFile{{Path: writeFile(t, filepath.Join(workingDir, ".env"))}},
+							Configs:  []types.ServiceConfigObjConfig{{Source: "app_config"}},
+						},
+					},
+					Configs: types.Configs{
+						"app_config": {File: writeFile(t, filepath.Join(workingDir, "config", "app.yaml"))},
+					},
+				}
+			},
+			matching: []string{
+				"stacks/a/compose.yaml",
+				"stacks/a/.env",
+				"stacks/a/config/app.yaml",
+			},
+			notMatching: []string{
+				"stacks/b/compose.yaml",
+				"stacks/a/compose.yaml.bak",
+				"stacks/a/config/other.yaml",
+				"README.md",
+			},
+		},
+		{
+			name: "bind mounted directory matches everything below it",
+			buildProject: func(t *testing.T, repoPath string) *types.Project {
+				t.Helper()
+
+				workingDir := mkDir(t, filepath.Join(repoPath, "stacks", "a"))
+				dataDir := mkDir(t, filepath.Join(workingDir, "data"))
+				bindFile := writeFile(t, filepath.Join(workingDir, "nginx.conf"))
+
+				return &types.Project{
+					WorkingDir:   workingDir,
+					ComposeFiles: []string{writeFile(t, filepath.Join(workingDir, "compose.yaml"))},
+					Services: types.Services{
+						"svc": {
+							Name: "svc",
+							Volumes: []types.ServiceVolumeConfig{
+								{Type: "bind", Source: dataDir, Target: "/data"},
+								{Type: "bind", Source: bindFile, Target: "/etc/nginx/nginx.conf"},
+								{Type: "volume", Source: "named", Target: "/var/lib/data"},
+							},
+						},
+					},
+				}
+			},
+			matching: []string{
+				"stacks/a/data/nested/file.txt",
+				"stacks/a/data/file.txt",
+				"stacks/a/nginx.conf",
+			},
+			notMatching: []string{
+				"stacks/a/database/file.txt",
+				"stacks/a/nginx.conf.tpl",
+				"named",
+			},
+		},
+		{
+			name: "build context and its files",
+			buildProject: func(t *testing.T, repoPath string) *types.Project {
+				t.Helper()
+
+				workingDir := mkDir(t, filepath.Join(repoPath, "stacks", "a"))
+				buildContext := mkDir(t, filepath.Join(repoPath, "src"))
+
+				writeFile(t, filepath.Join(buildContext, "Dockerfile"))
+
+				return &types.Project{
+					WorkingDir:   workingDir,
+					ComposeFiles: []string{writeFile(t, filepath.Join(workingDir, "compose.yaml"))},
+					Services: types.Services{
+						"svc": {
+							Name: "svc",
+							Build: &types.BuildConfig{
+								Context:    buildContext,
+								Dockerfile: "Dockerfile",
+							},
+						},
+					},
+				}
+			},
+			matching: []string{
+				"src/main.go",
+				"src/Dockerfile",
+				"stacks/a/compose.yaml",
+			},
+			notMatching: []string{
+				"stacks/b/compose.yaml",
+				"srcs/main.go",
+			},
+		},
+		{
+			name: "project without any file resolves to no filter",
+			buildProject: func(t *testing.T, repoPath string) *types.Project {
+				t.Helper()
+
+				return &types.Project{
+					WorkingDir: repoPath,
+					Services: types.Services{
+						"svc": {Name: "svc", Image: "nginx:alpine"},
+					},
+				}
+			},
+			wantNilFilter: true,
+		},
+		{
+			name: "files outside the repository are ignored",
+			buildProject: func(t *testing.T, repoPath string) *types.Project {
+				t.Helper()
+
+				outside := mkDir(t, filepath.Join(filepath.Dir(repoPath), "outside"))
+				workingDir := mkDir(t, filepath.Join(repoPath, "stacks", "a"))
+
+				return &types.Project{
+					WorkingDir:   workingDir,
+					ComposeFiles: []string{writeFile(t, filepath.Join(workingDir, "compose.yaml"))},
+					Services: types.Services{
+						"svc": {
+							Name: "svc",
+							Volumes: []types.ServiceVolumeConfig{
+								{Type: "bind", Source: outside, Target: "/data"},
+							},
+						},
+					},
+				}
+			},
+			matching:    []string{"stacks/a/compose.yaml"},
+			notMatching: []string{"outside/file.txt", "stacks/b/compose.yaml"},
+		},
+		{
+			name: "stack covering the repository root resolves to no filter",
+			buildProject: func(t *testing.T, repoPath string) *types.Project {
+				t.Helper()
+
+				return &types.Project{
+					WorkingDir:   repoPath,
+					ComposeFiles: []string{writeFile(t, filepath.Join(repoPath, "compose.yaml"))},
+					Services: types.Services{
+						"svc": {
+							Name: "svc",
+							Volumes: []types.ServiceVolumeConfig{
+								{Type: "bind", Source: repoPath, Target: "/repo"},
+							},
+						},
+					},
+				}
+			},
+			wantNilFilter: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The repository lives in a subdirectory so a test can also place files next to it.
+			repoPath := mkDir(t, filepath.Join(t.TempDir(), "repo"))
+
+			filter, err := ProjectPathFilter(repoPath, tc.buildProject(t, repoPath))
+			if err != nil {
+				t.Fatalf("ProjectPathFilter returned unexpected error: %v", err)
+			}
+
+			if tc.wantNilFilter {
+				if filter != nil {
+					t.Fatal("expected no filter")
+				}
+
+				return
+			}
+
+			if filter == nil {
+				t.Fatal("expected a filter, got nil")
+			}
+
+			for _, p := range tc.matching {
+				if !filter(p) {
+					t.Errorf("expected %q to match", p)
+				}
+			}
+
+			for _, p := range tc.notMatching {
+				if filter(p) {
+					t.Errorf("expected %q not to match", p)
+				}
+			}
+		})
+	}
+}
+
+func TestProjectPathFilter_NilProject(t *testing.T) {
+	filter, err := ProjectPathFilter(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("ProjectPathFilter returned unexpected error: %v", err)
+	}
+
+	if filter != nil {
+		t.Fatal("expected no filter for a nil project")
+	}
+}

--- a/internal/git/commits.go
+++ b/internal/git/commits.go
@@ -113,41 +113,113 @@ func commitBoundary(repo *git.Repository, oldHash, newHash plumbing.Hash) map[pl
 	return boundary
 }
 
-// GetCommitsBetween returns commits reachable from newHash but not from oldHash,
-// newest first, capped at maxCommits.
-func GetCommitsBetween(repo *git.Repository, oldHash, newHash plumbing.Hash, maxCommits int) ([]CommitInfo, error) {
-	iter, err := repo.Log(&git.LogOptions{From: newHash, Order: git.LogOrderCommitterTime})
+// errStopWalk ends a commit log walk early.
+var errStopWalk = errors.New("stop walk")
+
+// newCommitInfo maps a commit to the shape exposed to notification templates.
+func newCommitInfo(c *object.Commit) CommitInfo {
+	subject := c.Message
+	if i := strings.IndexByte(subject, '\n'); i >= 0 {
+		subject = subject[:i]
+	}
+
+	return CommitInfo{
+		Hash:      c.Hash.String(),
+		ShortHash: c.Hash.String()[:DefaultShortSHALength],
+		Subject:   strings.TrimSpace(subject),
+		Author:    c.Author.Name,
+	}
+}
+
+// walkLog walks the commit log from newHash, newest first, and hands every commit to
+// visit until it returns false or the log ends. A non-nil pathFilter reduces the log to
+// the commits that changed a matching path, like `git log -- <paths>`.
+func walkLog(repo *git.Repository, newHash plumbing.Hash, pathFilter func(string) bool, visit func(*object.Commit) bool) error {
+	iter, err := repo.Log(&git.LogOptions{From: newHash, Order: git.LogOrderCommitterTime, PathFilter: pathFilter})
 	if err != nil {
-		return nil, fmt.Errorf("failed to read commit log from %s: %w", newHash, err)
+		return fmt.Errorf("failed to read commit log from %s: %w", newHash, err)
 	}
 	defer iter.Close()
 
-	boundary := commitBoundary(repo, oldHash, newHash)
-	commits := make([]CommitInfo, 0, maxCommits)
-
-	stop := errors.New("stop")
-
 	err = iter.ForEach(func(c *object.Commit) error {
-		if _, atBoundary := boundary[c.Hash]; atBoundary || len(commits) >= maxCommits {
-			return stop
+		if !visit(c) {
+			return errStopWalk
 		}
-
-		subject := c.Message
-		if i := strings.IndexByte(subject, '\n'); i >= 0 {
-			subject = subject[:i]
-		}
-
-		commits = append(commits, CommitInfo{
-			Hash:      c.Hash.String(),
-			ShortHash: c.Hash.String()[:DefaultShortSHALength],
-			Subject:   strings.TrimSpace(subject),
-			Author:    c.Author.Name,
-		})
 
 		return nil
 	})
-	if err != nil && !errors.Is(err, stop) {
-		return nil, fmt.Errorf("failed to walk commit log: %w", err)
+	if err != nil && !errors.Is(err, errStopWalk) {
+		return fmt.Errorf("failed to walk commit log: %w", err)
+	}
+
+	return nil
+}
+
+// GetCommitsBetween returns commits reachable from newHash but not from oldHash,
+// newest first, capped at maxCommits.
+//
+// A non-nil pathFilter keeps only the commits that changed a path it matches, so a stack
+// gets a changelog of its own files instead of everything that happened in the repository.
+// Paths are relative to the root of the repository. The cap counts the commits that pass
+// the filter, and a nil filter returns the whole range.
+func GetCommitsBetween(repo *git.Repository, oldHash, newHash plumbing.Hash, maxCommits int, pathFilter func(string) bool) ([]CommitInfo, error) {
+	boundary := commitBoundary(repo, oldHash, newHash)
+	commits := make([]CommitInfo, 0, maxCommits)
+
+	if pathFilter == nil {
+		err := walkLog(repo, newHash, nil, func(c *object.Commit) bool {
+			if _, atBoundary := boundary[c.Hash]; atBoundary || len(commits) >= maxCommits {
+				return false
+			}
+
+			commits = append(commits, newCommitInfo(c))
+
+			return true
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return commits, nil
+	}
+
+	// go-git filters paths by dropping the non-matching commits from the log iterator,
+	// the boundary commit included. The walk would then miss where to stop and run
+	// through the whole history, so the range is taken from the unfiltered log first and
+	// the filtered log is limited to it. Walking the range twice only reads commit
+	// objects, the tree diffs of the filtered walk dominate either way.
+	inRange := make(map[plumbing.Hash]struct{})
+
+	err := walkLog(repo, newHash, nil, func(c *object.Commit) bool {
+		if _, atBoundary := boundary[c.Hash]; atBoundary {
+			return false
+		}
+
+		inRange[c.Hash] = struct{}{}
+
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(inRange) == 0 {
+		return commits, nil
+	}
+
+	err = walkLog(repo, newHash, pathFilter, func(c *object.Commit) bool {
+		// The filtered log is a subsequence of the unfiltered one, so the first commit
+		// outside the range also ends it.
+		if _, ok := inRange[c.Hash]; !ok {
+			return false
+		}
+
+		commits = append(commits, newCommitInfo(c))
+
+		return len(commits) < maxCommits
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return commits, nil

--- a/internal/git/commits_internal_test.go
+++ b/internal/git/commits_internal_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -51,7 +52,7 @@ func TestGetCommitsBetween(t *testing.T) {
 	h := commitN(t, wt, 4) // h[0] oldest .. h[3] newest
 
 	// commits after h[0] up to h[3]: h[3], h[2], h[1] (newest first)
-	got, err := GetCommitsBetween(repo, h[0], h[3], 50)
+	got, err := GetCommitsBetween(repo, h[0], h[3], 50, nil)
 	if err != nil {
 		t.Fatalf("GetCommitsBetween: %v", err)
 	}
@@ -69,7 +70,7 @@ func TestGetCommitsBetween(t *testing.T) {
 	}
 
 	// same old==new -> empty
-	empty, err := GetCommitsBetween(repo, h[3], h[3], 50)
+	empty, err := GetCommitsBetween(repo, h[3], h[3], 50, nil)
 	if err != nil {
 		t.Fatalf("GetCommitsBetween equal: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestGetCommitsBetween(t *testing.T) {
 	}
 
 	// cap is honoured
-	capped, err := GetCommitsBetween(repo, plumbing.ZeroHash, h[3], 2)
+	capped, err := GetCommitsBetween(repo, plumbing.ZeroHash, h[3], 2, nil)
 	if err != nil {
 		t.Fatalf("GetCommitsBetween capped: %v", err)
 	}
@@ -112,7 +113,7 @@ func TestGetCommitsBetween_DivergedHistory(t *testing.T) {
 
 	d := commitN(t, wt, 2) // d and newTip=e(d[1]) are both parented on b
 
-	got, err := GetCommitsBetween(repo, h[2], d[1], 50)
+	got, err := GetCommitsBetween(repo, h[2], d[1], 50, nil)
 	if err != nil {
 		t.Fatalf("GetCommitsBetween: %v", err)
 	}
@@ -177,5 +178,153 @@ func TestSharedPrefixLength(t *testing.T) {
 				t.Errorf("sharedPrefixLength(%q, %q) = %d, want %d", tt.first, tt.second, got, tt.want)
 			}
 		})
+	}
+}
+
+// commitFileAt writes content to relPath in the worktree and commits it with a fixed commit time.
+func commitFileAt(t *testing.T, wt *gogit.Worktree, relPath, content, msg string, when time.Time) plumbing.Hash {
+	t.Helper()
+
+	f, err := wt.Filesystem.Create(relPath)
+	if err != nil {
+		t.Fatalf("create %s: %v", relPath, err)
+	}
+
+	if _, err = f.Write([]byte(content)); err != nil {
+		t.Fatalf("write %s: %v", relPath, err)
+	}
+
+	if err = f.Close(); err != nil {
+		t.Fatalf("close %s: %v", relPath, err)
+	}
+
+	if _, err = wt.Add(relPath); err != nil {
+		t.Fatalf("add %s: %v", relPath, err)
+	}
+
+	sig := &object.Signature{Name: "Jane Doe", Email: "jane@example.com", When: when}
+
+	h, err := wt.Commit(msg, &gogit.CommitOptions{Author: sig, Committer: sig})
+	if err != nil {
+		t.Fatalf("commit %s: %v", msg, err)
+	}
+
+	return h
+}
+
+// stackPathFilter matches everything below dir, like the filter a compose project produces.
+func stackPathFilter(dir string) func(string) bool {
+	return func(p string) bool {
+		return strings.HasPrefix(p, dir+"/")
+	}
+}
+
+// A stack only wants the commits that touch its own files, not everything that happened
+// in a repository holding several stacks.
+func TestGetCommitsBetween_PathFilter(t *testing.T) {
+	repo, err := gogit.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	first := commitFileAt(t, wt, "README.md", "initial\n", "initial commit", when)
+	stackA := commitFileAt(t, wt, "stacks/a/compose.yaml", "a1\n", "feat(a): first", when.Add(1*time.Minute))
+	stackB := commitFileAt(t, wt, "stacks/b/compose.yaml", "b1\n", "feat(b): first", when.Add(2*time.Minute))
+	stackBEnv := commitFileAt(t, wt, "stacks/b/.env", "B=1\n", "chore(b): env", when.Add(3*time.Minute))
+	stackAEnv := commitFileAt(t, wt, "stacks/a/.env", "A=1\n", "chore(a): env", when.Add(4*time.Minute))
+
+	// Stack A deployed at stackB and now deploys stackAEnv: only its own commit is new.
+	// The boundary commit (stackB) touches stack B only, so the path filter drops it from
+	// the log. The walk still has to stop there instead of reaching back to stackA.
+	got, err := GetCommitsBetween(repo, stackB, stackAEnv, 50, stackPathFilter("stacks/a"))
+	if err != nil {
+		t.Fatalf("GetCommitsBetween: %v", err)
+	}
+
+	if len(got) != 1 || got[0].Hash != stackAEnv.String() {
+		t.Fatalf("expected only %s, got %+v", stackAEnv.String(), got)
+	}
+
+	// Unfiltered, the same range also carries the commit of stack B.
+	unfiltered, err := GetCommitsBetween(repo, stackB, stackAEnv, 50, nil)
+	if err != nil {
+		t.Fatalf("GetCommitsBetween unfiltered: %v", err)
+	}
+
+	if len(unfiltered) != 2 || unfiltered[1].Hash != stackBEnv.String() {
+		t.Fatalf("expected [stackAEnv, stackBEnv], got %+v", unfiltered)
+	}
+
+	// A stack whose files did not change at all gets an empty changelog.
+	none, err := GetCommitsBetween(repo, stackBEnv, stackAEnv, 50, stackPathFilter("stacks/c"))
+	if err != nil {
+		t.Fatalf("GetCommitsBetween no match: %v", err)
+	}
+
+	if len(none) != 0 {
+		t.Fatalf("expected no commits, got %+v", none)
+	}
+
+	// A filter matching a single file only takes the commits that changed that file.
+	single, err := GetCommitsBetween(repo, first, stackAEnv, 50, func(p string) bool {
+		return p == "stacks/a/compose.yaml"
+	})
+	if err != nil {
+		t.Fatalf("GetCommitsBetween single file: %v", err)
+	}
+
+	if len(single) != 1 || single[0].Hash != stackA.String() {
+		t.Fatalf("expected only %s, got %+v", stackA.String(), single)
+	}
+}
+
+// The cap counts the commits that passed the filter, not the walked ones.
+func TestGetCommitsBetween_PathFilterCap(t *testing.T) {
+	repo, err := gogit.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	first := commitFileAt(t, wt, "README.md", "initial\n", "initial commit", when)
+
+	var wanted []plumbing.Hash
+
+	// Six commits, every second one belongs to stack A.
+	for i := range 6 {
+		dir := "stacks/b"
+		if i%2 == 0 {
+			dir = "stacks/a"
+		}
+
+		h := commitFileAt(t, wt, dir+"/compose.yaml", fmt.Sprintf("v%d\n", i), fmt.Sprintf("commit %d", i), when.Add(time.Duration(i+1)*time.Minute))
+		if dir == "stacks/a" {
+			wanted = append(wanted, h)
+		}
+	}
+
+	got, err := GetCommitsBetween(repo, first, wanted[len(wanted)-1], 2, stackPathFilter("stacks/a"))
+	if err != nil {
+		t.Fatalf("GetCommitsBetween: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 commits (capped), got %d: %+v", len(got), got)
+	}
+
+	if got[0].Hash != wanted[2].String() || got[1].Hash != wanted[1].String() {
+		t.Fatalf("expected the two newest stack A commits, got %+v", got)
 	}
 }

--- a/internal/stages/stage_4_post-deploy.go
+++ b/internal/stages/stage_4_post-deploy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 
 	"github.com/kimdre/doco-cd/internal/config"
+	"github.com/kimdre/doco-cd/internal/docker"
 	"github.com/kimdre/doco-cd/internal/git"
 	"github.com/kimdre/doco-cd/internal/logger"
 	"github.com/kimdre/doco-cd/internal/notification"
@@ -53,11 +54,21 @@ func (s *StageManager) RunPostDeployStage(_ context.Context, stageLog *slog.Logg
 	metadata.ChangedServices = s.DeployState.changedServiceNames()
 
 	if s.DeployState.DeployedCommit != "" && latestCommit != "" {
+		// Only commits that touch the files of this stack belong in its changelog, so a
+		// repository with several stacks does not report the changes of all of them.
+		// A nil filter walks the log unfiltered, which is what a project without any
+		// resolvable path in the repository falls back to.
+		pathFilter, filterErr := docker.ProjectPathFilter(s.Repository.PathExternal, s.Docker.Project)
+		if filterErr != nil {
+			stageLog.Warn("failed to build changelog path filter, listing all commits", logger.ErrAttr(filterErr))
+		}
+
 		metadata.Commits, err = git.GetCommitsBetween(
 			s.Repository.Git,
 			plumbing.NewHash(s.DeployState.DeployedCommit),
 			plumbing.NewHash(latestCommit),
 			maxChangelogCommits,
+			pathFilter,
 		)
 		if err != nil {
 			// changelog is best-effort, never block the notification

--- a/wiki/docs/Advanced/Notifications.md
+++ b/wiki/docs/Advanced/Notifications.md
@@ -127,7 +127,7 @@ The following fields are available:
 | `.AffectedActorKind`  | `container` or `service`                                                 |
 | `.AffectedActorID`    | Affected container/service ID                                            |
 | `.AffectedActorName`  | Affected container/service name                                          |
-| `.Commits`            | Commits deployed since the last deploy (see [Commit changelog](#commit-changelog)) |
+| `.Commits`            | Commits that changed this stack since the last deploy (see [Commit changelog](#commit-changelog)) |
 | `.Duration`           | Time the deployment (or destroy) took, from job start to the notification, e.g. `12.483s`. Zero where no deployment ran (reconciliation restarts, scheduled jobs); hide it with `{{if .Duration}}...{{end}}` |
 | `.ChangedServices`    | Sorted names of the services changed by this deploy: force-recreated ones (changed mounted/referenced files or a changed auto-discovery label) plus services whose image digest changed in the registry (detected with [`force_image_pull`](../Deploy-Settings.md)). Empty when the whole stack is (re)deployed for other reasons, e.g. a compose config change (including image tag changes in the compose file), state drift or `force_recreate` |
 
@@ -165,7 +165,9 @@ Printing an entry directly (`{{ . }}`) gives `shortHash subject`.
         {{ end }}
     ```
 
-Up to 50 commits are listed. After a rebase or force-push the list starts from the point where the histories diverged.
+Only commits that changed a file of the stack are listed, like `git log -- <paths>`. The paths are the ones the compose project resolves to: the compose files, `configs:`, `secrets:`, `env_file:`, bind mount sources and build contexts. A repository that holds several stacks therefore gets a changelog per stack instead of everything that happened in the repository. Where the stack resolves to no path inside the repository, or covers the repository root, all commits of the range are listed.
+
+Up to 50 commits are listed, counted after that filtering. After a rebase or force-push the list starts from the point where the histories diverged.
 
 The changelog is best-effort: with a small `GIT_CLONE_DEPTH` the previously deployed commit may sit beyond the shallow boundary, in which case the list is truncated or omitted. It never blocks the notification.
 


### PR DESCRIPTION
Implements what you described in discussion #1835: filter inside `GetCommitsBetween` with go-git `LogOptions.PathFilter`, built from resolved file set of the project, and no new config setting.

Problem: changelog took whole range between last deployed commit and new one, so in repo with many stacks every stack reported also commits of other stacks.

Approach: file collection is extracted out of `DecryptProjectFiles` into `serviceFiles`, so decryption and changelog work on same set and cannot drift apart. For the changelog that set is extended by compose files and build contexts (`resolvedProjectFiles`). `ProjectPathFilter` then converts those docker-host paths to repo-root-relative ones, because that is what go-git passes to the filter — files match exactly, directories (bind mount source, build context) match by prefix. `GetCommitsBetween` got a `pathFilter` parameter, and the cap of 50 counts commits after filtering.

One place worth your eyes: range is still taken from the unfiltered log first and the filtered log is limited to it. go-git filters by dropping non-matching commits from the iterator, boundary commit included, so single filtered walk loses where to stop and runs back through whole history. Boundary logic itself is untouched. `TestGetCommitsBetween_PathFilter` covers exactly that — with naive single walk it returns an ancient commit of the stack instead of one.

Empty file set means no filter, so changelog stays unfiltered as today. Same when the stack covers repo root (then every path is relevant anyway). Empty changelog would be worse than a noisy one, imo. Failure of filter build only logs a warning, changelog is best-effort as before.

Tested: `go build ./...` and `golangci-lint run ./...` clean. New unit tests in `internal/git` (filtered vs unfiltered range, boundary commit of another stack, single-file filter, cap applied after filtering) and `internal/docker` (exact file match, directory prefix, build context, paths outside repo, empty set, repo root, nil project). 49 test packages pass; only `TestDeployCompose`, `TestVerifySocketConnection` and `TestVerifyDockerHostConnectionContextCancellation/Unix` fail, they stat hardcoded `/var/run/docker.sock` and fail the same on clean `main`. Docs updated in `wiki/docs/Advanced/Notifications.md`.

